### PR TITLE
fix(parser): use proper types for URL and path handling

### DIFF
--- a/acdc-parser/fixtures/tests/document_with_two_video_ids.json
+++ b/acdc-parser/fixtures/tests/document_with_two_video_ids.json
@@ -7,15 +7,15 @@
       "type": "block",
       "sources": [
         {
-          "type": "path",
+          "type": "name",
           "value": "Video1ID"
         },
         {
-          "type": "path",
+          "type": "name",
           "value": "Video2ID"
         },
         {
-          "type": "path",
+          "type": "name",
           "value": "Video3ID"
         }
       ],

--- a/acdc-parser/fixtures/tests/video_comprehensive.json
+++ b/acdc-parser/fixtures/tests/video_comprehensive.json
@@ -646,7 +646,7 @@
           "type": "block",
           "sources": [
             {
-              "type": "path",
+              "type": "name",
               "value": "rPQoq7ThGAU"
             }
           ],
@@ -705,7 +705,7 @@
           "type": "block",
           "sources": [
             {
-              "type": "path",
+              "type": "name",
               "value": "rPQoq7ThGAU"
             }
           ],
@@ -766,7 +766,7 @@
           "type": "block",
           "sources": [
             {
-              "type": "path",
+              "type": "name",
               "value": "rPQoq7ThGAU"
             }
           ],
@@ -828,7 +828,7 @@
           "type": "block",
           "sources": [
             {
-              "type": "path",
+              "type": "name",
               "value": "rPQoq7ThGAU"
             }
           ],
@@ -892,7 +892,7 @@
           "type": "block",
           "sources": [
             {
-              "type": "path",
+              "type": "name",
               "value": "67480300"
             }
           ],
@@ -951,7 +951,7 @@
           "type": "block",
           "sources": [
             {
-              "type": "path",
+              "type": "name",
               "value": "67480300"
             }
           ],
@@ -1012,7 +1012,7 @@
           "type": "block",
           "sources": [
             {
-              "type": "path",
+              "type": "name",
               "value": "67480300"
             }
           ],

--- a/converters/common/src/video.rs
+++ b/converters/common/src/video.rs
@@ -214,7 +214,7 @@ mod tests {
         Video {
             sources: sources
                 .into_iter()
-                .map(|s| Source::Path(s.to_string()))
+                .map(|s| Source::Path(std::path::PathBuf::from(s)))
                 .collect(),
             metadata: BlockMetadata {
                 attributes,

--- a/converters/terminal/src/audio.rs
+++ b/converters/terminal/src/audio.rs
@@ -11,10 +11,16 @@ impl Render for Audio {
     fn render<W: Write>(&self, w: &mut W, _processor: &Processor) -> Result<(), Self::Error> {
         match &self.source {
             Source::Url(url) => {
-                queue!(w, PrintStyledContent(url.clone().italic()))?;
+                queue!(w, PrintStyledContent(url.as_str().to_string().italic()))?;
             }
-            Source::Path(path) | Source::Name(path) => {
-                queue!(w, PrintStyledContent(format!("[Audio: {path}]").italic()))?;
+            Source::Path(path) => {
+                queue!(
+                    w,
+                    PrintStyledContent(format!("[Audio: {}]", path.display()).italic())
+                )?;
+            }
+            Source::Name(name) => {
+                queue!(w, PrintStyledContent(format!("[Audio: {name}]").italic()))?;
             }
         }
         Ok(())


### PR DESCRIPTION
Use PathBuf for filesystem paths and url::Url for URLs instead of String in the Source enum. Added centralized parsing logic in Source::from_str().

Fixes #145