### PR TITLE
fix(parser): complete block title parsing and fix compound blocks

### DIFF
--- a/acdc-parser/fixtures/tests/admonition_with_title.adoc
+++ b/acdc-parser/fixtures/tests/admonition_with_title.adoc
@@ -1,0 +1,2 @@
+.Important Notice
+NOTE: This is a note with a title.

--- a/acdc-parser/fixtures/tests/admonition_with_title.json
+++ b/acdc-parser/fixtures/tests/admonition_with_title.json
@@ -1,0 +1,81 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "admonition",
+      "type": "block",
+      "variant": "note",
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Important Notice",
+          "location": [
+            {
+              "line": 1,
+              "col": 2
+            },
+            {
+              "line": 1,
+              "col": 17
+            }
+          ]
+        }
+      ],
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "This is a note with a title.",
+              "location": [
+                {
+                  "line": 2,
+                  "col": 7
+                },
+                {
+                  "line": 2,
+                  "col": 34
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 2,
+              "col": 7
+            },
+            {
+              "line": 2,
+              "col": 34
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 2,
+          "col": 34
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 2,
+      "col": 34
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/admonition_without_title.adoc
+++ b/acdc-parser/fixtures/tests/admonition_without_title.adoc
@@ -1,0 +1,1 @@
+WARNING: This is a warning without a title.

--- a/acdc-parser/fixtures/tests/admonition_without_title.json
+++ b/acdc-parser/fixtures/tests/admonition_without_title.json
@@ -1,0 +1,64 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "admonition",
+      "type": "block",
+      "variant": "warning",
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "This is a warning without a title.",
+              "location": [
+                {
+                  "line": 1,
+                  "col": 10
+                },
+                {
+                  "line": 1,
+                  "col": 43
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 1,
+              "col": 10
+            },
+            {
+              "line": 1,
+              "col": 43
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 1,
+          "col": 43
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 1,
+      "col": 43
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/open_block_with_paragraphs.adoc
+++ b/acdc-parser/fixtures/tests/open_block_with_paragraphs.adoc
@@ -1,0 +1,8 @@
+--
+First paragraph in open block.
+
+Second paragraph in open block.
+
+.Title on third paragraph
+Third paragraph has its own title.
+--

--- a/acdc-parser/fixtures/tests/open_block_with_paragraphs.json
+++ b/acdc-parser/fixtures/tests/open_block_with_paragraphs.json
@@ -1,0 +1,144 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "open",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "--",
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "First paragraph in open block.",
+              "location": [
+                {
+                  "line": 2,
+                  "col": 1
+                },
+                {
+                  "line": 2,
+                  "col": 30
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 2,
+              "col": 1
+            },
+            {
+              "line": 2,
+              "col": 30
+            }
+          ]
+        },
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Second paragraph in open block.",
+              "location": [
+                {
+                  "line": 4,
+                  "col": 1
+                },
+                {
+                  "line": 4,
+                  "col": 31
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 4,
+              "col": 1
+            },
+            {
+              "line": 4,
+              "col": 31
+            }
+          ]
+        },
+        {
+          "name": "paragraph",
+          "type": "block",
+          "title": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Title on third paragraph",
+              "location": [
+                {
+                  "line": 6,
+                  "col": 2
+                },
+                {
+                  "line": 6,
+                  "col": 25
+                }
+              ]
+            }
+          ],
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Third paragraph has its own title.",
+              "location": [
+                {
+                  "line": 7,
+                  "col": 1
+                },
+                {
+                  "line": 7,
+                  "col": 34
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 6,
+              "col": 1
+            },
+            {
+              "line": 7,
+              "col": 34
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 8,
+          "col": 2
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 8,
+      "col": 2
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/paragraph_with_title.adoc
+++ b/acdc-parser/fixtures/tests/paragraph_with_title.adoc
@@ -1,0 +1,2 @@
+.My Paragraph Title
+This is a paragraph with a title above it.

--- a/acdc-parser/fixtures/tests/paragraph_with_title.json
+++ b/acdc-parser/fixtures/tests/paragraph_with_title.json
@@ -1,0 +1,64 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "paragraph",
+      "type": "block",
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "My Paragraph Title",
+          "location": [
+            {
+              "line": 1,
+              "col": 2
+            },
+            {
+              "line": 1,
+              "col": 19
+            }
+          ]
+        }
+      ],
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "This is a paragraph with a title above it.",
+          "location": [
+            {
+              "line": 2,
+              "col": 1
+            },
+            {
+              "line": 2,
+              "col": 42
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 2,
+          "col": 42
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 2,
+      "col": 42
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/quote_block_with_paragraphs.adoc
+++ b/acdc-parser/fixtures/tests/quote_block_with_paragraphs.adoc
@@ -1,0 +1,8 @@
+____
+First paragraph in quote.
+
+Second paragraph in quote.
+
+.Quote author
+Third paragraph with title.
+____

--- a/acdc-parser/fixtures/tests/quote_block_with_paragraphs.json
+++ b/acdc-parser/fixtures/tests/quote_block_with_paragraphs.json
@@ -1,0 +1,144 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "quote",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "____",
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "First paragraph in quote.",
+              "location": [
+                {
+                  "line": 2,
+                  "col": 1
+                },
+                {
+                  "line": 2,
+                  "col": 25
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 2,
+              "col": 1
+            },
+            {
+              "line": 2,
+              "col": 25
+            }
+          ]
+        },
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Second paragraph in quote.",
+              "location": [
+                {
+                  "line": 4,
+                  "col": 1
+                },
+                {
+                  "line": 4,
+                  "col": 26
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 4,
+              "col": 1
+            },
+            {
+              "line": 4,
+              "col": 26
+            }
+          ]
+        },
+        {
+          "name": "paragraph",
+          "type": "block",
+          "title": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Quote author",
+              "location": [
+                {
+                  "line": 6,
+                  "col": 2
+                },
+                {
+                  "line": 6,
+                  "col": 13
+                }
+              ]
+            }
+          ],
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Third paragraph with title.",
+              "location": [
+                {
+                  "line": 7,
+                  "col": 1
+                },
+                {
+                  "line": 7,
+                  "col": 27
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 6,
+              "col": 1
+            },
+            {
+              "line": 7,
+              "col": 27
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 8,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 8,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/thematic_break_with_title.adoc
+++ b/acdc-parser/fixtures/tests/thematic_break_with_title.adoc
@@ -1,0 +1,2 @@
+.Section Divider
+'''

--- a/acdc-parser/fixtures/tests/thematic_break_with_title.json
+++ b/acdc-parser/fixtures/tests/thematic_break_with_title.json
@@ -1,0 +1,48 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "break",
+      "type": "block",
+      "variant": "thematic",
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Section Divider",
+          "location": [
+            {
+              "line": 1,
+              "col": 2
+            },
+            {
+              "line": 1,
+              "col": 16
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 2,
+          "col": 3
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 2,
+      "col": 3
+    }
+  ]
+}

--- a/converters/html/src/admonition.rs
+++ b/converters/html/src/admonition.rs
@@ -20,9 +20,11 @@ impl Render for Admonition {
         writeln!(w, "<div class=\"title\">{}</div>", self.variant)?;
         writeln!(w, "</td>")?;
         writeln!(w, "<td class=\"content\">")?;
-        write!(w, "<div class=\"title\">")?;
-        crate::inlines::render_inlines(&self.title, w, processor, options)?;
-        writeln!(w, "</div>")?;
+        if !self.title.is_empty() {
+            write!(w, "<div class=\"title\">")?;
+            crate::inlines::render_inlines(&self.title, w, processor, options)?;
+            writeln!(w, "</div>")?;
+        }
         for block in &self.blocks {
             block.render(w, processor, options)?;
         }

--- a/converters/html/src/block.rs
+++ b/converters/html/src/block.rs
@@ -27,7 +27,12 @@ impl Render for Block {
             Block::Audio(a) => a.render(w, processor, options),
             Block::Video(v) => v.render(w, processor, options),
             Block::DiscreteHeader(d) => d.render(w, processor, options),
-            Block::ThematicBreak(_) => {
+            Block::ThematicBreak(t) => {
+                if !t.title.is_empty() {
+                    write!(w, "<div class=\"title\">")?;
+                    crate::inlines::render_inlines(&t.title, w, processor, options)?;
+                    writeln!(w, "</div>")?;
+                }
                 writeln!(w, "<hr>")?;
                 Ok(())
             }

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -147,6 +147,23 @@ impl Render for DelimitedBlock {
                 writeln!(w, "</blockquote>")?;
                 writeln!(w, "</div>")?;
             }
+            DelimitedBlockType::DelimitedOpen(blocks) => {
+                writeln!(w, "<div class=\"openblock\">")?;
+
+                // Only render title if not empty
+                if !self.title.is_empty() {
+                    write!(w, "<div class=\"title\">")?;
+                    crate::inlines::render_inlines(&self.title, w, processor, options)?;
+                    writeln!(w, "</div>")?;
+                }
+
+                writeln!(w, "<div class=\"content\">")?;
+                for block in blocks {
+                    block.render(w, processor, options)?;
+                }
+                writeln!(w, "</div>")?;
+                writeln!(w, "</div>")?;
+            }
             unknown => todo!("Unknown delimited block type: {:?}", unknown),
         }
         Ok(())


### PR DESCRIPTION
- Fix ThematicBreak and Admonition to use parsed titles correctly
- Add title rendering to ThematicBreak HTML converter
- Skip empty title divs in admonition renderer
- Fix open and quote blocks to parse content as blocks instead of plain text
- Add DelimitedOpen HTML rendering support