### PR TITLE
fix(grammar): correct location mapping for inline macros

### DIFF
--- a/acdc-parser/fixtures/tests/cross_reference_basic.adoc
+++ b/acdc-parser/fixtures/tests/cross_reference_basic.adoc
@@ -1,0 +1,9 @@
+= Cross Reference Test
+
+== Introduction
+
+This is a reference to <<conclusion>>.
+
+== Conclusion
+
+This is the conclusion section.

--- a/acdc-parser/fixtures/tests/cross_reference_basic.json
+++ b/acdc-parser/fixtures/tests/cross_reference_basic.json
@@ -1,0 +1,209 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Cross Reference Test",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 22
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 22
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "section",
+      "type": "block",
+      "level": 1,
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Introduction",
+          "location": [
+            {
+              "line": 3,
+              "col": 4
+            },
+            {
+              "line": 3,
+              "col": 15
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "This is a reference to ",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 1
+                },
+                {
+                  "line": 5,
+                  "col": 23
+                }
+              ]
+            },
+            {
+              "name": "xref",
+              "type": "inline",
+              "target": {
+                "type": "name",
+                "value": "conclusion"
+              },
+              "location": [
+                {
+                  "line": 5,
+                  "col": 24
+                },
+                {
+                  "line": 5,
+                  "col": 37
+                }
+              ]
+            },
+            {
+              "name": "text",
+              "type": "string",
+              "value": ".",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 38
+                },
+                {
+                  "line": 5,
+                  "col": 38
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 5,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 38
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 5,
+          "col": 38
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "type": "block",
+      "level": 1,
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Conclusion",
+          "location": [
+            {
+              "line": 7,
+              "col": 4
+            },
+            {
+              "line": 7,
+              "col": 13
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "This is the conclusion section.",
+              "location": [
+                {
+                  "line": 9,
+                  "col": 1
+                },
+                {
+                  "line": 9,
+                  "col": 31
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 9,
+              "col": 1
+            },
+            {
+              "line": 9,
+              "col": 31
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 7,
+          "col": 1
+        },
+        {
+          "line": 9,
+          "col": 31
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 9,
+      "col": 31
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/cross_reference_custom_text.adoc
+++ b/acdc-parser/fixtures/tests/cross_reference_custom_text.adoc
@@ -1,0 +1,9 @@
+= Cross Reference with Custom Text
+
+== Introduction
+
+See the <<conclusion,final section>> for more details.
+
+== Conclusion
+
+This is the conclusion section.

--- a/acdc-parser/fixtures/tests/cross_reference_custom_text.json
+++ b/acdc-parser/fixtures/tests/cross_reference_custom_text.json
@@ -1,0 +1,210 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Cross Reference with Custom Text",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 34
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 34
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "section",
+      "type": "block",
+      "level": 1,
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Introduction",
+          "location": [
+            {
+              "line": 3,
+              "col": 4
+            },
+            {
+              "line": 3,
+              "col": 15
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "See the ",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 1
+                },
+                {
+                  "line": 5,
+                  "col": 8
+                }
+              ]
+            },
+            {
+              "name": "xref",
+              "type": "inline",
+              "target": {
+                "type": "name",
+                "value": "conclusion"
+              },
+              "text": "final section",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 9
+                },
+                {
+                  "line": 5,
+                  "col": 36
+                }
+              ]
+            },
+            {
+              "name": "text",
+              "type": "string",
+              "value": " for more details.",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 37
+                },
+                {
+                  "line": 5,
+                  "col": 54
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 5,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 54
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 5,
+          "col": 54
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "type": "block",
+      "level": 1,
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Conclusion",
+          "location": [
+            {
+              "line": 7,
+              "col": 4
+            },
+            {
+              "line": 7,
+              "col": 13
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "This is the conclusion section.",
+              "location": [
+                {
+                  "line": 9,
+                  "col": 1
+                },
+                {
+                  "line": 9,
+                  "col": 31
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 9,
+              "col": 1
+            },
+            {
+              "line": 9,
+              "col": 31
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 7,
+          "col": 1
+        },
+        {
+          "line": 9,
+          "col": 31
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 9,
+      "col": 31
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/cross_reference_simple.adoc
+++ b/acdc-parser/fixtures/tests/cross_reference_simple.adoc
@@ -1,0 +1,1 @@
+xref:conclusion[click here]

--- a/acdc-parser/fixtures/tests/cross_reference_simple.json
+++ b/acdc-parser/fixtures/tests/cross_reference_simple.json
@@ -1,0 +1,51 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "xref",
+          "type": "inline",
+          "target": {
+            "type": "name",
+            "value": "conclusion"
+          },
+          "text": "click here",
+          "location": [
+            {
+              "line": 1,
+              "col": 1
+            },
+            {
+              "line": 1,
+              "col": 27
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 1,
+          "col": 27
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 1,
+      "col": 27
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/cross_reference_xref_macro.adoc
+++ b/acdc-parser/fixtures/tests/cross_reference_xref_macro.adoc
@@ -1,0 +1,9 @@
+= Cross Reference Macro Test
+
+== Introduction
+
+This uses the macro format: xref:conclusion[click here].
+
+== Conclusion
+
+This is the conclusion section.

--- a/acdc-parser/fixtures/tests/cross_reference_xref_macro.json
+++ b/acdc-parser/fixtures/tests/cross_reference_xref_macro.json
@@ -1,0 +1,210 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Cross Reference Macro Test",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 28
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 28
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "section",
+      "type": "block",
+      "level": 1,
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Introduction",
+          "location": [
+            {
+              "line": 3,
+              "col": 4
+            },
+            {
+              "line": 3,
+              "col": 15
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "This uses the macro format: ",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 1
+                },
+                {
+                  "line": 5,
+                  "col": 28
+                }
+              ]
+            },
+            {
+              "name": "xref",
+              "type": "inline",
+              "target": {
+                "type": "name",
+                "value": "conclusion"
+              },
+              "text": "click here",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 29
+                },
+                {
+                  "line": 5,
+                  "col": 55
+                }
+              ]
+            },
+            {
+              "name": "text",
+              "type": "string",
+              "value": ".",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 56
+                },
+                {
+                  "line": 5,
+                  "col": 56
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 5,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 56
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 5,
+          "col": 56
+        }
+      ]
+    },
+    {
+      "name": "section",
+      "type": "block",
+      "level": 1,
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Conclusion",
+          "location": [
+            {
+              "line": 7,
+              "col": 4
+            },
+            {
+              "line": 7,
+              "col": 13
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "This is the conclusion section.",
+              "location": [
+                {
+                  "line": 9,
+                  "col": 1
+                },
+                {
+                  "line": 9,
+                  "col": 31
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 9,
+              "col": 1
+            },
+            {
+              "line": 9,
+              "col": 31
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 7,
+          "col": 1
+        },
+        {
+          "line": 9,
+          "col": 31
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 9,
+      "col": 31
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/dots_in_link_text.json
+++ b/acdc-parser/fixtures/tests/dots_in_link_text.json
@@ -23,7 +23,7 @@
             "type": "path",
             "value": "/projects/markdown/basics.text"
           },
-          "location": [{"line": 1, "col": 57},{"line": 1, "col": 145}]
+          "location": [{"line": 3, "col": 57},{"line": 3, "col": 115}]
         },
         {
           "name": "text",

--- a/acdc-parser/fixtures/tests/url_macro.json
+++ b/acdc-parser/fixtures/tests/url_macro.json
@@ -29,6 +29,7 @@
             "type": "url",
             "value": "https://example.com"
           },
+          "text": "example.com",
           "location": [
             {
               "line": 1,
@@ -97,11 +98,11 @@
           },
           "location": [
             {
-              "line": 1,
+              "line": 3,
               "col": 20
             },
             {
-              "line": 1,
+              "line": 3,
               "col": 97
             }
           ],
@@ -134,11 +135,11 @@
           },
           "location": [
             {
-              "line": 1,
+              "line": 3,
               "col": 102
             },
             {
-              "line": 1,
+              "line": 3,
               "col": 152
             }
           ],
@@ -200,11 +201,11 @@
           },
           "location": [
             {
-              "line": 1,
+              "line": 5,
               "col": 31
             },
             {
-              "line": 1,
+              "line": 5,
               "col": 121
             }
           ],

--- a/acdc-parser/src/grammar/location_mapping.rs
+++ b/acdc-parser/src/grammar/location_mapping.rs
@@ -385,11 +385,37 @@ pub(crate) fn map_inline_locations(
             InlineNode::Macro(inline_macro) => {
                 use crate::InlineMacro;
                 let mut mapped_macro = inline_macro.clone();
-                if let InlineMacro::Footnote(footnote) = &mut mapped_macro {
-                    // Map the footnote's own location
-                    footnote.location = map_loc(&footnote.location);
-                    // Recursively map the content locations using the same mapping function
-                    footnote.content = map_inline_locations(state, processed, &footnote.content, location);
+                match &mut mapped_macro {
+                    InlineMacro::Footnote(footnote) => {
+                        footnote.location = map_loc(&footnote.location);
+                        // Recursively map the content locations using the same mapping function
+                        footnote.content = map_inline_locations(state, processed, &footnote.content, location);
+                    }
+                    InlineMacro::Url(url) => {
+                        url.location = map_loc(&url.location);
+                    }
+                    InlineMacro::Link(link) => {
+                        link.location = map_loc(&link.location);
+                    }
+                    InlineMacro::Icon(icon) => {
+                        icon.location = map_loc(&icon.location);
+                    }
+                    InlineMacro::Button(button) => {
+                        button.location = map_loc(&button.location);
+                    }
+                    InlineMacro::Image(image) => {
+                        image.location = map_loc(&image.location);
+                    }
+                    InlineMacro::Menu(menu) => {
+                        menu.location = map_loc(&menu.location);
+                    }
+                    InlineMacro::Keyboard(keyboard) => {
+                        keyboard.location = map_loc(&keyboard.location);
+                    }
+                    InlineMacro::CrossReference(xref) => {
+                        xref.location = map_loc(&xref.location);
+                    }
+                    _ => todo!("location mapping not implemented for {mapped_macro:#?}"),
                 }
                 vec![InlineNode::Macro(mapped_macro)]
             }


### PR DESCRIPTION
Also added a bunch of tests we were missing for cross references.