### PR TITLE
feat(html): add docinfo file support

### DIFF
--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Docinfo file support** — inject custom HTML snippets into `<head>`, after `<body>`, or
+  before `</body>` via the `:docinfo:` attribute. Supports `shared`, `private`, and granular
+  values (`shared-head`, `private-footer`, etc.), `:docinfodir:` for alternate directories,
+  and `:docinfosubs:` for attribute substitution. Disabled in embedded mode and
+  `SafeMode::Secure`.
 - **No-stylesheet mode (`:!stylesheet:`)** — setting `:!stylesheet:` now disables all
   stylesheet output: no embedded `<style>`, no linked `<link>`, no Google Fonts link, and
   no `copycss` file writing. Other head elements (MathJax, Font Awesome, syntax CSS) are

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -197,6 +197,86 @@ acdc convert -a dark-mode document.adoc
 
 When using class-based syntax highlighting (`:syntect-css: class`), the highlighting CSS is handled the same way — embedded by default, or linked/written to disk when `:linkcss:` is set. See the <<Syntax Highlighting>> section above.
 
+### Docinfo files
+
+Docinfo files let you inject custom HTML into specific positions in the output — analytics snippets, custom `<meta>` tags, banners, footers, or anything else that doesn't belong in the AsciiDoc source itself.
+
+Enable docinfo with the `:docinfo:` document attribute:
+
+[source,asciidoc]
+....
+= My Document
+:docinfo: shared
+....
+
+The `:docinfo:` attribute accepts:
+
+- `shared` — load shared docinfo files (used across all documents)
+- `private` — load private docinfo files (specific to this document). This is the default when `:docinfo:` is set with no value
+- Granular values: `shared-head`, `shared-header`, `shared-footer`, `private-head`, `private-header`, `private-footer`
+- Comma-separated combinations: `shared, private-footer`
+
+#### File naming
+
+Docinfo files follow a naming convention based on scope and injection position:
+
+[cols="1,1,1", options="header"]
+|===
+| Position | Shared filename | Private filename
+
+| Head (before `</head>`)
+| `docinfo.html`
+| `{docname}-docinfo.html`
+
+| Header (after `<body>`)
+| `docinfo-header.html`
+| `{docname}-docinfo-header.html`
+
+| Footer (before `</body>`)
+| `docinfo-footer.html`
+| `{docname}-docinfo-footer.html`
+|===
+
+For a document named `guide.adoc`, the private head file would be `guide-docinfo.html`.
+
+#### Docinfo directory (`:docinfodir:`)
+
+By default, docinfo files are loaded from the same directory as the source document. Set `:docinfodir:` to load them from a different location:
+
+[source,asciidoc]
+....
+= My Document
+:docinfo: shared
+:docinfodir: _docinfo
+....
+
+The path is resolved relative to the source document directory, or can be absolute.
+
+#### Attribute substitution (`:docinfosubs:`)
+
+Docinfo content is processed with attribute substitution by default — `\{attribute-name}` references in docinfo files are replaced with their values. Control this with `:docinfosubs:`:
+
+[source,asciidoc]
+....
+= My Document
+:docinfo: shared
+:docinfosubs: attributes
+....
+
+NOTE: Currently only `attributes` substitution is supported for docinfo content.
+
+#### Injection points
+
+- **Head** — injected just before the closing `</head>` tag
+- **Header** — injected immediately after the opening `<body>` tag
+- **Footer** — injected just before the closing `</body>` tag
+
+When both private and shared files exist for the same position, private content is injected first.
+
+NOTE: Docinfo is disabled when running in secure safe mode (`--safe-mode secure`). In embedded mode, head docinfo has no effect since the `<head>` element is not generated.
+
+For full details, see the https://docs.asciidoctor.org/asciidoc/latest/docinfo/[Asciidoctor docinfo documentation].
+
 ### Table Enhancements
 
 Full table feature support:

