### PR TITLE
fix(grammar): preserve commas in link text

### DIFF
--- a/acdc-parser/fixtures/tests/commas_in_link_text.adoc
+++ b/acdc-parser/fixtures/tests/commas_in_link_text.adoc
@@ -1,0 +1,9 @@
+Visit https://example.com[Example, a test website] for more information.
+
+This is a link with multiple commas: https://reddit.com/about/[About reddit, including some mind boggling statistics].
+
+Link with comma and attributes: https://rust-lang.org[The Rust language, official docs,role=external].
+
+:fn-test: footnote:fn-test[https://example.com/path[Link text, with comma].]
+
+Testing footnote attribute: {fn-test}

--- a/acdc-parser/fixtures/tests/commas_in_link_text.json
+++ b/acdc-parser/fixtures/tests/commas_in_link_text.json
@@ -1,0 +1,317 @@
+{
+  "name": "document",
+  "type": "block",
+  "attributes": {
+    "fn-test": "footnote:fn-test[https://example.com/path[Link text, with comma].]"
+  },
+  "blocks": [
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Visit ",
+          "location": [
+            {
+              "line": 1,
+              "col": 1
+            },
+            {
+              "line": 1,
+              "col": 6
+            }
+          ]
+        },
+        {
+          "name": "ref",
+          "type": "inline",
+          "variant": "link",
+          "target": {
+            "type": "url",
+            "value": "https://example.com"
+          },
+          "location": [
+            {
+              "line": 1,
+              "col": 7
+            },
+            {
+              "line": 1,
+              "col": 50
+            }
+          ],
+          "attributes": {}
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "value": " for more information.",
+          "location": [
+            {
+              "line": 1,
+              "col": 51
+            },
+            {
+              "line": 1,
+              "col": 72
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 1,
+          "col": 72
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "This is a link with multiple commas: ",
+          "location": [
+            {
+              "line": 3,
+              "col": 1
+            },
+            {
+              "line": 3,
+              "col": 37
+            }
+          ]
+        },
+        {
+          "name": "ref",
+          "type": "inline",
+          "variant": "link",
+          "target": {
+            "type": "url",
+            "value": "https://reddit.com/about/"
+          },
+          "location": [
+            {
+              "line": 3,
+              "col": 38
+            },
+            {
+              "line": 3,
+              "col": 117
+            }
+          ],
+          "attributes": {}
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "value": ".",
+          "location": [
+            {
+              "line": 3,
+              "col": 118
+            },
+            {
+              "line": 3,
+              "col": 118
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 3,
+          "col": 118
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Link with comma and attributes: ",
+          "location": [
+            {
+              "line": 5,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 32
+            }
+          ]
+        },
+        {
+          "name": "ref",
+          "type": "inline",
+          "variant": "link",
+          "target": {
+            "type": "url",
+            "value": "https://rust-lang.org"
+          },
+          "location": [
+            {
+              "line": 5,
+              "col": 33
+            },
+            {
+              "line": 5,
+              "col": 101
+            }
+          ],
+          "attributes": {
+            "role": "external"
+          }
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "value": ".",
+          "location": [
+            {
+              "line": 5,
+              "col": 102
+            },
+            {
+              "line": 5,
+              "col": 102
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 5,
+          "col": 1
+        },
+        {
+          "line": 5,
+          "col": 102
+        }
+      ]
+    },
+    {
+      "name": "fn-test",
+      "value": "footnote:fn-test[https://example.com/path[Link text, with comma].]",
+      "type": "attribute",
+      "location": [
+        {
+          "line": 7,
+          "col": 1
+        },
+        {
+          "line": 7,
+          "col": 77
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Testing footnote attribute: ",
+          "location": [
+            {
+              "line": 9,
+              "col": 1
+            },
+            {
+              "line": 9,
+              "col": 28
+            }
+          ]
+        },
+        {
+          "name": "footnote",
+          "type": "inline",
+          "id": "fn-test",
+          "inlines": [
+            {
+              "name": "ref",
+              "type": "inline",
+              "variant": "link",
+              "target": {
+                "type": "url",
+                "value": "https://example.com/path"
+              },
+              "location": [
+                {
+                  "line": 9,
+                  "col": 29
+                },
+                {
+                  "line": 9,
+                  "col": 29
+                }
+              ],
+              "attributes": {}
+            },
+            {
+              "name": "text",
+              "type": "string",
+              "value": ".",
+              "location": [
+                {
+                  "line": 9,
+                  "col": 29
+                },
+                {
+                  "line": 9,
+                  "col": 29
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 9,
+              "col": 29
+            },
+            {
+              "line": 9,
+              "col": 29
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 9,
+          "col": 1
+        },
+        {
+          "line": 9,
+          "col": 37
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 9,
+      "col": 37
+    }
+  ]
+}

--- a/acdc-parser/src/model/inlines/mod.rs
+++ b/acdc-parser/src/model/inlines/mod.rs
@@ -482,9 +482,12 @@ impl<'de> Deserialize<'de> for InlineNode {
                         //
                         //
                         match my_variant.as_str() {
-                            "url" => todo!(
-                                "implement url deserialization - this uses variant 'link' as well so need to be differentiated"
-                            ),
+                            "url" => Ok(InlineNode::Macro(InlineMacro::Url(Url {
+                                text: vec![],
+                                attributes: my_attributes.unwrap_or_default(),
+                                target: my_target,
+                                location: my_location,
+                            }))),
                             "link" => Ok(InlineNode::Macro(InlineMacro::Link(Link {
                                 text: None,
                                 attributes: my_attributes.unwrap_or_default(),
@@ -492,7 +495,10 @@ impl<'de> Deserialize<'de> for InlineNode {
                                 location: my_location,
                             }))),
 
-                            "autolink" => todo!("implement autolink deserialization"),
+                            "autolink" => Ok(InlineNode::Macro(InlineMacro::Autolink(Autolink {
+                                url: my_target,
+                                location: my_location,
+                            }))),
                             "pass" => todo!("implement pass deserialization"),
                             _ => {
                                 tracing::error!(variant = %my_variant, "invalid inline macro variant");


### PR DESCRIPTION
The balanced_link_title_part rule was stopping at any comma, treating all commas as attribute delimiters. This caused link text like "About reddit, including statistics" to be truncated to "About reddit".

Changed the lookahead pattern to only stop at commas followed by attributes (name=) or closing brackets (]). Now commas that are part of the link text are correctly preserved.