### PR TITLE
feat(parser,html,terminal): add inline anchor support

### DIFF
--- a/acdc-parser/src/model/inlines/converter.rs
+++ b/acdc-parser/src/model/inlines/converter.rs
@@ -26,6 +26,7 @@ pub fn inlines_to_string(inlines: &[InlineNode]) -> String {
             InlineNode::CurvedApostropheText(apos) => inlines_to_string(&apos.content),
             InlineNode::StandaloneCurvedApostrophe(_) => "'".to_string(),
             InlineNode::LineBreak(_) => " ".to_string(),
+            InlineNode::InlineAnchor(_) => String::new(),
             InlineNode::Macro(macro_node) => match macro_node {
                 InlineMacro::Link(link) => {
                     link.text.clone().unwrap_or_else(|| link.target.to_string())

--- a/acdc-parser/src/model/mod.rs
+++ b/acdc-parser/src/model/mod.rs
@@ -468,7 +468,6 @@ pub enum ListItemCheckedStatus {
 /// with their full wrapper divs.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ListItem {
-    // TODO(nlopes): missing anchors
     pub level: ListLevel,
     pub marker: String,
     pub checked: Option<ListItemCheckedStatus>,

--- a/converters/html/src/inlines.rs
+++ b/converters/html/src/inlines.rs
@@ -172,6 +172,9 @@ impl Render for InlineNode {
             InlineNode::LineBreak(_) => {
                 writeln!(w, "<br>")?;
             }
+            InlineNode::InlineAnchor(anchor) => {
+                write!(w, "<a id=\"{}\"></a>", anchor.id)?;
+            }
             unknown => todo!("inlines: {:?}", unknown),
         }
         Ok(())

--- a/converters/html/src/list.rs
+++ b/converters/html/src/list.rs
@@ -16,7 +16,14 @@ impl Render for UnorderedList {
         processor: &Processor,
         options: &RenderOptions,
     ) -> Result<(), Self::Error> {
-        writeln!(w, "<div class=\"ulist\">")?;
+        write!(w, "<div")?;
+        // Use metadata.id if present, otherwise use first anchor
+        if let Some(id) = &self.metadata.id {
+            write!(w, " id=\"{}\"", id.id)?;
+        } else if let Some(anchor) = self.metadata.anchors.first() {
+            write!(w, " id=\"{}\"", anchor.id)?;
+        }
+        writeln!(w, " class=\"ulist\">")?;
         writeln!(w, "<ul>")?;
         render_nested_list_items(&self.items, w, processor, options, 1, false)?;
         writeln!(w, "</ul>")?;
@@ -34,7 +41,14 @@ impl Render for OrderedList {
         processor: &Processor,
         options: &RenderOptions,
     ) -> Result<(), Self::Error> {
-        writeln!(w, "<div class=\"olist arabic\">")?;
+        write!(w, "<div")?;
+        // Use metadata.id if present, otherwise use first anchor
+        if let Some(id) = &self.metadata.id {
+            write!(w, " id=\"{}\"", id.id)?;
+        } else if let Some(anchor) = self.metadata.anchors.first() {
+            write!(w, " id=\"{}\"", anchor.id)?;
+        }
+        writeln!(w, " class=\"olist arabic\">")?;
         writeln!(w, "<ol class=\"arabic\">")?;
         render_nested_list_items(&self.items, w, processor, options, 1, true)?;
         writeln!(w, "</ol>")?;
@@ -224,7 +238,14 @@ impl Render for DescriptionList {
         processor: &Processor,
         options: &RenderOptions,
     ) -> Result<(), Self::Error> {
-        writeln!(w, "<div class=\"dlist\">")?;
+        write!(w, "<div")?;
+        // Use metadata.id if present, otherwise use first anchor
+        if let Some(id) = &self.metadata.id {
+            write!(w, " id=\"{}\"", id.id)?;
+        } else if let Some(anchor) = self.metadata.anchors.first() {
+            write!(w, " id=\"{}\"", anchor.id)?;
+        }
+        writeln!(w, " class=\"dlist\">")?;
         writeln!(w, "<dl>")?;
         for item in &self.items {
             item.render(w, processor, options)?;

--- a/converters/terminal/src/inline.rs
+++ b/converters/terminal/src/inline.rs
@@ -81,6 +81,9 @@ impl Render for InlineNode {
             InlineNode::Macro(m) => {
                 m.render(w, processor)?;
             }
+            InlineNode::InlineAnchor(_) => {
+                // Anchors are invisible in terminal output
+            }
             unknown => unimplemented!("GAH: {:?}", unknown),
         }
         Ok(())


### PR DESCRIPTION
This covers the implementation of:
- Inline anchor parsing (`[[id]]` and `[[id,reftext]]` syntax)
- HTML rendering as <a id="..."></a> tags
- ID attribute support for lists using metadata or anchors
- Terminal converter handling (invisible output)