### PR TITLE
feat(parser): add column width and style parsing for tables

### DIFF
--- a/acdc-parser/fixtures/tests/table_column_alignment.adoc
+++ b/acdc-parser/fixtures/tests/table_column_alignment.adoc
@@ -1,0 +1,8 @@
+= Table Column Alignment
+
+[cols="<,^,>"]
+|===
+| Left | Center | Right
+
+| A | B | C
+|===

--- a/acdc-parser/fixtures/tests/table_column_alignment.json
+++ b/acdc-parser/fixtures/tests/table_column_alignment.json
@@ -1,0 +1,309 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Table Column Alignment",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 24
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 24
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "table",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "|===",
+      "metadata": {
+        "attributes": {
+          "cols": "\"<,^,>\""
+        }
+      },
+      "content": {
+        "header": {
+          "columns": [
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Left",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 3
+                        },
+                        {
+                          "line": 5,
+                          "col": 6
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 3
+                    },
+                    {
+                      "line": 5,
+                      "col": 6
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Center",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 10
+                        },
+                        {
+                          "line": 5,
+                          "col": 15
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 10
+                    },
+                    {
+                      "line": 5,
+                      "col": 15
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Right",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 19
+                        },
+                        {
+                          "line": 5,
+                          "col": 23
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 19
+                    },
+                    {
+                      "line": 5,
+                      "col": 23
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "footer": null,
+        "rows": [
+          {
+            "columns": [
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "A",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 3
+                          },
+                          {
+                            "line": 7,
+                            "col": 3
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 3
+                      },
+                      {
+                        "line": 7,
+                        "col": 3
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "B",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 7
+                          },
+                          {
+                            "line": 7,
+                            "col": 7
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 7
+                      },
+                      {
+                        "line": 7,
+                        "col": 7
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "C",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 11
+                          },
+                          {
+                            "line": 7,
+                            "col": 11
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 11
+                      },
+                      {
+                        "line": 7,
+                        "col": 11
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "columns": [
+          {},
+          {
+            "halign": "center"
+          },
+          {
+            "halign": "right"
+          }
+        ],
+        "location": [
+          {
+            "line": 4,
+            "col": 1
+          },
+          {
+            "line": 8,
+            "col": 4
+          }
+        ]
+      },
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 8,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 8,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/table_column_alignment_combined.adoc
+++ b/acdc-parser/fixtures/tests/table_column_alignment_combined.adoc
@@ -1,0 +1,8 @@
+= Table Column Alignment Combined
+
+[cols="^.>2,1"]
+|===
+| Center+Bottom | Default
+
+| A | B
+|===

--- a/acdc-parser/fixtures/tests/table_column_alignment_combined.json
+++ b/acdc-parser/fixtures/tests/table_column_alignment_combined.json
@@ -1,0 +1,240 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Table Column Alignment Combined",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 33
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 33
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "table",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "|===",
+      "metadata": {
+        "attributes": {
+          "cols": "\"^.>2,1\""
+        }
+      },
+      "content": {
+        "header": {
+          "columns": [
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Center+Bottom",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 3
+                        },
+                        {
+                          "line": 5,
+                          "col": 15
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 3
+                    },
+                    {
+                      "line": 5,
+                      "col": 15
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Default",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 19
+                        },
+                        {
+                          "line": 5,
+                          "col": 25
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 19
+                    },
+                    {
+                      "line": 5,
+                      "col": 25
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "footer": null,
+        "rows": [
+          {
+            "columns": [
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "A",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 3
+                          },
+                          {
+                            "line": 7,
+                            "col": 3
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 3
+                      },
+                      {
+                        "line": 7,
+                        "col": 3
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "B",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 7
+                          },
+                          {
+                            "line": 7,
+                            "col": 7
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 7
+                      },
+                      {
+                        "line": 7,
+                        "col": 7
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "columns": [
+          {
+            "halign": "center",
+            "valign": "bottom",
+            "width": {
+              "proportional": 2
+            }
+          },
+          {}
+        ],
+        "location": [
+          {
+            "line": 4,
+            "col": 1
+          },
+          {
+            "line": 8,
+            "col": 4
+          }
+        ]
+      },
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 8,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 8,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/table_column_alignment_multiplier.adoc
+++ b/acdc-parser/fixtures/tests/table_column_alignment_multiplier.adoc
@@ -1,0 +1,8 @@
+= Table Column Alignment Multiplier
+
+[cols="2*.^"]
+|===
+| Middle1 | Middle2
+
+| A | B
+|===

--- a/acdc-parser/fixtures/tests/table_column_alignment_multiplier.json
+++ b/acdc-parser/fixtures/tests/table_column_alignment_multiplier.json
@@ -1,0 +1,238 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Table Column Alignment Multiplier",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 35
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 35
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "table",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "|===",
+      "metadata": {
+        "attributes": {
+          "cols": "\"2*.^\""
+        }
+      },
+      "content": {
+        "header": {
+          "columns": [
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Middle1",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 3
+                        },
+                        {
+                          "line": 5,
+                          "col": 9
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 3
+                    },
+                    {
+                      "line": 5,
+                      "col": 9
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Middle2",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 13
+                        },
+                        {
+                          "line": 5,
+                          "col": 19
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 13
+                    },
+                    {
+                      "line": 5,
+                      "col": 19
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "footer": null,
+        "rows": [
+          {
+            "columns": [
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "A",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 3
+                          },
+                          {
+                            "line": 7,
+                            "col": 3
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 3
+                      },
+                      {
+                        "line": 7,
+                        "col": 3
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "B",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 7
+                          },
+                          {
+                            "line": 7,
+                            "col": 7
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 7
+                      },
+                      {
+                        "line": 7,
+                        "col": 7
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "columns": [
+          {
+            "valign": "middle"
+          },
+          {
+            "valign": "middle"
+          }
+        ],
+        "location": [
+          {
+            "line": 4,
+            "col": 1
+          },
+          {
+            "line": 8,
+            "col": 4
+          }
+        ]
+      },
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 8,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 8,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/table_column_alignment_right_middle.adoc
+++ b/acdc-parser/fixtures/tests/table_column_alignment_right_middle.adoc
@@ -1,0 +1,8 @@
+= Table Column Alignment Right Middle
+
+[cols=">.^1,2"]
+|===
+| Right+Middle | Default
+
+| A | B
+|===

--- a/acdc-parser/fixtures/tests/table_column_alignment_right_middle.json
+++ b/acdc-parser/fixtures/tests/table_column_alignment_right_middle.json
@@ -1,0 +1,241 @@
+{
+  "name": "document",
+  "type": "block",
+  "header": {
+    "title": [
+      {
+        "name": "text",
+        "type": "string",
+        "value": "Table Column Alignment Right Middle",
+        "location": [
+          {
+            "line": 1,
+            "col": 3
+          },
+          {
+            "line": 1,
+            "col": 37
+          }
+        ]
+      }
+    ],
+    "location": [
+      {
+        "line": 1,
+        "col": 1
+      },
+      {
+        "line": 1,
+        "col": 37
+      }
+    ]
+  },
+  "attributes": {},
+  "blocks": [
+    {
+      "name": "table",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "|===",
+      "metadata": {
+        "attributes": {
+          "cols": "\">.^1,2\""
+        }
+      },
+      "content": {
+        "header": {
+          "columns": [
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Right+Middle",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 3
+                        },
+                        {
+                          "line": 5,
+                          "col": 14
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 3
+                    },
+                    {
+                      "line": 5,
+                      "col": 14
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "name": "paragraph",
+                  "type": "block",
+                  "inlines": [
+                    {
+                      "name": "text",
+                      "type": "string",
+                      "value": "Default",
+                      "location": [
+                        {
+                          "line": 5,
+                          "col": 18
+                        },
+                        {
+                          "line": 5,
+                          "col": 24
+                        }
+                      ]
+                    }
+                  ],
+                  "location": [
+                    {
+                      "line": 5,
+                      "col": 18
+                    },
+                    {
+                      "line": 5,
+                      "col": 24
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "footer": null,
+        "rows": [
+          {
+            "columns": [
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "A",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 3
+                          },
+                          {
+                            "line": 7,
+                            "col": 3
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 3
+                      },
+                      {
+                        "line": 7,
+                        "col": 3
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "content": [
+                  {
+                    "name": "paragraph",
+                    "type": "block",
+                    "inlines": [
+                      {
+                        "name": "text",
+                        "type": "string",
+                        "value": "B",
+                        "location": [
+                          {
+                            "line": 7,
+                            "col": 7
+                          },
+                          {
+                            "line": 7,
+                            "col": 7
+                          }
+                        ]
+                      }
+                    ],
+                    "location": [
+                      {
+                        "line": 7,
+                        "col": 7
+                      },
+                      {
+                        "line": 7,
+                        "col": 7
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "columns": [
+          {
+            "halign": "right",
+            "valign": "middle"
+          },
+          {
+            "width": {
+              "proportional": 2
+            }
+          }
+        ],
+        "location": [
+          {
+            "line": 4,
+            "col": 1
+          },
+          {
+            "line": 8,
+            "col": 4
+          }
+        ]
+      },
+      "location": [
+        {
+          "line": 3,
+          "col": 1
+        },
+        {
+          "line": 8,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 8,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/table_incomplete_row_single_line.json
+++ b/acdc-parser/fixtures/tests/table_incomplete_row_single_line.json
@@ -485,6 +485,23 @@
             ]
           }
         ],
+        "columns": [
+          {
+            "width": {
+              "percentage": 34
+            }
+          },
+          {
+            "width": {
+              "percentage": 36
+            }
+          },
+          {
+            "width": {
+              "percentage": 31
+            }
+          }
+        ],
         "location": [
           {
             "line": 4,

--- a/acdc-parser/src/lib.rs
+++ b/acdc-parser/src/lib.rs
@@ -50,15 +50,16 @@ use preprocessor::Preprocessor;
 pub use error::{Error, Positioning, SourceLocation};
 pub use model::{
     Admonition, AdmonitionVariant, Anchor, AttributeName, AttributeValue, Audio, Author, Autolink,
-    Block, BlockMetadata, Bold, Button, CalloutList, CrossReference, CurvedApostrophe,
-    CurvedQuotation, DelimitedBlock, DelimitedBlockType, DescriptionList, DescriptionListItem,
-    DiscreteHeader, Document, DocumentAttribute, DocumentAttributes, ElementAttributes, Footnote,
-    Form, Header, Highlight, Icon, Image, InlineMacro, InlineNode, Italic, Keyboard, LineBreak,
-    Link, ListItem, ListItemCheckedStatus, Location, Menu, Monospace, OrderedList, PageBreak,
-    Paragraph, Pass, PassthroughKind, Plain, Position, Raw, Role, Section, Source,
-    StandaloneCurvedApostrophe, Stem, StemContent, StemNotation, Subscript, Substitution,
-    Superscript, Table, TableColumn, TableOfContents, TableRow, ThematicBreak, TocEntry,
-    UnorderedList, Url, Verbatim, Video, inlines_to_string,
+    Block, BlockMetadata, Bold, Button, CalloutList, ColumnFormat, ColumnStyle, ColumnWidth,
+    CrossReference, CurvedApostrophe, CurvedQuotation, DelimitedBlock, DelimitedBlockType,
+    DescriptionList, DescriptionListItem, DiscreteHeader, Document, DocumentAttribute,
+    DocumentAttributes, ElementAttributes, Footnote, Form, Header, Highlight, HorizontalAlignment,
+    Icon, Image, InlineMacro, InlineNode, Italic, Keyboard, LineBreak, Link, ListItem,
+    ListItemCheckedStatus, Location, Menu, Monospace, OrderedList, PageBreak, Paragraph, Pass,
+    PassthroughKind, Plain, Position, Raw, Role, Section, Source, StandaloneCurvedApostrophe, Stem,
+    StemContent, StemNotation, Subscript, Substitution, Superscript, Table, TableColumn,
+    TableOfContents, TableRow, ThematicBreak, TocEntry, UnorderedList, Url, Verbatim,
+    VerticalAlignment, Video, inlines_to_string,
 };
 pub use options::{Options, OptionsBuilder};
 

--- a/acdc-parser/src/model/mod.rs
+++ b/acdc-parser/src/model/mod.rs
@@ -628,11 +628,112 @@ impl DelimitedBlockType {
     }
 }
 
+/// Horizontal alignment for table cells
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HorizontalAlignment {
+    #[default]
+    Left,
+    Center,
+    Right,
+}
+
+/// Vertical alignment for table cells
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerticalAlignment {
+    #[default]
+    Top,
+    Middle,
+    Bottom,
+}
+
+/// Column width specification
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ColumnWidth {
+    /// Proportional width (e.g., 1, 2, 3 - relative to other columns)
+    Proportional(u32),
+    /// Percentage width (e.g., 15%, 30%, 55%)
+    Percentage(u32),
+    /// Auto-width - content determines width (~)
+    Auto,
+}
+
+impl Default for ColumnWidth {
+    fn default() -> Self {
+        ColumnWidth::Proportional(1)
+    }
+}
+
+/// Column content style
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ColumnStyle {
+    /// `AsciiDoc` block content (a) - supports lists, blocks, macros
+    #[serde(rename = "asciidoc")]
+    AsciiDoc,
+    /// Default paragraph-level markup (d)
+    #[default]
+    Default,
+    /// Emphasis/italic (e)
+    Emphasis,
+    /// Header styling (h)
+    Header,
+    /// Literal block text (l)
+    Literal,
+    /// Monospace font (m)
+    Monospace,
+    /// Strong/bold (s)
+    Strong,
+}
+
+/// Column format specification for table formatting
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ColumnFormat {
+    #[serde(default, skip_serializing_if = "is_default_halign")]
+    pub halign: HorizontalAlignment,
+    #[serde(default, skip_serializing_if = "is_default_valign")]
+    pub valign: VerticalAlignment,
+    #[serde(default, skip_serializing_if = "is_default_width")]
+    pub width: ColumnWidth,
+    #[serde(default, skip_serializing_if = "is_default_style")]
+    pub style: ColumnStyle,
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_default_halign(h: &HorizontalAlignment) -> bool {
+    *h == HorizontalAlignment::default()
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_default_valign(v: &VerticalAlignment) -> bool {
+    *v == VerticalAlignment::default()
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_default_width(w: &ColumnWidth) -> bool {
+    *w == ColumnWidth::default()
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_default_style(s: &ColumnStyle) -> bool {
+    *s == ColumnStyle::default()
+}
+
+fn are_all_columns_default(specs: &[ColumnFormat]) -> bool {
+    specs.iter().all(|s| *s == ColumnFormat::default())
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Table {
     pub header: Option<TableRow>,
     pub footer: Option<TableRow>,
     pub rows: Vec<TableRow>,
+    /// Column format specification for each column (alignment, width, style)
+    /// Skipped if all columns have default format
+    #[serde(default, skip_serializing_if = "are_all_columns_default")]
+    pub columns: Vec<ColumnFormat>,
     pub location: Location,
 }
 

--- a/converters/terminal/src/table.rs
+++ b/converters/terminal/src/table.rs
@@ -186,6 +186,7 @@ mod tests {
                     },
                 ],
             }),
+            columns: Vec::new(),
             location: Location::default(),
         };
 
@@ -228,6 +229,7 @@ mod tests {
                 }],
             }],
             footer: None,
+            columns: Vec::new(),
             location: Location::default(),
         };
 


### PR DESCRIPTION
Extend table column specification parsing to support the full AsciiDoc cols attribute syntax: [multiplier*][halign][valign][width][style]

- Add ColumnWidth enum: Proportional(u32), Percentage(u32), Auto
- Add ColumnStyle enum: AsciiDoc, Default, Emphasis, Header, Literal, Monospace, Strong
- Rename ColumnAlignmentFormat to ColumnFormat
- Rename Table.columns_alignment to Table.columns
- Parse width: integers (proportional), percentages, ~ (auto)
- Parse style: a, d, e, h, l, m, s specifiers