### PR TITLE
fix(parser): context-aware backslash stripping

### DIFF
--- a/acdc-parser/fixtures/tests/escaped_superscript_subscript.json
+++ b/acdc-parser/fixtures/tests/escaped_superscript_subscript.json
@@ -167,11 +167,71 @@
         {
           "name": "text",
           "type": "string",
-          "value": "Mixed: H\\~2~O and E=mc\\^2^ vs H",
+          "value": "Mixed: H",
           "location": [
             {
               "line": 5,
               "col": 1
+            },
+            {
+              "line": 5,
+              "col": 8
+            }
+          ]
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "value": "~2~",
+          "location": [
+            {
+              "line": 5,
+              "col": 9
+            },
+            {
+              "line": 5,
+              "col": 13
+            }
+          ]
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "value": "O and E=mc",
+          "location": [
+            {
+              "line": 5,
+              "col": 13
+            },
+            {
+              "line": 5,
+              "col": 22
+            }
+          ]
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "value": "^2^",
+          "location": [
+            {
+              "line": 5,
+              "col": 23
+            },
+            {
+              "line": 5,
+              "col": 27
+            }
+          ]
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "value": " vs H",
+          "location": [
+            {
+              "line": 5,
+              "col": 27
             },
             {
               "line": 5,

--- a/acdc-parser/src/grammar/location_mapping.rs
+++ b/acdc-parser/src/grammar/location_mapping.rs
@@ -639,6 +639,7 @@ fn map_plain_text_inline_locations<'a>(
         Ok(vec![InlineNode::PlainText(Plain {
             content: original_content.clone(),
             location: mapped_location,
+            escaped: plain.escaped,
         })])
     }
 }

--- a/acdc-parser/src/grammar/passthrough_processing.rs
+++ b/acdc-parser/src/grammar/passthrough_processing.rs
@@ -199,6 +199,7 @@ pub(crate) fn process_passthrough_with_quotes(
             vec![InlineNode::PlainText(Plain {
                 content: content.to_string(),
                 location: passthrough.location.clone(),
+                escaped: false,
             })]
         } else {
             vec![InlineNode::RawText(Raw {
@@ -258,6 +259,7 @@ pub fn parse_text_for_quotes(content: &str) -> Vec<InlineNode> {
                         current_offset,
                         current_offset + before_content.len(),
                     ),
+                    escaped: false,
                 }));
                 current_offset += before_content.len();
             }
@@ -271,6 +273,7 @@ pub fn parse_text_for_quotes(content: &str) -> Vec<InlineNode> {
             let inner_content = InlineNode::PlainText(Plain {
                 content: markup_match.content.clone(),
                 location: inner_location,
+                escaped: false,
             });
 
             // Create outer location
@@ -300,6 +303,7 @@ pub fn parse_text_for_quotes(content: &str) -> Vec<InlineNode> {
                             current_offset,
                             current_offset + remaining.len(),
                         ),
+                        escaped: false,
                     }));
                 }
             }
@@ -397,6 +401,7 @@ pub(crate) fn process_passthrough_placeholders(
                             column: base_location.start.column + processed_offset + before.len(),
                         },
                     },
+                    escaped: false,
                 }));
                 processed_offset += before.len();
             }
@@ -449,6 +454,7 @@ pub(crate) fn process_passthrough_placeholders(
                     },
                     end: base_location.end.clone(),
                 },
+                escaped: false,
             }));
         }
     }
@@ -458,6 +464,7 @@ pub(crate) fn process_passthrough_placeholders(
         result.push(InlineNode::PlainText(Plain {
             content: content.to_string(),
             location: base_location.clone(),
+            escaped: false,
         }));
     }
 

--- a/acdc-parser/src/model/inlines/mod.rs
+++ b/acdc-parser/src/model/inlines/mod.rs
@@ -447,6 +447,7 @@ fn construct_plain_text<E: de::Error>(raw: RawInlineFields) -> Result<InlineNode
     Ok(InlineNode::PlainText(Plain {
         content: raw.value.ok_or_else(|| E::missing_field("value"))?,
         location: raw.location.ok_or_else(|| E::missing_field("location"))?,
+        escaped: false,
     }))
 }
 

