### PR TITLE
fix(grammar): list item (de)serialization

### DIFF
--- a/acdc-parser/fixtures/tests/admonition_block.json
+++ b/acdc-parser/fixtures/tests/admonition_block.json
@@ -62,29 +62,14 @@
           "marker": ".",
           "items": [
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "They are allergic to cinnamon.",
-                      "location": [
-                        {
-                          "line": 6,
-                          "col": 3
-                        },
-                        {
-                          "line": 6,
-                          "col": 32
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "They are allergic to cinnamon.",
                   "location": [
                     {
                       "line": 6,
@@ -109,29 +94,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "More than two glasses of orange juice in 24 hours makes them howl in harmony with alarms and sirens.",
-                      "location": [
-                        {
-                          "line": 7,
-                          "col": 3
-                        },
-                        {
-                          "line": 7,
-                          "col": 102
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "More than two glasses of orange juice in 24 hours makes them howl in harmony with alarms and sirens.",
                   "location": [
                     {
                       "line": 7,
@@ -156,29 +126,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Celery makes them sad.",
-                      "location": [
-                        {
-                          "line": 8,
-                          "col": 3
-                        },
-                        {
-                          "line": 8,
-                          "col": 24
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Celery makes them sad.",
                   "location": [
                     {
                       "line": 8,

--- a/acdc-parser/fixtures/tests/basic_title_with_double_colon_with_subtitle.json
+++ b/acdc-parser/fixtures/tests/basic_title_with_double_colon_with_subtitle.json
@@ -47,6 +47,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "paragraph",

--- a/acdc-parser/fixtures/tests/basic_title_with_subtitle.json
+++ b/acdc-parser/fixtures/tests/basic_title_with_subtitle.json
@@ -47,6 +47,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "paragraph",

--- a/acdc-parser/fixtures/tests/cross_reference_basic.json
+++ b/acdc-parser/fixtures/tests/cross_reference_basic.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/cross_reference_custom_text.json
+++ b/acdc-parser/fixtures/tests/cross_reference_custom_text.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/cross_reference_xref_macro.json
+++ b/acdc-parser/fixtures/tests/cross_reference_xref_macro.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/curved_quotes.json
+++ b/acdc-parser/fixtures/tests/curved_quotes.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/description_list_explicit_continuation.json
+++ b/acdc-parser/fixtures/tests/description_list_explicit_continuation.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -79,29 +80,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "List item 1",
-                          "location": [
-                            {
-                              "line": 5,
-                              "col": 3
-                            },
-                            {
-                              "line": 5,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "List item 1",
                       "location": [
                         {
                           "line": 5,
@@ -144,29 +130,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "List item 2",
-                          "location": [
-                            {
-                              "line": 6,
-                              "col": 3
-                            },
-                            {
-                              "line": 6,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "List item 2",
                       "location": [
                         {
                           "line": 6,
@@ -258,29 +229,14 @@
               "marker": ".",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": ".",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Ordered item 1",
-                          "location": [
-                            {
-                              "line": 10,
-                              "col": 3
-                            },
-                            {
-                              "line": 10,
-                              "col": 16
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Ordered item 1",
                       "location": [
                         {
                           "line": 10,
@@ -305,29 +261,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": ".",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Ordered item 2",
-                          "location": [
-                            {
-                              "line": 11,
-                              "col": 3
-                            },
-                            {
-                              "line": 11,
-                              "col": 16
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Ordered item 2",
                       "location": [
                         {
                           "line": 11,

--- a/acdc-parser/fixtures/tests/description_list_mixed_content.json
+++ b/acdc-parser/fixtures/tests/description_list_mixed_content.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -133,29 +134,14 @@
       "marker": "-",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "A list item",
-                  "location": [
-                    {
-                      "line": 7,
-                      "col": 3
-                    },
-                    {
-                      "line": 7,
-                      "col": 13
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "A list item",
               "location": [
                 {
                   "line": 7,
@@ -180,29 +166,14 @@
           ]
         },
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "Another list item",
-                  "location": [
-                    {
-                      "line": 8,
-                      "col": 3
-                    },
-                    {
-                      "line": 8,
-                      "col": 19
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "Another list item",
               "location": [
                 {
                   "line": 8,
@@ -317,29 +288,14 @@
               "marker": ".",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": ".",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Ordered item 1",
-                          "location": [
-                            {
-                              "line": 14,
-                              "col": 3
-                            },
-                            {
-                              "line": 14,
-                              "col": 16
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Ordered item 1",
                       "location": [
                         {
                           "line": 14,
@@ -364,29 +320,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": ".",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Ordered item 2",
-                          "location": [
-                            {
-                              "line": 15,
-                              "col": 3
-                            },
-                            {
-                              "line": 15,
-                              "col": 16
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Ordered item 2",
                       "location": [
                         {
                           "line": 15,

--- a/acdc-parser/fixtures/tests/description_list_multiple_blank_lines.json
+++ b/acdc-parser/fixtures/tests/description_list_multiple_blank_lines.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -79,29 +80,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "List item 1",
-                          "location": [
-                            {
-                              "line": 6,
-                              "col": 3
-                            },
-                            {
-                              "line": 6,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "List item 1",
                       "location": [
                         {
                           "line": 6,
@@ -126,29 +112,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "List item 2",
-                          "location": [
-                            {
-                              "line": 7,
-                              "col": 3
-                            },
-                            {
-                              "line": 7,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "List item 2",
                       "location": [
                         {
                           "line": 7,

--- a/acdc-parser/fixtures/tests/description_list_nested_lists.json
+++ b/acdc-parser/fixtures/tests/description_list_nested_lists.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -79,29 +80,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Level 1 item",
-                          "location": [
-                            {
-                              "line": 5,
-                              "col": 3
-                            },
-                            {
-                              "line": 5,
-                              "col": 14
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Level 1 item",
                       "location": [
                         {
                           "line": 5,
@@ -126,29 +112,14 @@
                   ]
                 },
                 {
-                  "level": 2,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "**",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Level 2 item",
-                          "location": [
-                            {
-                              "line": 6,
-                              "col": 4
-                            },
-                            {
-                              "line": 6,
-                              "col": 15
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Level 2 item",
                       "location": [
                         {
                           "line": 6,
@@ -173,29 +144,14 @@
                   ]
                 },
                 {
-                  "level": 2,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "**",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Another level 2",
-                          "location": [
-                            {
-                              "line": 7,
-                              "col": 4
-                            },
-                            {
-                              "line": 7,
-                              "col": 18
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Another level 2",
                       "location": [
                         {
                           "line": 7,
@@ -220,29 +176,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Back to level 1",
-                          "location": [
-                            {
-                              "line": 8,
-                              "col": 3
-                            },
-                            {
-                              "line": 8,
-                              "col": 17
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Back to level 1",
                       "location": [
                         {
                           "line": 8,

--- a/acdc-parser/fixtures/tests/description_list_no_blank_line.json
+++ b/acdc-parser/fixtures/tests/description_list_no_blank_line.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -79,29 +80,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "List item 1",
-                          "location": [
-                            {
-                              "line": 4,
-                              "col": 3
-                            },
-                            {
-                              "line": 4,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "List item 1",
                       "location": [
                         {
                           "line": 4,
@@ -126,29 +112,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "List item 2",
-                          "location": [
-                            {
-                              "line": 5,
-                              "col": 3
-                            },
-                            {
-                              "line": 5,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "List item 2",
                       "location": [
                         {
                           "line": 5,

--- a/acdc-parser/fixtures/tests/description_list_no_inline_with_lists.json
+++ b/acdc-parser/fixtures/tests/description_list_no_inline_with_lists.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -62,29 +63,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "list item 1",
-                          "location": [
-                            {
-                              "line": 5,
-                              "col": 3
-                            },
-                            {
-                              "line": 5,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "list item 1",
                       "location": [
                         {
                           "line": 5,
@@ -109,29 +95,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "list item 2",
-                          "location": [
-                            {
-                              "line": 6,
-                              "col": 3
-                            },
-                            {
-                              "line": 6,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "list item 2",
                       "location": [
                         {
                           "line": 6,
@@ -206,29 +177,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "mem item 1",
-                          "location": [
-                            {
-                              "line": 10,
-                              "col": 3
-                            },
-                            {
-                              "line": 10,
-                              "col": 12
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "mem item 1",
                       "location": [
                         {
                           "line": 10,
@@ -253,29 +209,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "mem item 2",
-                          "location": [
-                            {
-                              "line": 11,
-                              "col": 3
-                            },
-                            {
-                              "line": 11,
-                              "col": 12
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "mem item 2",
                       "location": [
                         {
                           "line": 11,

--- a/acdc-parser/fixtures/tests/description_list_with_admonition.json
+++ b/acdc-parser/fixtures/tests/description_list_with_admonition.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -150,29 +151,14 @@
       "marker": "-",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "List item 1",
-                  "location": [
-                    {
-                      "line": 7,
-                      "col": 3
-                    },
-                    {
-                      "line": 7,
-                      "col": 13
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "List item 1",
               "location": [
                 {
                   "line": 7,
@@ -197,29 +183,14 @@
           ]
         },
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "List item 2",
-                  "location": [
-                    {
-                      "line": 8,
-                      "col": 3
-                    },
-                    {
-                      "line": 8,
-                      "col": 13
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "List item 2",
               "location": [
                 {
                   "line": 8,

--- a/acdc-parser/fixtures/tests/description_list_with_auto_attached_list.json
+++ b/acdc-parser/fixtures/tests/description_list_with_auto_attached_list.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -79,29 +80,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "list item 1",
-                          "location": [
-                            {
-                              "line": 5,
-                              "col": 3
-                            },
-                            {
-                              "line": 5,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "list item 1",
                       "location": [
                         {
                           "line": 5,
@@ -126,29 +112,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "list item 2",
-                          "location": [
-                            {
-                              "line": 6,
-                              "col": 3
-                            },
-                            {
-                              "line": 6,
-                              "col": 13
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "list item 2",
                       "location": [
                         {
                           "line": 6,

--- a/acdc-parser/fixtures/tests/description_list_with_ordered_list.json
+++ b/acdc-parser/fixtures/tests/description_list_with_ordered_list.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "dlist",
@@ -79,29 +80,14 @@
               "marker": ".",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": ".",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "ordered item 1",
-                          "location": [
-                            {
-                              "line": 5,
-                              "col": 3
-                            },
-                            {
-                              "line": 5,
-                              "col": 16
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "ordered item 1",
                       "location": [
                         {
                           "line": 5,
@@ -126,29 +112,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": ".",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "ordered item 2",
-                          "location": [
-                            {
-                              "line": 6,
-                              "col": 3
-                            },
-                            {
-                              "line": 6,
-                              "col": 16
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "ordered item 2",
                       "location": [
                         {
                           "line": 6,

--- a/acdc-parser/fixtures/tests/description_list_with_surrounding_blocks.json
+++ b/acdc-parser/fixtures/tests/description_list_with_surrounding_blocks.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "paragraph",
@@ -69,29 +70,14 @@
       "marker": "-",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "A list before",
-                  "location": [
-                    {
-                      "line": 5,
-                      "col": 3
-                    },
-                    {
-                      "line": 5,
-                      "col": 15
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "A list before",
               "location": [
                 {
                   "line": 5,
@@ -116,29 +102,14 @@
           ]
         },
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "Another item",
-                  "location": [
-                    {
-                      "line": 6,
-                      "col": 3
-                    },
-                    {
-                      "line": 6,
-                      "col": 14
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "Another item",
               "location": [
                 {
                   "line": 6,
@@ -222,29 +193,14 @@
               "marker": "-",
               "items": [
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Auto-attached list",
-                          "location": [
-                            {
-                              "line": 10,
-                              "col": 3
-                            },
-                            {
-                              "line": 10,
-                              "col": 20
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Auto-attached list",
                       "location": [
                         {
                           "line": 10,
@@ -269,29 +225,14 @@
                   ]
                 },
                 {
-                  "level": 1,
+                  "name": "listItem",
+                  "type": "block",
                   "marker": "-",
                   "principal": [
                     {
-                      "name": "paragraph",
-                      "type": "block",
-                      "inlines": [
-                        {
-                          "name": "text",
-                          "type": "string",
-                          "value": "Another item",
-                          "location": [
-                            {
-                              "line": 11,
-                              "col": 3
-                            },
-                            {
-                              "line": 11,
-                              "col": 14
-                            }
-                          ]
-                        }
-                      ],
+                      "name": "text",
+                      "type": "string",
+                      "value": "Another item",
                       "location": [
                         {
                           "line": 11,
@@ -437,29 +378,14 @@
       "marker": ".",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": ".",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "An ordered list after",
-                  "location": [
-                    {
-                      "line": 17,
-                      "col": 3
-                    },
-                    {
-                      "line": 17,
-                      "col": 23
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "An ordered list after",
               "location": [
                 {
                   "line": 17,
@@ -484,29 +410,14 @@
           ]
         },
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": ".",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "Another item",
-                  "location": [
-                    {
-                      "line": 18,
-                      "col": 3
-                    },
-                    {
-                      "line": 18,
-                      "col": 14
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "Another item",
               "location": [
                 {
                   "line": 18,

--- a/acdc-parser/fixtures/tests/document_with_page_breaks.json
+++ b/acdc-parser/fixtures/tests/document_with_page_breaks.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "break",

--- a/acdc-parser/fixtures/tests/footnotes.json
+++ b/acdc-parser/fixtures/tests/footnotes.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "paragraph",

--- a/acdc-parser/fixtures/tests/list_followed_by_paragraph.json
+++ b/acdc-parser/fixtures/tests/list_followed_by_paragraph.json
@@ -9,29 +9,14 @@
       "marker": "*",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "*",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "First item",
-                  "location": [
-                    {
-                      "line": 1,
-                      "col": 3
-                    },
-                    {
-                      "line": 1,
-                      "col": 12
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "First item",
               "location": [
                 {
                   "line": 1,
@@ -56,29 +41,14 @@
           ]
         },
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "*",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "Second item",
-                  "location": [
-                    {
-                      "line": 2,
-                      "col": 3
-                    },
-                    {
-                      "line": 2,
-                      "col": 13
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "Second item",
               "location": [
                 {
                   "line": 2,

--- a/acdc-parser/fixtures/tests/list_multiline.json
+++ b/acdc-parser/fixtures/tests/list_multiline.json
@@ -9,29 +9,14 @@
       "marker": "*",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "*",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "The document header in AsciiDoc is optional.\nIf present, it must start with a document title.",
-                  "location": [
-                    {
-                      "line": 1,
-                      "col": 3
-                    },
-                    {
-                      "line": 2,
-                      "col": 48
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "The document header in AsciiDoc is optional.\nIf present, it must start with a document title.",
               "location": [
                 {
                   "line": 1,
@@ -56,29 +41,14 @@
           ]
         },
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "*",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "Optional author and revision information lines\nimmediately follow the document title.",
-                  "location": [
-                    {
-                      "line": 4,
-                      "col": 3
-                    },
-                    {
-                      "line": 5,
-                      "col": 38
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "Optional author and revision information lines\nimmediately follow the document title.",
               "location": [
                 {
                   "line": 4,
@@ -103,29 +73,14 @@
           ]
         },
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "*",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "The document header must be separated from\n  the remainder of the document by one or more\n  empty lines and it cannot contain empty lines.",
-                  "location": [
-                    {
-                      "line": 7,
-                      "col": 3
-                    },
-                    {
-                      "line": 9,
-                      "col": 48
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "The document header must be separated from\n  the remainder of the document by one or more\n  empty lines and it cannot contain empty lines.",
               "location": [
                 {
                   "line": 7,

--- a/acdc-parser/fixtures/tests/list_to_section_transition.json
+++ b/acdc-parser/fixtures/tests/list_to_section_transition.json
@@ -31,29 +31,14 @@
           "marker": "-",
           "items": [
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "-",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item one",
-                      "location": [
-                        {
-                          "line": 3,
-                          "col": 3
-                        },
-                        {
-                          "line": 3,
-                          "col": 10
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item one",
                   "location": [
                     {
                       "line": 3,
@@ -78,29 +63,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "-",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item two",
-                      "location": [
-                        {
-                          "line": 4,
-                          "col": 3
-                        },
-                        {
-                          "line": 4,
-                          "col": 10
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item two",
                   "location": [
                     {
                       "line": 4,

--- a/acdc-parser/fixtures/tests/nested_ordered_list_with_checkmarks.json
+++ b/acdc-parser/fixtures/tests/nested_ordered_list_with_checkmarks.json
@@ -48,29 +48,14 @@
           ],
           "items": [
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "*",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "West wood maze",
-                      "location": [
-                        {
-                          "line": 4,
-                          "col": 3
-                        },
-                        {
-                          "line": 4,
-                          "col": 16
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "West wood maze",
                   "location": [
                     {
                       "line": 4,
@@ -95,29 +80,14 @@
               ]
             },
             {
-              "level": 2,
+              "name": "listItem",
+              "type": "block",
               "marker": "**",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Maze heart",
-                      "location": [
-                        {
-                          "line": 5,
-                          "col": 4
-                        },
-                        {
-                          "line": 5,
-                          "col": 13
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Maze heart",
                   "location": [
                     {
                       "line": 5,
@@ -142,29 +112,14 @@
               ]
             },
             {
-              "level": 3,
+              "name": "listItem",
+              "type": "block",
               "marker": "***",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Reflection pool",
-                      "location": [
-                        {
-                          "line": 6,
-                          "col": 5
-                        },
-                        {
-                          "line": 6,
-                          "col": 19
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Reflection pool",
                   "location": [
                     {
                       "line": 6,
@@ -189,29 +144,14 @@
               ]
             },
             {
-              "level": 2,
+              "name": "listItem",
+              "type": "block",
               "marker": "**",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Secret exit",
-                      "location": [
-                        {
-                          "line": 7,
-                          "col": 4
-                        },
-                        {
-                          "line": 7,
-                          "col": 14
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Secret exit",
                   "location": [
                     {
                       "line": 7,
@@ -236,29 +176,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "*",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Untracked file in git repository",
-                      "location": [
-                        {
-                          "line": 8,
-                          "col": 3
-                        },
-                        {
-                          "line": 8,
-                          "col": 34
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Untracked file in git repository",
                   "location": [
                     {
                       "line": 8,
@@ -301,30 +226,15 @@
           "marker": ".",
           "items": [
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "checked": false,
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 1",
-                      "location": [
-                        {
-                          "line": 11,
-                          "col": 7
-                        },
-                        {
-                          "line": 11,
-                          "col": 12
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 1",
                   "location": [
                     {
                       "line": 11,
@@ -349,29 +259,14 @@
               ]
             },
             {
-              "level": 2,
+              "name": "listItem",
+              "type": "block",
               "marker": "..",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 1.1",
-                      "location": [
-                        {
-                          "line": 12,
-                          "col": 4
-                        },
-                        {
-                          "line": 12,
-                          "col": 11
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 1.1",
                   "location": [
                     {
                       "line": 12,
@@ -396,30 +291,15 @@
               ]
             },
             {
-              "level": 3,
+              "name": "listItem",
+              "type": "block",
               "marker": "...",
               "checked": true,
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 1.1.1",
-                      "location": [
-                        {
-                          "line": 13,
-                          "col": 9
-                        },
-                        {
-                          "line": 13,
-                          "col": 18
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 1.1.1",
                   "location": [
                     {
                       "line": 13,
@@ -444,29 +324,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 2",
-                      "location": [
-                        {
-                          "line": 14,
-                          "col": 3
-                        },
-                        {
-                          "line": 14,
-                          "col": 8
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 2",
                   "location": [
                     {
                       "line": 14,
@@ -491,29 +356,14 @@
               ]
             },
             {
-              "level": 2,
+              "name": "listItem",
+              "type": "block",
               "marker": "..",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 2.1",
-                      "location": [
-                        {
-                          "line": 15,
-                          "col": 4
-                        },
-                        {
-                          "line": 15,
-                          "col": 11
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 2.1",
                   "location": [
                     {
                       "line": 15,
@@ -538,30 +388,15 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "checked": true,
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 3",
-                      "location": [
-                        {
-                          "line": 16,
-                          "col": 7
-                        },
-                        {
-                          "line": 16,
-                          "col": 12
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 3",
                   "location": [
                     {
                       "line": 16,

--- a/acdc-parser/fixtures/tests/nested_sections.json
+++ b/acdc-parser/fixtures/tests/nested_sections.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/ordered_list.json
+++ b/acdc-parser/fixtures/tests/ordered_list.json
@@ -31,29 +31,14 @@
           "marker": "1.",
           "items": [
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "1.",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 1",
-                      "location": [
-                        {
-                          "line": 3,
-                          "col": 4
-                        },
-                        {
-                          "line": 3,
-                          "col": 9
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 1",
                   "location": [
                     {
                       "line": 3,
@@ -78,29 +63,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "2.",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 2",
-                      "location": [
-                        {
-                          "line": 4,
-                          "col": 4
-                        },
-                        {
-                          "line": 4,
-                          "col": 9
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 2",
                   "location": [
                     {
                       "line": 4,
@@ -125,29 +95,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "3.",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 3",
-                      "location": [
-                        {
-                          "line": 5,
-                          "col": 4
-                        },
-                        {
-                          "line": 5,
-                          "col": 9
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 3",
                   "location": [
                     {
                       "line": 5,

--- a/acdc-parser/fixtures/tests/ordered_list_with_checkmarks.json
+++ b/acdc-parser/fixtures/tests/ordered_list_with_checkmarks.json
@@ -31,30 +31,15 @@
           "marker": ".",
           "items": [
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "checked": false,
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 1",
-                      "location": [
-                        {
-                          "line": 3,
-                          "col": 7
-                        },
-                        {
-                          "line": 3,
-                          "col": 12
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 1",
                   "location": [
                     {
                       "line": 3,
@@ -79,29 +64,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 2",
-                      "location": [
-                        {
-                          "line": 4,
-                          "col": 3
-                        },
-                        {
-                          "line": 4,
-                          "col": 8
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 2",
                   "location": [
                     {
                       "line": 4,
@@ -126,30 +96,15 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": ".",
               "checked": true,
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 3",
-                      "location": [
-                        {
-                          "line": 5,
-                          "col": 7
-                        },
-                        {
-                          "line": 5,
-                          "col": 12
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 3",
                   "location": [
                     {
                       "line": 5,

--- a/acdc-parser/fixtures/tests/ordered_list_with_explicit_continuation.json
+++ b/acdc-parser/fixtures/tests/ordered_list_with_explicit_continuation.json
@@ -9,29 +9,14 @@
       "marker": "1.",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "1.",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "First item",
-                  "location": [
-                    {
-                      "line": 1,
-                      "col": 4
-                    },
-                    {
-                      "line": 1,
-                      "col": 13
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "First item",
               "location": [
                 {
                   "line": 1,
@@ -42,7 +27,9 @@
                   "col": 13
                 }
               ]
-            },
+            }
+          ],
+          "blocks": [
             {
               "name": "listing",
               "type": "block",
@@ -113,29 +100,14 @@
       "marker": "2.",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "2.",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "Second item",
-                  "location": [
-                    {
-                      "line": 8,
-                      "col": 4
-                    },
-                    {
-                      "line": 8,
-                      "col": 14
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "Second item",
               "location": [
                 {
                   "line": 8,

--- a/acdc-parser/fixtures/tests/section.json
+++ b/acdc-parser/fixtures/tests/section.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/section_with_multiple_paragraphs.json
+++ b/acdc-parser/fixtures/tests/section_with_multiple_paragraphs.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/section_with_valid_subsection_interleaved.json
+++ b/acdc-parser/fixtures/tests/section_with_valid_subsection_interleaved.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/unordered_list.json
+++ b/acdc-parser/fixtures/tests/unordered_list.json
@@ -31,29 +31,14 @@
           "marker": "*",
           "items": [
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "*",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 1",
-                      "location": [
-                        {
-                          "line": 3,
-                          "col": 3
-                        },
-                        {
-                          "line": 3,
-                          "col": 8
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 1",
                   "location": [
                     {
                       "line": 3,
@@ -78,29 +63,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "*",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 2",
-                      "location": [
-                        {
-                          "line": 4,
-                          "col": 3
-                        },
-                        {
-                          "line": 4,
-                          "col": 8
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 2",
                   "location": [
                     {
                       "line": 4,
@@ -125,29 +95,14 @@
               ]
             },
             {
-              "level": 1,
+              "name": "listItem",
+              "type": "block",
               "marker": "*",
               "principal": [
                 {
-                  "name": "paragraph",
-                  "type": "block",
-                  "inlines": [
-                    {
-                      "name": "text",
-                      "type": "string",
-                      "value": "Item 3",
-                      "location": [
-                        {
-                          "line": 5,
-                          "col": 3
-                        },
-                        {
-                          "line": 5,
-                          "col": 8
-                        }
-                      ]
-                    }
-                  ],
+                  "name": "text",
+                  "type": "string",
+                  "value": "Item 3",
                   "location": [
                     {
                       "line": 5,

--- a/acdc-parser/fixtures/tests/unordered_list_with_explicit_continuation.json
+++ b/acdc-parser/fixtures/tests/unordered_list_with_explicit_continuation.json
@@ -9,29 +9,14 @@
       "marker": "-",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "First item",
-                  "location": [
-                    {
-                      "line": 1,
-                      "col": 3
-                    },
-                    {
-                      "line": 1,
-                      "col": 12
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "First item",
               "location": [
                 {
                   "line": 1,
@@ -42,7 +27,9 @@
                   "col": 12
                 }
               ]
-            },
+            }
+          ],
+          "blocks": [
             {
               "name": "listing",
               "type": "block",
@@ -110,29 +97,14 @@
       "marker": "-",
       "items": [
         {
-          "level": 1,
+          "name": "listItem",
+          "type": "block",
           "marker": "-",
           "principal": [
             {
-              "name": "paragraph",
-              "type": "block",
-              "inlines": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "value": "Second item",
-                  "location": [
-                    {
-                      "line": 7,
-                      "col": 3
-                    },
-                    {
-                      "line": 7,
-                      "col": 13
-                    }
-                  ]
-                }
-              ],
+              "name": "text",
+              "type": "string",
+              "value": "Second item",
               "location": [
                 {
                   "line": 7,

--- a/acdc-parser/fixtures/tests/utf8_box_drawing.json
+++ b/acdc-parser/fixtures/tests/utf8_box_drawing.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/utf8_cjk_text.json
+++ b/acdc-parser/fixtures/tests/utf8_cjk_text.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/utf8_multibyte_emoji.json
+++ b/acdc-parser/fixtures/tests/utf8_multibyte_emoji.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/acdc-parser/fixtures/tests/video_comprehensive.json
+++ b/acdc-parser/fixtures/tests/video_comprehensive.json
@@ -30,6 +30,7 @@
       }
     ]
   },
+  "attributes": {},
   "blocks": [
     {
       "name": "section",

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -102,12 +102,7 @@ impl Render for DelimitedBlock {
                     writeln!(w, "<pre>")?;
                 }
 
-                crate::inlines::render_inlines(
-                    inlines,
-                    w,
-                    processor,
-                    options,
-                )?;
+                crate::inlines::render_inlines(inlines, w, processor, options)?;
 
                 if language.is_some() {
                     writeln!(w, "</code></pre>")?;
@@ -134,12 +129,7 @@ impl Render for DelimitedBlock {
 
                 writeln!(w, "<div class=\"content\">")?;
                 writeln!(w, "<pre>")?;
-                crate::inlines::render_inlines(
-                    inlines,
-                    w,
-                    processor,
-                    options,
-                )?;
+                crate::inlines::render_inlines(inlines, w, processor, options)?;
                 writeln!(w, "</pre>")?;
                 writeln!(w, "</div>")?;
                 writeln!(w, "</div>")?;

--- a/converters/html/src/list.rs
+++ b/converters/html/src/list.rs
@@ -66,8 +66,14 @@ fn render_nested_list_items<W: Write>(
             // Render item at current level
             writeln!(w, "<li>")?;
             render_checked_status(item.checked.as_ref(), w)?;
-            // Render each block in the list item content
-            for block in &item.content {
+            // Render principal text as bare <p> (if not empty)
+            if !item.principal.is_empty() {
+                writeln!(w, "<p>")?;
+                crate::inlines::render_inlines(&item.principal, w, processor, options)?;
+                writeln!(w, "</p>")?;
+            }
+            // Render attached blocks with their full wrapper divs
+            for block in &item.blocks {
                 block.render(w, processor, options)?;
             }
 
@@ -158,8 +164,14 @@ impl Render for ListItem {
     ) -> Result<(), Self::Error> {
         writeln!(w, "<li>")?;
         render_checked_status(self.checked.as_ref(), w)?;
-        // Render each block in the list item content
-        for block in &self.content {
+        // Render principal text as bare <p> (if not empty)
+        if !self.principal.is_empty() {
+            writeln!(w, "<p>")?;
+            crate::inlines::render_inlines(&self.principal, w, processor, options)?;
+            writeln!(w, "</p>")?;
+        }
+        // Render attached blocks with their full wrapper divs
+        for block in &self.blocks {
             block.render(w, processor, options)?;
         }
         writeln!(w, "</li>")?;

--- a/converters/terminal/src/list.rs
+++ b/converters/terminal/src/list.rs
@@ -149,9 +149,16 @@ fn render_list_item_with_indent<W: Write>(
     render_checked_status(item.checked.as_ref(), w)?;
     write!(w, " ")?;
 
-    // Render each node with a space between them
-    render_nodes_with_spaces(&item.content, w, processor)?;
+    // Render principal text inline
+    render_nodes_with_spaces(&item.principal, w, processor)?;
     writeln!(w)?;
+
+    // Render attached blocks with proper indentation
+    for block in &item.blocks {
+        // Add indentation for nested content
+        write!(w, "{:indent$}", " ", indent = indent + 2)?;
+        block.render(w, processor)?;
+    }
     Ok(())
 }
 
@@ -212,9 +219,13 @@ impl Render for ListItem {
         write!(w, "{}", self.marker)?;
         render_checked_status(self.checked.as_ref(), w)?;
         write!(w, " ")?;
-        // render each node with a space between them
-        render_nodes_with_spaces(&self.content, w, processor)?;
+        // Render principal text inline
+        render_nodes_with_spaces(&self.principal, w, processor)?;
         writeln!(w)?;
+        // Render attached blocks
+        for block in &self.blocks {
+            block.render(w, processor)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
I had accidentally removed the manual parsing of the list item because I did not realise I was breaking the TCK testing.

This adds it back, and also matches the approach I had used with description lists for principal + blocks.