### PR TITLE
fix(parser): definition-time attribute resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Passthrough content (`pass:[]`, `+++`, `++`, `+`) no longer has attribute references
+  incorrectly expanded by the converter. Attribute expansion is now handled solely by
+  the parser based on each passthrough's own substitution settings. ([#291])
 - Verbatim blocks (listing/literal) now correctly skip typography replacements by default,
   matching asciidoctor behavior. Previously, smart quotes were incorrectly applied.
 
@@ -69,6 +72,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Attribute references in attribute definitions are now resolved at definition time,
+  matching asciidoctor behavior. Previously, `:foo: {bar}` followed by `:bar: value`
+  would incorrectly expand `{foo}` to `value`; now `{foo}` correctly outputs `{bar}`
+  (the literal value stored when foo was defined, before bar existed). ([#291])
+- `pass:normal[]` and `pass:n[]` passthroughs now correctly expand attribute references.
+  The `normal` substitution group includes `attributes`, but this was previously not
+  being checked. ([#291])
 - Context-aware backslash stripping for `\^` and `\~` escapes now matches asciidoctor
   behavior. Backslashes are only stripped when they prevent actual formatting (e.g.,
   `\^super^`), preserved as literal text when at word boundaries without closing marker
@@ -118,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#279]: https://github.com/nlopes/acdc/issues/279
 [#280]: https://github.com/nlopes/acdc/issues/280
 [#289]: https://github.com/nlopes/acdc/issues/289
+[#291]: https://github.com/nlopes/acdc/issues/291
 
 ## [acdc-parser-v0.1.4] - 2026-01-04
 

--- a/acdc-parser/src/grammar/inline_preprocessor.rs
+++ b/acdc-parser/src/grammar/inline_preprocessor.rs
@@ -445,11 +445,14 @@ parser!(
             };
             let padding = 5 + subs_len + 1 + 1; // "pass:" + subs + "[" + "]"
             let location = state.calculate_location(start, content, padding);
-            let content = if substitutions.contains(&Substitution::Attributes) {
-                    inline_preprocessing::attribute_reference_substitutions(content, document_attributes, state).unwrap_or_else(|_| content.to_string())
-                } else {
-                    content.to_string()
-                };
+            // Normal substitution group includes Attributes, so check for both
+            let content = if substitutions.contains(&Substitution::Attributes)
+                || substitutions.contains(&Substitution::Normal)
+            {
+                inline_preprocessing::attribute_reference_substitutions(content, document_attributes, state).unwrap_or_else(|_| content.to_string())
+            } else {
+                content.to_string()
+            };
                 state.passthroughs.borrow_mut().push(Pass {
                     text: Some(content.clone()),
                     substitutions: substitutions.clone(),

--- a/acdc-parser/src/model/substitution.rs
+++ b/acdc-parser/src/model/substitution.rs
@@ -672,6 +672,26 @@ mod tests {
     }
 
     #[test]
+    fn test_substitute_single_pass_expansion() {
+        // Test that the substitute() function does single-pass expansion.
+        // When foo's value is "{bar}", substitute("{foo}") returns the literal
+        // "{bar}" string - it does NOT recursively resolve {bar}.
+        //
+        // This is correct behavior because:
+        // 1. Definition-time resolution is handled separately (in the grammar parser)
+        // 2. The substitute function just replaces one level of references
+        let mut attributes = DocumentAttributes::default();
+        attributes.insert("foo".into(), AttributeValue::String("{bar}".to_string()));
+        attributes.insert(
+            "bar".into(),
+            AttributeValue::String("should-not-appear".to_string()),
+        );
+
+        let resolved = substitute("{foo}", HEADER, &attributes);
+        assert_eq!(resolved, "{bar}");
+    }
+
+    #[test]
     fn test_utf8_boundary_handling() {
         // Regression test for fuzzer-found bug: UTF-8 multi-byte characters
         // should not cause panics during attribute substitution

--- a/acdc-parser/src/preprocessor/attribute.rs
+++ b/acdc-parser/src/preprocessor/attribute.rs
@@ -83,4 +83,31 @@ mod tests {
             Some(&AttributeValue::String("value".into()))
         );
     }
+
+    #[test]
+    fn test_definition_time_attribute_expansion() {
+        // When bar is defined before foo, {bar} in foo's value should be expanded
+        let mut attributes = DocumentAttributes::default();
+        parse_line(&mut attributes, ":bar: resolved-bar");
+        parse_line(&mut attributes, ":foo: {bar}");
+
+        // foo should have bar's value expanded at definition time
+        assert_eq!(
+            attributes.get("foo"),
+            Some(&AttributeValue::String("resolved-bar".into()))
+        );
+    }
+
+    #[test]
+    fn test_undefined_attribute_kept_literal() {
+        // When bar is NOT defined when foo is parsed, {bar} should stay literal
+        let mut attributes = DocumentAttributes::default();
+        parse_line(&mut attributes, ":foo: {bar}");
+
+        // foo should keep {bar} as literal since bar wasn't defined
+        assert_eq!(
+            attributes.get("foo"),
+            Some(&AttributeValue::String("{bar}".into()))
+        );
+    }
 }


### PR DESCRIPTION
Match asciidoctor's attribute resolution semantics:

- Attributes are resolved at definition time, not reference time
- `:foo: {bar}` stores "{bar}" literal if bar is undefined
- `:foo: {bar}` stores bar's value if bar is already defined

Example behavior change below 👇

If the doc is:
```
  :foo: {bar}
  :bar: resolved-bar
  {foo}
```

Then `{foo}`:
  Before: `resolved-bar` (wrong - double expansion)
  After:  `{bar}`        (correct - matches `asciidoctor`)

I've also added a couple more changes to this commit:
- Remove redundant attribute expansion in HTML converter for PlainText and RawText nodes (preprocessor already handles this)
- Fix `pass:normal[]` not expanding attributes (`Normal` group includes `Attributes` substitution)

Closes #291.