### PR TITLE
fix(parser): break description list when separated by block attrs

### DIFF
--- a/acdc-parser/fixtures/tests/description_list_block_attributes_boundary.adoc
+++ b/acdc-parser/fixtures/tests/description_list_block_attributes_boundary.adoc
@@ -1,0 +1,5 @@
+[.role1]
+Term A:: Definition A
+
+[.role2]
+Term B:: Definition B

--- a/acdc-parser/fixtures/tests/description_list_block_attributes_boundary.json
+++ b/acdc-parser/fixtures/tests/description_list_block_attributes_boundary.json
@@ -1,0 +1,154 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "dlist",
+      "type": "block",
+      "metadata": {
+        "roles": [
+          "role1"
+        ]
+      },
+      "items": [
+        {
+          "term": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Term A",
+              "location": [
+                {
+                  "line": 2,
+                  "col": 1
+                },
+                {
+                  "line": 2,
+                  "col": 6
+                }
+              ]
+            }
+          ],
+          "delimiter": "::",
+          "principal_text": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Definition A",
+              "location": [
+                {
+                  "line": 2,
+                  "col": 10
+                },
+                {
+                  "line": 2,
+                  "col": 21
+                }
+              ]
+            }
+          ],
+          "description": [],
+          "location": [
+            {
+              "line": 2,
+              "col": 1
+            },
+            {
+              "line": 2,
+              "col": 22
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 2,
+          "col": 22
+        }
+      ]
+    },
+    {
+      "name": "dlist",
+      "type": "block",
+      "metadata": {
+        "roles": [
+          "role2"
+        ]
+      },
+      "items": [
+        {
+          "term": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Term B",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 1
+                },
+                {
+                  "line": 5,
+                  "col": 6
+                }
+              ]
+            }
+          ],
+          "delimiter": "::",
+          "principal_text": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Definition B",
+              "location": [
+                {
+                  "line": 5,
+                  "col": 10
+                },
+                {
+                  "line": 5,
+                  "col": 21
+                }
+              ]
+            }
+          ],
+          "description": [],
+          "location": [
+            {
+              "line": 5,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 22
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 4,
+          "col": 1
+        },
+        {
+          "line": 5,
+          "col": 22
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 5,
+      "col": 21
+    }
+  ]
+}


### PR DESCRIPTION
When a blank line is followed by block attributes (e.g., `[.role2]`), asciidoctor treats
it as starting a new description list with those attributes applied. Previously,
`acdc-parser` would incorrectly continue the existing list and include the attribute text
in the next term.

Note: Block attributes must start at column 1 (no leading whitespace) to trigger a new
list, matching asciidoctor's behavior.

Closes https://github.com/nlopes/acdc/issues/267