--- a/acdc-parser/src/model/inlines/text.rs
+++ b/acdc-parser/src/model/inlines/text.rs
@@ -153,6 +153,10 @@ pub struct Plain {
     #[serde(rename = "value")]
     pub content: String,
     pub location: Location,
+    /// True if content originated from an escaped pattern (e.g., `\^2^`).
+    /// When true, the converter should not re-parse for quotes.
+    #[serde(default, skip_serializing)]
+    pub escaped: bool,
 }
 
 impl Serialize for Plain {

--- a/acdc-parser/src/model/section.rs
+++ b/acdc-parser/src/model/section.rs
@@ -158,6 +158,7 @@ mod tests {
         let inlines: &[InlineNode] = &[InlineNode::PlainText(Plain {
             content: "This is a title.".to_string(),
             location: Location::default(),
+            escaped: false,
         })];
         assert_eq!(
             Section::id_from_title(inlines),
@@ -166,6 +167,7 @@ mod tests {
         let inlines: &[InlineNode] = &[InlineNode::PlainText(Plain {
             content: "This is a----title.".to_string(),
             location: Location::default(),
+            escaped: false,
         })];
         assert_eq!(
             Section::id_from_title(inlines),
@@ -178,6 +180,7 @@ mod tests {
         let inlines: &[InlineNode] = &[InlineNode::PlainText(Plain {
             content: "This is a b__i__g title.".to_string(),
             location: Location::default(),
+            escaped: false,
         })];
         // metadata has an empty id
         let metadata = BlockMetadata::default();

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -326,6 +326,7 @@ mod tests {
         vec![InlineNode::PlainText(Plain {
             content: content.to_string(),
             location: Location::default(),
+            escaped: false,
         })]
     }
 
@@ -472,6 +473,7 @@ mod tests {
         let title = Title::new(vec![InlineNode::PlainText(Plain {
             content: "My Code Example".to_string(),
             location: Location::default(),
+            escaped: false,
         })]);
 
         let block = DelimitedBlock::new(
@@ -512,11 +514,13 @@ mod tests {
         let title1 = Title::new(vec![InlineNode::PlainText(Plain {
             content: "First Example".to_string(),
             location: Location::default(),
+            escaped: false,
         })]);
 
         let title2 = Title::new(vec![InlineNode::PlainText(Plain {
             content: "Second Example".to_string(),
             location: Location::default(),
+            escaped: false,
         })]);
 
         let block1 = DelimitedBlock::new(

--- a/converters/html/tests/fixtures/expected/escaped_superscript_subscript.html
+++ b/converters/html/tests/fixtures/expected/escaped_superscript_subscript.html
@@ -440,10 +440,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <body class="article">
 <div id="content">
 <div class="paragraph">
-<p>Escaped caret ^not superscript^ and real <sup>superscript</sup> text.</p>
+<p>Escaped caret \^not superscript^ and real <sup>superscript</sup> text.</p>
 </div>
 <div class="paragraph">
-<p>Escaped tilde ~not subscript~ and real <sub>subscript</sub> text.</p>
+<p>Escaped tilde \~not subscript~ and real <sub>subscript</sub> text.</p>
 </div>
 <div class="paragraph">
 <p>Mixed: H~2~O and E=mc^2^ vs H<sub>2</sub>O and E=mc<sup>2</sup>.</p>

--- a/converters/terminal/src/delimited.rs
+++ b/converters/terminal/src/delimited.rs
@@ -350,6 +350,7 @@ mod tests {
         vec![InlineNode::PlainText(Plain {
             content: content.to_string(),
             location: Location::default(),
+            escaped: false,
         })]
     }
 
@@ -358,6 +359,7 @@ mod tests {
         Title::new(vec![InlineNode::PlainText(Plain {
             content: content.to_string(),
             location: Location::default(),
+            escaped: false,
         })])
     }
 

--- a/converters/terminal/src/document.rs
+++ b/converters/terminal/src/document.rs
@@ -144,6 +144,7 @@ mod tests {
         let title = Title::new(vec![InlineNode::PlainText(Plain {
             content: "Title".to_string(),
             location: Location::default(),
+            escaped: false,
         })]);
         doc.header = Some(Header::new(title, Location::default()).with_authors(vec![
             Author::new("John", Some("M"), Some("Doe"))
@@ -176,6 +177,7 @@ mod tests {
                 vec![InlineNode::PlainText(Plain {
                     content: "Hello, world!".to_string(),
                     location: Location::default(),
+                    escaped: false,
                 })],
                 Location::default(),
             )),
@@ -183,12 +185,14 @@ mod tests {
                 Title::new(vec![InlineNode::PlainText(Plain {
                     content: "Section".to_string(),
                     location: Location::default(),
+                    escaped: false,
                 })]),
                 1,
                 vec![Block::Paragraph(Paragraph::new(
                     vec![InlineNode::PlainText(Plain {
                         content: "Hello, section!".to_string(),
                         location: Location::default(),
+                        escaped: false,
                     })],
                     Location::default(),
                 ))],

--- a/converters/terminal/src/inlines.rs
+++ b/converters/terminal/src/inlines.rs
@@ -413,6 +413,7 @@ mod tests {
         InlineNode::PlainText(Plain {
             content: content.to_string(),
             location: Location::default(),
+            escaped: false,
         })
     }
 

--- a/converters/terminal/src/table.rs
+++ b/converters/terminal/src/table.rs
@@ -126,6 +126,7 @@ mod tests {
         vec![InlineNode::PlainText(Plain {
             content: content.to_string(),
             location: Location::default(),
+            escaped: false,
         })]
     }
 

--- a/converters/terminal/tests/fixtures/expected/escaped_superscript_subscript.txt
+++ b/converters/terminal/tests/fixtures/expected/escaped_superscript_subscript.txt
@@ -1,3 +1,3 @@
-Escaped caret ^not superscript^ and real ^{superscript} text.
-Escaped tilde ~not subscript~ and real _{subscript} text.
+Escaped caret \^not superscript^ and real ^{superscript} text.
+Escaped tilde \~not subscript~ and real _{subscript} text.
 Mixed: H~2~O and E=mc^2^ vs H_{2}O and E=mc^{2}.


### PR DESCRIPTION
Previously, acdc always stripped the backslash from \^ and \~ escapes unconditionally. This didn't match asciidoctor's behavior which only strips the backslash when it actually prevents formatting.

For example, `\^caret` at a word boundary (no closing ^) should preserve the backslash as literal text, while `\^super^` should strip it because it's preventing the superscript formatting.

Fixes #278