### PR TITLE
fix(parser): match delimited blocks delimiters precisely

### DIFF
--- a/acdc-parser/CHANGELOG.md
+++ b/acdc-parser/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Block delimiters in source block content** — lines inside a delimited block containing
+  a longer sequence of the same delimiter character (e.g., `--------------------` inside a
+  `----` block) are no longer incorrectly treated as closing delimiters. The parser now
+  requires an exact match of the opening delimiter length. ([#349])
+
 ## [0.5.0] - 2026-02-14
 
 ### Added

--- a/acdc-parser/fixtures/tests/delimited_block_with_identical_inner_delimited_symbol.adoc
+++ b/acdc-parser/fixtures/tests/delimited_block_with_identical_inner_delimited_symbol.adoc
@@ -1,0 +1,19 @@
+[source,shell]
+----
+$ grep --context=5 virtualbox ~/apt-key-list
+
+/etc/apt/trusted.gpg
+--------------------
+pub   dsa1024 2010-05-18 [SC]
+      7B0F AB3A 13B9 0743 5925  D9C9 5442 2A4B 98AB 5139
+uid           [ unknown] Oracle Corporation (VirtualBox archive signing key) <info@virtualbox.org>
+sub   elg2048 2010-05-18 [E]
+
+...
+
+pub   rsa4096 2016-04-22 [SC]
+      B9F8 D658 297A F3EF C18D  5CDF A2F6 83C5 2980 AECF
+uid           [ unknown] Oracle Corporation (VirtualBox archive signing key) <info@virtualbox.org>
+sub   rsa4096 2016-04-22 [E]
+
+----

--- a/acdc-parser/fixtures/tests/delimited_block_with_identical_inner_delimited_symbol.json
+++ b/acdc-parser/fixtures/tests/delimited_block_with_identical_inner_delimited_symbol.json
@@ -1,0 +1,55 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "listing",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "----",
+      "metadata": {
+        "attributes": {
+          "shell": null
+        },
+        "style": "source"
+      },
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "$ grep --context=5 virtualbox ~/apt-key-list\n\n/etc/apt/trusted.gpg\n--------------------\npub   dsa1024 2010-05-18 [SC]\n      7B0F AB3A 13B9 0743 5925  D9C9 5442 2A4B 98AB 5139\nuid           [ unknown] Oracle Corporation (VirtualBox archive signing key) <info@virtualbox.org>\nsub   elg2048 2010-05-18 [E]\n\n...\n\npub   rsa4096 2016-04-22 [SC]\n      B9F8 D658 297A F3EF C18D  5CDF A2F6 83C5 2980 AECF\nuid           [ unknown] Oracle Corporation (VirtualBox archive signing key) <info@virtualbox.org>\nsub   rsa4096 2016-04-22 [E]",
+          "location": [
+            {
+              "line": 3,
+              "col": 1
+            },
+            {
+              "line": 17,
+              "col": 29
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 19,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 19,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/nested_delimited_blocks.adoc
+++ b/acdc-parser/fixtures/tests/nested_delimited_blocks.adoc
@@ -1,0 +1,15 @@
+====
+Here are your options:
+
+.Red Pill
+[%collapsible]
+======
+Escape into the real world.
+======
+
+.Blue Pill
+[%collapsible]
+======
+Live within the simulated reality without want or fear.
+======
+====

--- a/acdc-parser/fixtures/tests/nested_delimited_blocks.json
+++ b/acdc-parser/fixtures/tests/nested_delimited_blocks.json
@@ -1,0 +1,207 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "example",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "====",
+      "blocks": [
+        {
+          "name": "paragraph",
+          "type": "block",
+          "inlines": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Here are your options:",
+              "location": [
+                {
+                  "line": 2,
+                  "col": 1
+                },
+                {
+                  "line": 2,
+                  "col": 22
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 2,
+              "col": 1
+            },
+            {
+              "line": 2,
+              "col": 22
+            }
+          ]
+        },
+        {
+          "name": "example",
+          "type": "block",
+          "form": "delimited",
+          "delimiter": "======",
+          "metadata": {
+            "options": [
+              "collapsible"
+            ]
+          },
+          "blocks": [
+            {
+              "name": "paragraph",
+              "type": "block",
+              "inlines": [
+                {
+                  "name": "text",
+                  "type": "string",
+                  "value": "Escape into the real world.",
+                  "location": [
+                    {
+                      "line": 7,
+                      "col": 1
+                    },
+                    {
+                      "line": 7,
+                      "col": 27
+                    }
+                  ]
+                }
+              ],
+              "location": [
+                {
+                  "line": 7,
+                  "col": 1
+                },
+                {
+                  "line": 7,
+                  "col": 27
+                }
+              ]
+            }
+          ],
+          "title": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Red Pill",
+              "location": [
+                {
+                  "line": 4,
+                  "col": 2
+                },
+                {
+                  "line": 4,
+                  "col": 9
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 4,
+              "col": 1
+            },
+            {
+              "line": 8,
+              "col": 6
+            }
+          ]
+        },
+        {
+          "name": "example",
+          "type": "block",
+          "form": "delimited",
+          "delimiter": "======",
+          "metadata": {
+            "options": [
+              "collapsible"
+            ]
+          },
+          "blocks": [
+            {
+              "name": "paragraph",
+              "type": "block",
+              "inlines": [
+                {
+                  "name": "text",
+                  "type": "string",
+                  "value": "Live within the simulated reality without want or fear.",
+                  "location": [
+                    {
+                      "line": 13,
+                      "col": 1
+                    },
+                    {
+                      "line": 13,
+                      "col": 55
+                    }
+                  ]
+                }
+              ],
+              "location": [
+                {
+                  "line": 13,
+                  "col": 1
+                },
+                {
+                  "line": 13,
+                  "col": 55
+                }
+              ]
+            }
+          ],
+          "title": [
+            {
+              "name": "text",
+              "type": "string",
+              "value": "Blue Pill",
+              "location": [
+                {
+                  "line": 10,
+                  "col": 2
+                },
+                {
+                  "line": 10,
+                  "col": 10
+                }
+              ]
+            }
+          ],
+          "location": [
+            {
+              "line": 10,
+              "col": 1
+            },
+            {
+              "line": 14,
+              "col": 6
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 15,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 15,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/fixtures/tests/source_block_with_delimiter_in_content.adoc
+++ b/acdc-parser/fixtures/tests/source_block_with_delimiter_in_content.adoc
@@ -1,0 +1,6 @@
+[source,console]
+----
+$ some_command
+--------------------
+output
+----

--- a/acdc-parser/fixtures/tests/source_block_with_delimiter_in_content.json
+++ b/acdc-parser/fixtures/tests/source_block_with_delimiter_in_content.json
@@ -1,0 +1,55 @@
+{
+  "name": "document",
+  "type": "block",
+  "blocks": [
+    {
+      "name": "listing",
+      "type": "block",
+      "form": "delimited",
+      "delimiter": "----",
+      "metadata": {
+        "attributes": {
+          "console": null
+        },
+        "style": "source"
+      },
+      "inlines": [
+        {
+          "name": "text",
+          "type": "string",
+          "value": "$ some_command\n--------------------\noutput",
+          "location": [
+            {
+              "line": 3,
+              "col": 1
+            },
+            {
+              "line": 5,
+              "col": 6
+            }
+          ]
+        }
+      ],
+      "location": [
+        {
+          "line": 1,
+          "col": 1
+        },
+        {
+          "line": 6,
+          "col": 4
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "line": 1,
+      "col": 1
+    },
+    {
+      "line": 6,
+      "col": 4
+    }
+  ]
+}

--- a/acdc-parser/src/grammar/document.rs
+++ b/acdc-parser/src/grammar/document.rs
@@ -1763,94 +1763,80 @@ peg::parser! {
         rule markdown_code_delimiter() -> &'input str = delim:$("`"*<3,>) { delim }
         rule quote_delimiter() -> &'input str = delim:$("_"*<4,>) { delim }
 
-        rule until_comment_delimiter() -> &'input str
-            = content:$((!(eol() comment_delimiter()) [_])*)
-        {
-            content
-        }
+        // Exact delimiter matching rules - these use conditional actions to ensure
+        // the matched delimiter is identical to the expected one. This prevents
+        // content lines that happen to contain delimiter-like characters (but of
+        // different length) from being incorrectly treated as closing delimiters.
+        rule exact_comment_delimiter(expected: &str) -> &'input str
+            = delim:comment_delimiter() {? if delim == expected { Ok(delim) } else { Err("comment delimiter mismatch") } }
+        rule exact_example_delimiter(expected: &str) -> &'input str
+            = delim:example_delimiter() {? if delim == expected { Ok(delim) } else { Err("example delimiter mismatch") } }
+        rule exact_listing_delimiter(expected: &str) -> &'input str
+            = delim:listing_delimiter() {? if delim == expected { Ok(delim) } else { Err("listing delimiter mismatch") } }
+        rule exact_literal_delimiter(expected: &str) -> &'input str
+            = delim:literal_delimiter() {? if delim == expected { Ok(delim) } else { Err("literal delimiter mismatch") } }
+        rule exact_open_delimiter(expected: &str) -> &'input str
+            = delim:open_delimiter() {? if delim == expected { Ok(delim) } else { Err("open delimiter mismatch") } }
+        rule exact_sidebar_delimiter(expected: &str) -> &'input str
+            = delim:sidebar_delimiter() {? if delim == expected { Ok(delim) } else { Err("sidebar delimiter mismatch") } }
+        rule exact_pass_delimiter(expected: &str) -> &'input str
+            = delim:pass_delimiter() {? if delim == expected { Ok(delim) } else { Err("pass delimiter mismatch") } }
+        rule exact_markdown_code_delimiter(expected: &str) -> &'input str
+            = delim:markdown_code_delimiter() {? if delim == expected { Ok(delim) } else { Err("markdown code delimiter mismatch") } }
+        rule exact_quote_delimiter(expected: &str) -> &'input str
+            = delim:quote_delimiter() {? if delim == expected { Ok(delim) } else { Err("quote delimiter mismatch") } }
 
-        rule until_example_delimiter() -> &'input str
-            = content:$((!(eol() example_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_comment_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_comment_delimiter(expected)) [_])*) { content }
 
-        rule until_listing_delimiter() -> &'input str
-            = content:$((!(eol() listing_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_example_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_example_delimiter(expected)) [_])*) { content }
 
-        rule until_literal_delimiter() -> &'input str
-            = content:$((!(eol() literal_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_listing_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_listing_delimiter(expected)) [_])*) { content }
 
-        rule until_open_delimiter() -> &'input str
-        = content:$((!(eol() open_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_literal_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_literal_delimiter(expected)) [_])*) { content }
 
-        rule until_sidebar_delimiter() -> &'input str
-            = content:$((!(eol() sidebar_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_open_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_open_delimiter(expected)) [_])*) { content }
+
+        rule until_sidebar_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_sidebar_delimiter(expected)) [_])*) { content }
 
         rule until_table_delimiter() -> &'input str
-            = content:$((!(eol() table_delimiter()) [_])*)
-        {
-            content
-        }
+        = content:$((!(eol() table_delimiter()) [_])*) { content }
 
         // Delimiter-specific content rules for nested table support.
         // Each rule only looks ahead for its specific delimiter, allowing
         // nested tables with different delimiters to be parsed correctly.
         rule until_pipe_table_delimiter() -> &'input str
-            = content:$((!(eol() pipe_table_delimiter()) [_])*)
-        { content }
+        = content:$((!(eol() pipe_table_delimiter()) [_])*) { content }
 
         rule until_excl_table_delimiter() -> &'input str
-            = content:$((!(eol() excl_table_delimiter()) [_])*)
-        { content }
+        = content:$((!(eol() excl_table_delimiter()) [_])*) { content }
 
         rule until_comma_table_delimiter() -> &'input str
-            = content:$((!(eol() comma_table_delimiter()) [_])*)
-        { content }
+        = content:$((!(eol() comma_table_delimiter()) [_])*) { content }
 
         rule until_colon_table_delimiter() -> &'input str
-            = content:$((!(eol() colon_table_delimiter()) [_])*)
-        { content }
+        = content:$((!(eol() colon_table_delimiter()) [_])*) { content }
 
-        rule until_pass_delimiter() -> &'input str
-            = content:$((!(eol() pass_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_pass_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_pass_delimiter(expected)) [_])*) { content }
 
-        rule until_quote_delimiter() -> &'input str
-            = content:$((!(eol() quote_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_quote_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_quote_delimiter(expected)) [_])*) { content }
 
-        rule until_markdown_code_delimiter() -> &'input str
-            = content:$((!(eol() markdown_code_delimiter()) [_])*)
-        {
-            content
-        }
+        rule until_markdown_code_delimiter(expected: &str) -> &'input str
+        = content:$((!(eol() exact_markdown_code_delimiter(expected)) [_])*) { content }
 
         rule markdown_language() -> &'input str
-            = lang:$((['a'..='z'] / ['A'..='Z'] / ['0'..='9'] / "_" / "+" / "-")+)
-        {
-            lang
-        }
+        = lang:$((['a'..='z'] / ['A'..='Z'] / ['0'..='9'] / "_" / "+" / "-")+) { lang }
 
         rule example_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
         = open_delim:example_delimiter() eol()
-        content_start:position!() content:until_example_delimiter() content_end:position!()
+        content_start:position!() content:until_example_delimiter(open_delim) content_end:position!()
         eol() close_delim:example_delimiter() end:position!()
         {
             tracing::info!(?start, ?offset, ?content_start, ?block_metadata, ?content, "Parsing example block");
@@ -1889,7 +1875,7 @@ peg::parser! {
 
         rule comment_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
             = open_delim:comment_delimiter() eol()
-            content_start:position!() content:until_comment_delimiter() content_end:position!()
+            content_start:position!() content:until_comment_delimiter(open_delim) content_end:position!()
             eol() close_delim:comment_delimiter() end:position!()
         {
             check_delimiters(open_delim, close_delim, "comment", state.create_error_source_location(state.create_block_location(start, end, offset)))?;
@@ -1918,7 +1904,7 @@ peg::parser! {
 
         rule traditional_listing_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
             = open_delim:listing_delimiter() eol()
-            content_start:position!() content:until_listing_delimiter() content_end:position!()
+            content_start:position!() content:until_listing_delimiter(open_delim) content_end:position!()
             eol() close_delim:listing_delimiter() end:position!()
         {
             check_delimiters(open_delim, close_delim, "listing", state.create_error_source_location(state.create_block_location(start, end, offset)))?;
@@ -1942,7 +1928,7 @@ peg::parser! {
 
         rule markdown_listing_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
             = open_delim:markdown_code_delimiter() lang:markdown_language()? eol()
-            content_start:position!() content:until_markdown_code_delimiter() content_end:position!()
+            content_start:position!() content:until_markdown_code_delimiter(open_delim) content_end:position!()
             eol() close_delim:markdown_code_delimiter() end:position!()
         {
             check_delimiters(open_delim, close_delim, "listing", state.create_error_source_location(state.create_block_location(start, end, offset)))?;
@@ -1977,7 +1963,7 @@ peg::parser! {
         =
         open_delim:literal_delimiter()
         eol()
-        content_start:position!() content:until_literal_delimiter() content_end:position!()
+        content_start:position!() content:until_literal_delimiter(open_delim) content_end:position!()
         eol()
         close_delim:literal_delimiter()
         end:position!()
@@ -2003,7 +1989,7 @@ peg::parser! {
 
         rule open_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
             = open_delim:open_delimiter() eol()
-            content_start:position!() content:until_open_delimiter() content_end:position!()
+            content_start:position!() content:until_open_delimiter(open_delim) content_end:position!()
             eol() close_delim:open_delimiter() end:position!()
         {
             check_delimiters(open_delim, close_delim, "open", state.create_error_source_location(state.create_block_location(start, end, offset)))?;
@@ -2031,7 +2017,7 @@ peg::parser! {
 
         rule sidebar_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
             = open_delim:sidebar_delimiter() eol()
-            content_start:position!() content:until_sidebar_delimiter() content_end:position!()
+            content_start:position!() content:until_sidebar_delimiter(open_delim) content_end:position!()
             eol() close_delim:sidebar_delimiter() end:position!()
         {
             tracing::info!(?start, ?offset, ?content_start, ?block_metadata, ?content, "Parsing sidebar block");
@@ -2130,7 +2116,7 @@ peg::parser! {
 
         rule pass_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
             = open_delim:pass_delimiter() eol()
-            content_start:position!() content:until_pass_delimiter() content_end:position!()
+            content_start:position!() content:until_pass_delimiter(open_delim) content_end:position!()
             eol() close_delim:pass_delimiter() end:position!()
         {
             check_delimiters(open_delim, close_delim, "pass", state.create_error_source_location(state.create_block_location(start, end, offset)))?;
@@ -2183,7 +2169,7 @@ peg::parser! {
 
         rule quote_block(start: usize, offset: usize, block_metadata: &BlockParsingMetadata) -> Result<Block, Error>
             = open_delim:quote_delimiter() eol()
-            content_start:position!() content:until_quote_delimiter() content_end:position!()
+            content_start:position!() content:until_quote_delimiter(open_delim) content_end:position!()
             eol() close_delim:quote_delimiter() end:position!()
         {
             check_delimiters(open_delim, close_delim, "quote", state.create_error_source_location(state.create_block_location(start, end, offset)))?;


### PR DESCRIPTION
As part of this we now also properly parse inner delimited blocks correctly.

Closes #349.