### PR TITLE
fix(preprocessor): preserve comments in verbatim blocks

### DIFF
--- a/acdc-parser/fixtures/tests/listing_block_with_comments.adoc
+++ b/acdc-parser/fixtures/tests/listing_block_with_comments.adoc
@@ -1,0 +1,8 @@
+.Listing block with comments
+----
+code line 1
+// This comment should be PRESERVED
+code line 2
+// Another comment to preserve
+code line 3
+----

--- a/acdc-parser/fixtures/tests/listing_block_with_comments.json
+++ b/acdc-parser/fixtures/tests/listing_block_with_comments.json
@@ -1,0 +1,66 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "listing",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "----",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "code line 1\n// This comment should be PRESERVED\ncode line 2\n// Another comment to preserve\ncode line 3",
+          "location": [
+            {
+              "line": 3,
+              "col": 1
+            },
+            {
+              "line": 7,
+              "col": 11
+            }
+          ]
+        }
+      ],
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Listing block with comments",
+          "location": [
+            {
+              "line": 1,
+              "col": 2
+            },
+            {
+              "line": 1,
+              "col": 28
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 8,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 8,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/literal_block_with_comments.adoc
+++ b/acdc-parser/fixtures/tests/literal_block_with_comments.adoc
@@ -1,0 +1,6 @@
+.Literal block with comments
+....
+literal content line 1
+// This comment should be PRESERVED in literal block
+literal content line 2
+....

--- a/acdc-parser/fixtures/tests/literal_block_with_comments.json
+++ b/acdc-parser/fixtures/tests/literal_block_with_comments.json
@@ -1,0 +1,66 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "literal",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "....",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "literal content line 1\n// This comment should be PRESERVED in literal block\nliteral content line 2",
+          "location": [
+            {
+              "line": 3,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 22
+            }
+          ]
+        }
+      ],
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Literal block with comments",
+          "location": [
+            {
+              "line": 1,
+              "col": 2
+            },
+            {
+              "line": 1,
+              "col": 28
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 6,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 6,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/mixed_comments_and_blocks.adoc
+++ b/acdc-parser/fixtures/tests/mixed_comments_and_blocks.adoc
@@ -1,0 +1,26 @@
+= Document with Mixed Comments
+
+// This comment should be FILTERED (outside block)
+
+Regular paragraph.
+
+// Another comment to filter
+
+.Code block
+----
+code line 1
+// This comment should be PRESERVED (inside block)
+code line 2
+----
+
+// This comment should be FILTERED (between blocks)
+
+Another paragraph.
+
+....
+literal line 1
+// This comment should be PRESERVED (inside literal)
+literal line 2
+....
+
+// Final comment to filter (outside all blocks)

--- a/acdc-parser/fixtures/tests/mixed_comments_and_blocks.json
+++ b/acdc-parser/fixtures/tests/mixed_comments_and_blocks.json
@@ -1,0 +1,191 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Document with Mixed Comments",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 30
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 30
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Regular paragraph.",
+          "location": [
+            {
+              "line": 5,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 18
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 5,
+          "col": 1
+        },
+        {
+          "line": 5,
+          "col": 18
+        }
+      ]
+    },
+    {
+      "name": "listing",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "----",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "code line 1\n// This comment should be PRESERVED (inside block)\ncode line 2",
+          "location": [
+            {
+              "line": 11,
+              "col": 1
+            },
+            {
+              "line": 13,
+              "col": 11
+            }
+          ]
+        }
+      ],
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Code block",
+          "location": [
+            {
+              "line": 9,
+              "col": 2
+            },
+            {
+              "line": 9,
+              "col": 11
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 9,
+          "col": 1
+        },
+        {
+          "line": 14,
+          "col": 4
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "type": "block",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Another paragraph.",
+          "location": [
+            {
+              "line": 18,
+              "col": 1
+            },
+            {
+              "line": 18,
+              "col": 18
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 18,
+          "col": 1
+        },
+        {
+          "line": 18,
+          "col": 18
+        }
+      ]
+    },
+    {
+      "name": "literal",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "....",
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "literal line 1\n// This comment should be PRESERVED (inside literal)\nliteral line 2",
+          "location": [
+            {
+              "line": 21,
+              "col": 1
+            },
+            {
+              "line": 23,
+              "col": 14
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 20,
+          "col": 1
+        },
+        {
+          "line": 24,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 24,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/ordered_list_with_explicit_continuation.json
+++ b/acdc-parser/fixtures/tests/ordered_list_with_explicit_continuation.json
@@ -45,7 +45,7 @@
                 {
                   "name": "text",
                   "type": "string",
-                  "value": "\nfn main() {}",
+                  "value": "// code example\nfn main() {}",
                   "location": [
                     {
                       "line": 5,

--- a/acdc-parser/fixtures/tests/passthrough_block_with_comments.adoc
+++ b/acdc-parser/fixtures/tests/passthrough_block_with_comments.adoc
@@ -1,0 +1,7 @@
+.Passthrough block with comments
+++++
+<div class="custom">
+// This comment should be preserved in passthrough
+Raw HTML content
+</div>
+++++

--- a/acdc-parser/fixtures/tests/passthrough_block_with_comments.json
+++ b/acdc-parser/fixtures/tests/passthrough_block_with_comments.json
@@ -1,0 +1,66 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "pass",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "++++",
+      "inlines": [
+        {
+          "name": "raw",
+          "type": "string",
+          "value": "<div class=\"custom\">\n// This comment should be preserved in passthrough\nRaw HTML content\n</div>",
+          "location": [
+            {
+              "line": 3,
+              "col": 1
+            },
+            {
+              "line": 6,
+              "col": 6
+            }
+          ]
+        }
+      ],
+      "title": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "Passthrough block with comments",
+          "location": [
+            {
+              "line": 1,
+              "col": 2
+            },
+            {
+              "line": 1,
+              "col": 32
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 7,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 7,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/source_block_with_comments.adoc
+++ b/acdc-parser/fixtures/tests/source_block_with_comments.adoc
@@ -1,0 +1,7 @@
+[source,python]
+----
+def hello():
+    # Python comment (should be preserved)
+    // AsciiDoc comment (should also be preserved)
+    print("Hello, World!")
+----

--- a/acdc-parser/fixtures/tests/source_block_with_comments.json
+++ b/acdc-parser/fixtures/tests/source_block_with_comments.json
@@ -1,0 +1,55 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "listing",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "----",
+      "metadata": {
+        "attributes": {
+          "python": null
+        },
+        "style": "source"
+      },
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "def hello():\n    # Python comment (should be preserved)\n    // AsciiDoc comment (should also be preserved)\n    print(\"Hello, World!\")",
+          "location": [
+            {
+              "line": 3,
+              "col": 1
+            },
+            {
+              "line": 6,
+              "col": 26
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 7,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 7,
+      "col": 4
+    }
+  ]
+}


### PR DESCRIPTION
Comments (// lines) were being incorrectly removed from listing, literal, source, and passthrough blocks. The preprocessor was filtering all comments unconditionally before the parser ran.

Fixes #209