### PR TITLE
feat(converters)!: add OutputDestination and refactor Converter trait

### DIFF
--- a/converters/core/src/backend.rs
+++ b/converters/core/src/backend.rs
@@ -1,0 +1,71 @@
+//! Output format backend types.
+//!
+//! Defines the available converter backends (HTML, manpage, terminal).
+
+use std::str::FromStr;
+
+/// Output format backend type.
+///
+/// Used by converters to identify themselves and by the CLI for backend selection.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Backend {
+    /// HTML output format.
+    #[default]
+    Html,
+    /// Unix manpage (roff/troff) output format.
+    Manpage,
+    /// Terminal/console output with ANSI formatting.
+    Terminal,
+}
+
+impl FromStr for Backend {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "html" => Ok(Self::Html),
+            "manpage" => Ok(Self::Manpage),
+            "terminal" => Ok(Self::Terminal),
+            _ => Err(format!(
+                "invalid backend: '{s}', expected: html, manpage, terminal"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Html => write!(f, "html"),
+            Self::Manpage => write!(f, "manpage"),
+            Self::Terminal => write!(f, "terminal"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(Backend::from_str("html").unwrap(), Backend::Html);
+        assert_eq!(Backend::from_str("HTML").unwrap(), Backend::Html);
+        assert_eq!(Backend::from_str("manpage").unwrap(), Backend::Manpage);
+        assert_eq!(Backend::from_str("terminal").unwrap(), Backend::Terminal);
+        assert!(Backend::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(Backend::Html.to_string(), "html");
+        assert_eq!(Backend::Manpage.to_string(), "manpage");
+        assert_eq!(Backend::Terminal.to_string(), "terminal");
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(Backend::default(), Backend::Html);
+    }
+}

--- a/converters/html/examples/generate_expected_fixtures.rs
+++ b/converters/html/examples/generate_expected_fixtures.rs
@@ -3,7 +3,7 @@
 //! Usage:
 //!   `cargo run -p acdc-converters-html --example generate_expected_fixtures`
 
-use acdc_converters_core::{GeneratorMetadata, Options, Processable};
+use acdc_converters_core::{Converter, GeneratorMetadata, Options};
 use acdc_converters_dev::generate_fixtures::FixtureGenerator;
 use acdc_converters_html::{Processor, RenderOptions};
 

--- a/converters/html/tests/integration_test.rs
+++ b/converters/html/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use acdc_converters_core::{GeneratorMetadata, Options as ConverterOptions, Processable};
+use acdc_converters_core::{Converter, GeneratorMetadata, Options as ConverterOptions};
 use acdc_converters_dev::output::remove_lines_trailing_whitespace;
 use acdc_converters_html::{Processor, RenderOptions};
 use acdc_parser::Options as ParserOptions;

--- a/converters/manpage/examples/generate_expected_fixtures.rs
+++ b/converters/manpage/examples/generate_expected_fixtures.rs
@@ -3,7 +3,7 @@
 //! Usage:
 //!   `cargo run -p acdc-converters-manpage --example generate_expected_fixtures`
 
-use acdc_converters_core::{GeneratorMetadata, Options, Processable};
+use acdc_converters_core::{Converter, GeneratorMetadata, Options};
 use acdc_converters_dev::generate_fixtures::FixtureGenerator;
 use acdc_converters_manpage::Processor;
 
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .generator_metadata(GeneratorMetadata::new("acdc", "0.1.0"))
             .build();
         let processor = Processor::new(options, doc.attributes.clone());
-        processor.convert_to_writer(doc, output)?;
+        processor.write_to(doc, output, None)?;
         Ok(())
     })
 }

--- a/converters/manpage/tests/integration_test.rs
+++ b/converters/manpage/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use acdc_converters_core::{GeneratorMetadata, Options as ConverterOptions, Processable};
+use acdc_converters_core::{Converter, GeneratorMetadata, Options as ConverterOptions};
 use acdc_converters_dev::output::remove_lines_trailing_whitespace;
 use acdc_converters_manpage::Processor;
 use acdc_parser::Options as ParserOptions;
@@ -32,7 +32,7 @@ fn test_with_fixtures(#[files("tests/fixtures/source/*.adoc")] path: PathBuf) ->
         .generator_metadata(GeneratorMetadata::new("acdc", "0.1.0"))
         .build();
     let processor = Processor::new(converter_options, doc.attributes.clone());
-    processor.convert_to_writer(&doc, &mut output)?;
+    processor.write_to(&doc, &mut output, Some(path.as_path()))?;
 
     // Read expected output
     let expected = std::fs::read_to_string(&expected_path)?;

--- a/converters/terminal/examples/generate_expected_fixtures.rs
+++ b/converters/terminal/examples/generate_expected_fixtures.rs
@@ -3,14 +3,14 @@
 //! Usage:
 //!   `cargo run -p acdc-converters-terminal --features images,highlighting --example generate_expected_fixtures`
 
-use acdc_converters_core::{Options, Processable};
+use acdc_converters_core::{Converter, Options};
 use acdc_converters_dev::generate_fixtures::FixtureGenerator;
 use acdc_converters_terminal::Processor;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     FixtureGenerator::new("terminal", "txt").generate(|doc, output| {
         let processor = Processor::new(Options::default(), doc.attributes.clone());
-        processor.convert_to_writer(doc, output)?;
+        processor.write_to(doc, output, None)?;
         Ok(())
     })
 }

--- a/converters/terminal/tests/integration_test.rs
+++ b/converters/terminal/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use acdc_converters_core::{Options as ConverterOptions, Processable};
+use acdc_converters_core::{Converter, Options as ConverterOptions};
 use acdc_converters_dev::output::remove_lines_trailing_whitespace;
 use acdc_converters_terminal::Processor;
 use acdc_parser::Options as ParserOptions;
@@ -58,7 +58,7 @@ fn test_fixture(fixture_name: &str, osc8: bool) -> Result<(), Error> {
     // Convert to Terminal output
     let mut output = Vec::new();
     let processor = Processor::new(ConverterOptions::default(), doc.attributes.clone());
-    processor.convert_to_writer(&doc, &mut output)?;
+    processor.write_to(&doc, &mut output, Some(input_path.as_path()))?;
 
     if osc8 && !processor.appearance.capabilities.osc8_links {
         // If the fixture name indicates osc8 links but we're running in a terminal that


### PR DESCRIPTION
Add explicit output routing to converters-core with three modes:
- Derived: derive output path from input (e.g., .adoc → .html)
- Stdout: write to stdout (via -o -)
- File: write to specific path (via -o path)

Refactor Converter trait (renamed from Processable):
- convert() is now a provided method with routing logic
- Add convert_to_stdout() and convert_to_file() provided methods
- Add write_to() as the core method converters must implement
- Add derive_output_path() returning Result to properly propagate errors
- Add after_write() hook for post-processing (e.g., CSS copying)