### PR TITLE
fix(parser): stop list items at blank lines

### DIFF
--- a/acdc-parser/fixtures/tests/list_followed_by_paragraph.adoc
+++ b/acdc-parser/fixtures/tests/list_followed_by_paragraph.adoc
@@ -1,0 +1,4 @@
+* First item
+* Second item
+
+Following paragraph.

--- a/acdc-parser/fixtures/tests/list_followed_by_paragraph.json
+++ b/acdc-parser/fixtures/tests/list_followed_by_paragraph.json
@@ -1,0 +1,129 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "list",
+      "type": "block",
+      "variant": "unordered",
+      "marker": "*",
+      "items": [
+        {
+          "name": "listItem",
+          "type": "block",
+          "marker": "*",
+          "principal": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "First item",
+              "location": [
+                {
+                  "line": 1,
+                  "col": 3
+                },
+                {
+                  "line": 1,
+                  "col": 12
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 1,
+              "col": 1
+            },
+            {
+              "line": 1,
+              "col": 12
+            }
+          ]
+        },
+        {
+          "name": "listItem",
+          "type": "block",
+          "marker": "*",
+          "principal": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Second item",
+              "location": [
+                {
+                  "line": 2,
+                  "col": 3
+                },
+                {
+                  "line": 2,
+                  "col": 13
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 2,
+              "col": 1
+            },
+            {
+              "line": 2,
+              "col": 13
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 2,
+          "col": 13
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Following paragraph.",
+          "location": [
+            {
+              "line": 4,
+              "col": 1
+            },
+            {
+              "line": 4,
+              "col": 20
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 4,
+          "col": 1
+        },
+        {
+          "line": 4,
+          "col": 20
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 4,
+      "col": 20
+    }
+  ]
+}

--- a/acdc-parser/src/grammar/document.rs
+++ b/acdc-parser/src/grammar/document.rs
@@ -1165,7 +1165,7 @@ peg::parser! {
         whitespace()
         checked:checklist_item()?
         list_content_start:position()
-        list_item:$((!(&(eol()+ (unordered_list_marker() / ordered_list_marker() / check_start_of_description_list() / section_level_marker())) / ![_]) [_])+)
+        list_item:$((!(&(eol()+ (unordered_list_marker() / ordered_list_marker() / check_start_of_description_list() / section_level_marker())) / eol()*<2,> / ![_]) [_])+)
         end:position!() (eol()+ / ![_])
         {
             tracing::info!(%list_item, %marker, ?checked, "found list item");

--- a/acdc-parser/src/model/location.rs
+++ b/acdc-parser/src/model/location.rs
@@ -55,28 +55,6 @@ impl Location {
         }
     }
 
-    // TODO(nlopes): shift_start should be shift_inline_start
-    pub fn shift_start(&mut self, parent: Option<&Location>) {
-        if let Some(parent) = parent {
-            if parent.start.line == 0 {
-                return;
-            }
-            self.absolute_start += parent.absolute_start;
-            self.start.line += parent.start.line - 1;
-        }
-    }
-
-    // TODO(nlopes): shift_end should be shift_inline_end
-    pub fn shift_end(&mut self, parent: Option<&Location>) {
-        if let Some(parent) = parent {
-            if parent.start.line == 0 {
-                return;
-            }
-            self.absolute_end += parent.absolute_start;
-            self.end.line += parent.start.line - 1;
-        }
-    }
-
     pub fn shift_line_column(&mut self, line: usize, column: usize) {
         self.start.line += line - 1;
         self.end.line += line - 1;


### PR DESCRIPTION
List items were consuming content beyond blank lines, causing parsing errors for paragraphs following lists. Added `eol()*<2,>` check to the list_item rule to match AsciiDoc's blank line convention.

Also removed unused location shift methods.