### PR TITLE
feat(parser,editor): enrich AST with precise location data

### DIFF
--- a/acdc-editor-wasm/CHANGELOG.md
+++ b/acdc-editor-wasm/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `aside.admonition-block`, `figure.example-block`, `aside.sidebar`,
   `section.quote-block`, `.listing-block`, `figure.image-block`, `ol.toc-list`,
   `section.footnotes`, `ol.callout-list`, semantic list wrappers, etc.).
+- **Highlighter simplified to use AST locations** — replaced ~315 lines of raw text
+  scanning with direct use of parser location data. Inline delimiter highlighting,
+  block metadata spans, delimited block delimiters, macro spans, and description list
+  markers now use precise AST locations instead of heuristic text scanning.
 
 ### Fixed
 

--- a/acdc-parser/CHANGELOG.md
+++ b/acdc-parser/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`latexmath:[]` and `asciimath:[]` inline macros** — explicit notation overrides that
   set the stem notation directly instead of resolving from the `:stem:` document attribute.
+- **`BlockMetadata.location`** — metadata blocks now carry an `Option<Location>` tracking
+  their source position (attribute lines, anchors, titles).
+- **`DelimitedBlock.open_delimiter_location` / `close_delimiter_location`** — delimited
+  blocks now carry precise locations for both the opening and closing delimiter lines.
+- **`DescriptionListItem.delimiter_location`** — description list items now carry the
+  source location of their delimiter (`::`, `:::`, etc.).
 
 ## [0.6.0] - 2026-02-23
 

--- a/acdc-parser/src/grammar/inline_preprocessor.rs
+++ b/acdc-parser/src/grammar/inline_preprocessor.rs
@@ -287,11 +287,6 @@ parser!(
                     "Counters ({{{counter_type}:{name}}}) are not supported and will be removed from output"
                 ));
 
-                // Calculate total length for position tracking
-                // We capture the full match including any optional initial value
-                let total_len = counter_type.len() + 1 + name.len() + 2; // "{" + counter_type + ":" + name + "}"
-                let _location = state.calculate_location(start, "", total_len);
-
                 // Return empty string - counter is removed from output
                 String::new()
             }

--- a/acdc-parser/src/model/lists.rs
+++ b/acdc-parser/src/model/lists.rs
@@ -83,6 +83,9 @@ pub struct DescriptionListItem {
     pub term: Vec<InlineNode>,
     /// The delimiter used (`::`, `:::`, `::::`, or `;;`).
     pub delimiter: String,
+    /// Location of the delimiter in the source.
+    #[serde(skip)]
+    pub delimiter_location: Option<Location>,
     /// Inline content immediately after the delimiter on the same line.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub principal_text: Vec<InlineNode>,

--- a/acdc-parser/src/model/metadata.rs
+++ b/acdc-parser/src/model/metadata.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use super::anchor::Anchor;
 use super::attributes::{AttributeValue, ElementAttributes};
 use super::attribution::{Attribution, CiteTitle};
+use super::location::Location;
 use super::substitution::SubstitutionSpec;
 
 pub type Role = String;
@@ -39,6 +40,8 @@ pub struct BlockMetadata {
     pub attribution: Option<Attribution>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub citetitle: Option<CiteTitle>,
+    #[serde(skip)]
+    pub location: Option<Location>,
 }
 
 impl BlockMetadata {

--- a/acdc-parser/src/model/mod.rs
+++ b/acdc-parser/src/model/mod.rs
@@ -409,6 +409,8 @@ pub struct DelimitedBlock {
     pub delimiter: String,
     pub title: Title,
     pub location: Location,
+    pub open_delimiter_location: Option<Location>,
+    pub close_delimiter_location: Option<Location>,
 }
 
 impl DelimitedBlock {
@@ -421,6 +423,8 @@ impl DelimitedBlock {
             delimiter,
             title: Title::default(),
             location,
+            open_delimiter_location: None,
+            close_delimiter_location: None,
         }
     }
 


### PR DESCRIPTION
Add location fields to parser AST types.

This then helps the editor highlighter so that it doesn't need to do calculations in raw text:

- BlockMetadata.location: covers attribute/anchor/title lines (I don't particularly like this but it is what it is)
- DelimitedBlock.open/close_delimiter_location: delimiter line positions
- DescriptionListItem.delimiter_location: position of ::, :::, etc.