### PR TITLE
fix(converters-core): create parent directories for output file

### DIFF
--- a/converters/core/CHANGELOG.md
+++ b/converters/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Output file creation now creates parent directories if they don't exist, so
+  `-o path/to/nonexistent/dir/file.html` works without pre-creating the directory
+  tree. ([#358])
+
 ### Added
 
 - **Section numbering utilities** — new `section` module with `SectionNumberTracker`,
@@ -47,3 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#275]: https://github.com/nlopes/acdc/issues/275
 [#313]: https://github.com/nlopes/acdc/pull/313
+[#358]: https://github.com/nlopes/acdc/issues/358

--- a/converters/core/src/lib.rs
+++ b/converters/core/src/lib.rs
@@ -555,6 +555,9 @@ pub trait Converter: Sized {
             self.backend()
         );
 
+        if let Some(parent) = output_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         let file = std::fs::File::create(output_path)?;
         self.write_to(doc, std::io::BufWriter::new(file), source_file)?;
 


### PR DESCRIPTION
When using `-o path/to/nonexistent/dir/file.html`, the output file creation now creates parent directories if they don't exist.

Closes #358