--- a/converters/html/src/docinfo.rs
+++ b/converters/html/src/docinfo.rs
@@ -1,0 +1,387 @@
+use std::path::{Path, PathBuf};
+
+use acdc_parser::{AttributeValue, DocumentAttributes, SafeMode, Substitution, substitute};
+
+/// Resolved docinfo content for each injection position.
+///
+/// Constructed once per conversion via `DocInfo::resolve()`, then queried
+/// at each injection point.
+pub(crate) struct DocInfo {
+    pub head: Option<String>,
+    pub header: Option<String>,
+    pub footer: Option<String>,
+}
+
+impl DocInfo {
+    /// Return an empty `DocInfo` with no content at any position.
+    pub fn empty() -> Self {
+        Self {
+            head: None,
+            header: None,
+            footer: None,
+        }
+    }
+
+    /// Resolve all docinfo files for the current document.
+    ///
+    /// Returns a `DocInfo` with pre-loaded content for each position,
+    /// or `None` values when no files exist or docinfo is disabled.
+    pub fn resolve(
+        attributes: &DocumentAttributes,
+        safe_mode: SafeMode,
+        source_dir: Option<&Path>,
+        docname: Option<&str>,
+    ) -> Self {
+        // Secure mode disables docinfo entirely
+        if safe_mode >= SafeMode::Secure {
+            return Self::empty();
+        }
+
+        let docinfo_val = match attributes.get("docinfo") {
+            Some(AttributeValue::String(s)) if !s.is_empty() => s.clone(),
+            // `:docinfo:` set with no value defaults to "private"
+            Some(AttributeValue::Bool(true)) => "private".to_string(),
+            Some(AttributeValue::String(s)) if s.is_empty() => "private".to_string(),
+            _ => return Self::empty(),
+        };
+
+        let positions = parse_docinfo_value(&docinfo_val);
+        if positions.is_empty() {
+            return Self::empty();
+        }
+
+        // Resolve docinfodir
+        let docinfo_dir = resolve_docinfo_dir(attributes, source_dir);
+
+        // Determine substitutions to apply
+        let subs = resolve_docinfo_subs(attributes);
+
+        let head = load_position_content(
+            &positions,
+            Position::Head,
+            &docinfo_dir,
+            docname,
+            &subs,
+            attributes,
+        );
+        let header = load_position_content(
+            &positions,
+            Position::Header,
+            &docinfo_dir,
+            docname,
+            &subs,
+            attributes,
+        );
+        let footer = load_position_content(
+            &positions,
+            Position::Footer,
+            &docinfo_dir,
+            docname,
+            &subs,
+            attributes,
+        );
+
+        Self {
+            head,
+            header,
+            footer,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Position {
+    Head,
+    Header,
+    Footer,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Scope {
+    Shared,
+    Private,
+}
+
+/// A resolved (scope, position) pair that should be loaded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EnabledPosition {
+    scope: Scope,
+    position: Position,
+}
+
+/// Parse the `:docinfo:` attribute value into a set of enabled positions.
+///
+/// Supported values:
+/// - `shared` — all 3 shared positions
+/// - `private` — all 3 private positions
+/// - Granular: `shared-head`, `shared-header`, `shared-footer`,
+///   `private-head`, `private-header`, `private-footer`
+/// - Comma-separated combinations
+fn parse_docinfo_value(value: &str) -> Vec<EnabledPosition> {
+    value
+        .split(',')
+        .flat_map(|token| {
+            let token = token.trim();
+            match token {
+                "shared" => vec![
+                    EnabledPosition {
+                        scope: Scope::Shared,
+                        position: Position::Head,
+                    },
+                    EnabledPosition {
+                        scope: Scope::Shared,
+                        position: Position::Header,
+                    },
+                    EnabledPosition {
+                        scope: Scope::Shared,
+                        position: Position::Footer,
+                    },
+                ],
+                "private" => vec![
+                    EnabledPosition {
+                        scope: Scope::Private,
+                        position: Position::Head,
+                    },
+                    EnabledPosition {
+                        scope: Scope::Private,
+                        position: Position::Header,
+                    },
+                    EnabledPosition {
+                        scope: Scope::Private,
+                        position: Position::Footer,
+                    },
+                ],
+                "shared-head" => vec![EnabledPosition {
+                    scope: Scope::Shared,
+                    position: Position::Head,
+                }],
+                "shared-header" => vec![EnabledPosition {
+                    scope: Scope::Shared,
+                    position: Position::Header,
+                }],
+                "shared-footer" => vec![EnabledPosition {
+                    scope: Scope::Shared,
+                    position: Position::Footer,
+                }],
+                "private-head" => vec![EnabledPosition {
+                    scope: Scope::Private,
+                    position: Position::Head,
+                }],
+                "private-header" => vec![EnabledPosition {
+                    scope: Scope::Private,
+                    position: Position::Header,
+                }],
+                "private-footer" => vec![EnabledPosition {
+                    scope: Scope::Private,
+                    position: Position::Footer,
+                }],
+                _ => {
+                    tracing::warn!(token, "unknown docinfo value, ignoring");
+                    vec![]
+                }
+            }
+        })
+        .collect()
+}
+
+/// Resolve the directory where docinfo files are located.
+///
+/// Uses `:docinfodir:` if set (absolute or resolved relative to source dir),
+/// otherwise defaults to the source document directory.
+fn resolve_docinfo_dir(attributes: &DocumentAttributes, source_dir: Option<&Path>) -> PathBuf {
+    let base = source_dir.unwrap_or_else(|| Path::new("."));
+
+    if let Some(AttributeValue::String(dir)) = attributes.get("docinfodir")
+        && !dir.is_empty()
+    {
+        let dir_path = Path::new(dir.as_str());
+        if dir_path.is_absolute() {
+            return dir_path.to_path_buf();
+        }
+        return base.join(dir_path);
+    }
+
+    base.to_path_buf()
+}
+
+/// Determine substitutions to apply to docinfo content.
+///
+/// `:docinfosubs:` controls this; default is `attributes` only.
+fn resolve_docinfo_subs(attributes: &DocumentAttributes) -> Vec<Substitution> {
+    if let Some(AttributeValue::String(subs_str)) = attributes.get("docinfosubs") {
+        let mut subs = Vec::new();
+        for token in subs_str.split(',') {
+            match token.trim() {
+                "attributes" => subs.push(Substitution::Attributes),
+                other => {
+                    tracing::warn!(sub = other, "unsupported docinfosubs value, ignoring");
+                }
+            }
+        }
+        subs
+    } else {
+        vec![Substitution::Attributes]
+    }
+}
+
+/// Build the filename for a docinfo file.
+///
+/// Shared files: `docinfo.html`, `docinfo-header.html`, `docinfo-footer.html`
+/// Private files: `{docname}-docinfo.html`, `{docname}-docinfo-header.html`, etc.
+fn docinfo_filename(scope: Scope, position: Position, docname: Option<&str>) -> Option<String> {
+    let position_suffix = match position {
+        Position::Head => "",
+        Position::Header => "-header",
+        Position::Footer => "-footer",
+    };
+
+    match scope {
+        Scope::Shared => Some(format!("docinfo{position_suffix}.html")),
+        Scope::Private => {
+            let name = docname?;
+            Some(format!("{name}-docinfo{position_suffix}.html"))
+        }
+    }
+}
+
+/// Load and concatenate content for a specific position from all enabled scopes.
+///
+/// Private content comes first, then shared (matching asciidoctor ordering).
+fn load_position_content(
+    positions: &[EnabledPosition],
+    target: Position,
+    docinfo_dir: &Path,
+    docname: Option<&str>,
+    subs: &[Substitution],
+    attributes: &DocumentAttributes,
+) -> Option<String> {
+    let mut parts = Vec::new();
+
+    // Private first, then shared
+    for scope in [Scope::Private, Scope::Shared] {
+        let enabled = positions
+            .iter()
+            .any(|p| p.scope == scope && p.position == target);
+        if !enabled {
+            continue;
+        }
+
+        let Some(filename) = docinfo_filename(scope, target, docname) else {
+            continue;
+        };
+
+        let path = docinfo_dir.join(&filename);
+        match std::fs::read_to_string(&path) {
+            Ok(content) => {
+                let processed = if subs.is_empty() {
+                    content
+                } else {
+                    substitute(&content, subs, attributes)
+                };
+                if !processed.trim().is_empty() {
+                    parts.push(processed);
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "docinfo file not found or unreadable"
+                );
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_shared_expands_all_positions() {
+        let positions = parse_docinfo_value("shared");
+        assert_eq!(positions.len(), 3);
+        assert!(positions.iter().all(|p| p.scope == Scope::Shared));
+        assert!(positions.iter().any(|p| p.position == Position::Head));
+        assert!(positions.iter().any(|p| p.position == Position::Header));
+        assert!(positions.iter().any(|p| p.position == Position::Footer));
+    }
+
+    #[test]
+    fn parse_private_expands_all_positions() {
+        let positions = parse_docinfo_value("private");
+        assert_eq!(positions.len(), 3);
+        assert!(positions.iter().all(|p| p.scope == Scope::Private));
+    }
+
+    #[test]
+    fn parse_granular_values() {
+        let positions = parse_docinfo_value("shared-head,private-footer");
+        assert_eq!(positions.len(), 2);
+        assert!(
+            positions
+                .first()
+                .is_some_and(|p| p.scope == Scope::Shared && p.position == Position::Head)
+        );
+        assert!(
+            positions
+                .get(1)
+                .is_some_and(|p| p.scope == Scope::Private && p.position == Position::Footer)
+        );
+    }
+
+    #[test]
+    fn parse_comma_separated_combination() {
+        let positions = parse_docinfo_value("shared, private-footer");
+        assert_eq!(positions.len(), 4); // 3 shared + 1 private-footer
+    }
+
+    #[test]
+    fn parse_unknown_value_ignored() {
+        let positions = parse_docinfo_value("bogus");
+        assert!(positions.is_empty());
+    }
+
+    #[test]
+    fn docinfo_filename_shared_head() {
+        assert_eq!(
+            docinfo_filename(Scope::Shared, Position::Head, None),
+            Some("docinfo.html".to_string())
+        );
+    }
+
+    #[test]
+    fn docinfo_filename_shared_header() {
+        assert_eq!(
+            docinfo_filename(Scope::Shared, Position::Header, None),
+            Some("docinfo-header.html".to_string())
+        );
+    }
+
+    #[test]
+    fn docinfo_filename_shared_footer() {
+        assert_eq!(
+            docinfo_filename(Scope::Shared, Position::Footer, None),
+            Some("docinfo-footer.html".to_string())
+        );
+    }
+
+    #[test]
+    fn docinfo_filename_private_head() {
+        assert_eq!(
+            docinfo_filename(Scope::Private, Position::Head, Some("mydoc")),
+            Some("mydoc-docinfo.html".to_string())
+        );
+    }
+
+    #[test]
+    fn docinfo_filename_private_no_docname() {
+        assert_eq!(docinfo_filename(Scope::Private, Position::Head, None), None);
+    }
+}

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -12,6 +12,7 @@ mod admonition;
 mod audio;
 mod constants;
 mod delimited;
+mod docinfo;
 mod document;
 mod error;
 mod html_visitor;
@@ -277,6 +278,9 @@ pub struct RenderOptions {
     pub toc_mode: bool,
     /// Directory of the source document, used to resolve relative `stylesdir` paths.
     pub source_dir: Option<PathBuf>,
+    /// Stem of the source document filename (e.g., `"mydoc"` for `mydoc.adoc`),
+    /// used to locate private docinfo files like `mydoc-docinfo.html`.
+    pub docname: Option<String>,
 }
 
 pub(crate) const COPYCSS_DEFAULT: &str = "";
@@ -410,6 +414,10 @@ impl Converter for Processor {
             }),
             embedded: self.options.embedded(),
             source_dir: source_file.and_then(|f| f.parent().map(Path::to_path_buf)),
+            docname: source_file
+                .and_then(|f| f.file_stem())
+                .and_then(|s| s.to_str())
+                .map(String::from),
             ..RenderOptions::default()
         };
         self.convert_to_writer(doc, writer, &render_options)


### PR DESCRIPTION
Inject custom HTML from external docinfo files into head, header, and footer positions. Supports shared and private scopes, configurable directory and attribute substitution.

Closes #341 