### PR TITLE
test(terminal): add cell-grid verification via libghostty-vt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      # Required by the libghostty-vt dev-dependency in acdc-converters-terminal,
+      # which is compiled whenever --all-targets pulls in test code.
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: "0.15.1"
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- --deny clippy::pedantic
       - name: Install wasm32 target
@@ -105,6 +110,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
+      # Required by the libghostty-vt dev-dependency used in
+      # acdc-converters-terminal's cell-grid integration tests.
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: "0.15.1"
       - name: Run converter tests
         run: cargo nextest run -p acdc-converters-core -p acdc-converters-html -p acdc-converters-manpage -p acdc-converters-terminal -p acdc-converters-markdown --all-features --verbose
 
@@ -165,5 +175,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # Required by acdc-converters-terminal's libghostty-vt dev-dependency,
+      # which is compiled as part of the workspace-wide doctest build.
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: "0.15.1"
       - name: Run doc tests
         run: cargo test --doc --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "acdc-parser",
  "comfy-table",
  "crossterm",
+ "libghostty-vt",
  "pretty_assertions",
  "syntect",
  "thiserror",
@@ -1420,6 +1421,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "int-enum"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366a1634cccc76b4cfd3e7580de9b605e4d93f1edac48d786c1f867c0def495"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1553,23 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libghostty-vt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8afe5cc9ae303133220e530b28b7addbbf591160bb1564b88f7ee61387fee74"
+dependencies = [
+ "bitflags",
+ "int-enum",
+ "libghostty-vt-sys",
+]
+
+[[package]]
+name = "libghostty-vt-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee97068da1692162c4523d54843bdcb43fecf086a9ee412a3375817e433faca"
 
 [[package]]
 name = "linked-hash-map"
@@ -2066,6 +2096,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -3156,6 +3198,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "viuer"

--- a/converters/terminal/CHANGELOG.md
+++ b/converters/terminal/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cell-grid integration tests via `libghostty-vt`** — new `tests/grid_test.rs`
+  pipes converter output through a real VT emulator (Ghostty's `libghostty-vt`
+  0.1.1) and asserts on the rendered cell grid (character, bold/italic,
+  hyperlink) instead of raw ANSI byte streams. Complements the existing
+  fixture-based tests with a layer that survives harmless SGR reorderings and
+  catches bugs where bytes look correct but render wrong. Adds `libghostty-vt`
+  as a dev-dependency; building it requires Zig 0.15.x on `PATH` (CI jobs are
+  updated to install it automatically via `mlugg/setup-zig`).
+- **`Processor::with_capabilities()`** — new builder method to override the
+  auto-detected terminal capabilities. Used by the new cell-grid tests to
+  force OSC 8 hyperlink emission on regardless of the host `TERM`.
 - **`[listing]` and `[source]` styled paragraphs** — paragraphs with `[listing]` or
   `[source,lang]` style now render as preformatted text (same as `[literal]`).
 

--- a/converters/terminal/Cargo.toml
+++ b/converters/terminal/Cargo.toml
@@ -25,6 +25,7 @@ viuer = { version = "0.11", features = ["print-file"], optional = true }
 
 [dev-dependencies]
 acdc-converters-dev.workspace = true
+libghostty-vt = "0.1.1"
 pretty_assertions.workspace = true
 
 [lints]

--- a/converters/terminal/src/lib.rs
+++ b/converters/terminal/src/lib.rs
@@ -148,6 +148,17 @@ impl Processor {
         self
     }
 
+    /// Override the detected terminal capabilities.
+    ///
+    /// Useful for tests where a deterministic capability set (for example,
+    /// forcing OSC 8 hyperlink support on) is required regardless of the
+    /// host environment's `TERM` variable.
+    #[must_use]
+    pub fn with_capabilities(mut self, capabilities: Capabilities) -> Self {
+        self.appearance.capabilities = capabilities;
+        self
+    }
+
     /// Returns the terminal capabilities.
     #[must_use]
     pub fn terminal_capabilities(&self) -> &Capabilities {

--- a/converters/terminal/tests/grid_test.rs
+++ b/converters/terminal/tests/grid_test.rs
@@ -1,0 +1,377 @@
+//! Cell-grid verification tests for the terminal converter via `libghostty-vt`.
+//!
+//! These tests complement the byte-level fixture tests in `integration_test.rs`
+//! by piping converter output through a real VT emulator and asserting on the
+//! resulting cell grid. Targeting cells (char + style) instead of raw ANSI
+//! bytes catches regressions where an SGR reordering preserves the visual
+//! output, and it verifies that the emitted bytes actually render the way
+//! the converter intends.
+
+#![allow(
+    clippy::pedantic,
+    clippy::indexing_slicing,
+    reason = "test code: relaxed lints for readability and deterministic fixture inputs"
+)]
+
+use std::ops::Range;
+
+use acdc_converters_core::{Converter, Options as ConverterOptions, default_rendering_attributes};
+use acdc_converters_terminal::{Capabilities, Processor};
+use acdc_parser::Options as ParserOptions;
+use libghostty_vt::{
+    RenderState, Terminal, TerminalOptions,
+    render::{CellIterator, RowIterator},
+    style::{RgbColor, Underline},
+};
+
+type TestError = Box<dyn std::error::Error>;
+
+const TEST_COLS: u16 = 80;
+const TEST_ROWS: u16 = 200;
+
+/// A single cell extracted from the `libghostty-vt` render state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Cell {
+    ch: char,
+    bold: bool,
+    italic: bool,
+    underlined: bool,
+    #[allow(dead_code, reason = "available for future colour-sensitive assertions")]
+    fg: Option<RgbColor>,
+    #[allow(dead_code, reason = "available for future colour-sensitive assertions")]
+    bg: Option<RgbColor>,
+    hyperlink: bool,
+}
+
+/// A materialised 2D grid of cells (`rows[row_index][col_index]`).
+#[derive(Debug)]
+struct Grid {
+    rows: Vec<Vec<Cell>>,
+}
+
+impl Grid {
+    fn cell(&self, row: usize, col: usize) -> &Cell {
+        &self.rows[row][col]
+    }
+
+    fn row_text(&self, row: usize) -> String {
+        self.rows[row].iter().map(|c| c.ch).collect()
+    }
+
+    /// Find the first `(row, col)` where `needle` starts in the grid.
+    fn find_text(&self, needle: &str) -> Option<(usize, usize)> {
+        for (r, row) in self.rows.iter().enumerate() {
+            let text: String = row.iter().map(|c| c.ch).collect();
+            if let Some(col) = text.find(needle) {
+                return Some((r, col));
+            }
+        }
+        None
+    }
+}
+
+/// Parse AsciiDoc, run the terminal converter, and feed the bytes through
+/// `libghostty-vt` to produce a cell grid. OSC 8 hyperlink emission is
+/// disabled.
+fn render_adoc(adoc: &str) -> Result<Grid, TestError> {
+    render_adoc_inner(adoc, false)
+}
+
+/// Same as `render_adoc` but forces OSC 8 hyperlink emission on regardless
+/// of the host environment's `TERM` variable.
+fn render_adoc_osc8(adoc: &str) -> Result<Grid, TestError> {
+    render_adoc_inner(adoc, true)
+}
+
+fn render_adoc_inner(adoc: &str, force_osc8: bool) -> Result<Grid, TestError> {
+    let parser_opts = ParserOptions::with_attributes(default_rendering_attributes());
+    let doc = acdc_parser::parse(adoc, &parser_opts)?;
+
+    let capabilities = Capabilities {
+        unicode: true,
+        osc8_links: force_osc8,
+    };
+
+    let processor = Processor::new(ConverterOptions::default(), doc.attributes.clone())
+        .with_terminal_width(usize::from(TEST_COLS))
+        .with_capabilities(capabilities);
+
+    let mut buf = Vec::new();
+    processor.write_to(&doc, &mut buf, None)?;
+
+    drive_terminal(&buf, TEST_COLS, TEST_ROWS)
+}
+
+fn drive_terminal(bytes: &[u8], cols: u16, rows: u16) -> Result<Grid, TestError> {
+    let mut terminal = Terminal::new(TerminalOptions {
+        cols,
+        rows,
+        max_scrollback: 10_000,
+    })?;
+    terminal.vt_write(bytes);
+
+    let mut render_state = RenderState::new()?;
+    let mut row_iter = RowIterator::new()?;
+    let mut cell_iter = CellIterator::new()?;
+
+    let snapshot = render_state.update(&terminal)?;
+    let mut rows_iteration = row_iter.update(&snapshot)?;
+
+    let mut grid_rows: Vec<Vec<Cell>> = Vec::with_capacity(rows as usize);
+    while let Some(row) = rows_iteration.next() {
+        let mut row_cells: Vec<Cell> = Vec::with_capacity(cols as usize);
+        let mut cells_iteration = cell_iter.update(row)?;
+        while let Some(cell) = cells_iteration.next() {
+            let graphemes = cell.graphemes()?;
+            // Use U+0020 (SPACE) as the placeholder for empty / bg-only cells
+            // so that string searches against the grid behave naturally.
+            let ch = graphemes
+                .first()
+                .copied()
+                .filter(|c| *c != '\0')
+                .unwrap_or(' ');
+            let style = cell.style()?;
+            let fg = cell.fg_color()?;
+            let bg = cell.bg_color()?;
+            let hyperlink = cell.raw_cell()?.has_hyperlink()?;
+            row_cells.push(Cell {
+                ch,
+                bold: style.bold,
+                italic: style.italic,
+                underlined: style.underline != Underline::None,
+                fg,
+                bg,
+                hyperlink,
+            });
+        }
+        grid_rows.push(row_cells);
+    }
+
+    Ok(Grid { rows: grid_rows })
+}
+
+// ---------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------
+
+fn assert_cells_bold(grid: &Grid, row: usize, cols: Range<usize>) {
+    for col in cols {
+        let cell = grid.cell(row, col);
+        assert!(cell.bold, "expected bold at ({row}, {col}); got {cell:?}");
+    }
+}
+
+fn assert_cells_italic(grid: &Grid, row: usize, cols: Range<usize>) {
+    for col in cols {
+        let cell = grid.cell(row, col);
+        assert!(
+            cell.italic,
+            "expected italic at ({row}, {col}); got {cell:?}"
+        );
+    }
+}
+
+fn assert_cells_hyperlinked(grid: &Grid, row: usize, cols: Range<usize>) {
+    for col in cols {
+        let cell = grid.cell(row, col);
+        assert!(
+            cell.hyperlink,
+            "expected hyperlink at ({row}, {col}); got {cell:?}"
+        );
+    }
+}
+
+fn assert_cell_no_hyperlink(grid: &Grid, row: usize, col: usize) {
+    let cell = grid.cell(row, col);
+    assert!(
+        !cell.hyperlink,
+        "expected no hyperlink at ({row}, {col}); got {cell:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+#[test]
+fn section_header_is_bold() -> Result<(), TestError> {
+    let adoc = "= Document Title\n\n== Section Title\n\nBody paragraph.\n";
+    let grid = render_adoc(adoc)?;
+
+    let (row, col) = grid
+        .find_text("Section Title")
+        .ok_or("'Section Title' not found in grid")?;
+    assert_cells_bold(&grid, row, col..col + "Section Title".len());
+    Ok(())
+}
+
+#[test]
+fn plain_paragraph_has_no_inline_styling() -> Result<(), TestError> {
+    let adoc = "Just a plain sentence on its own.\n";
+    let grid = render_adoc(adoc)?;
+
+    let (row, col) = grid
+        .find_text("Just a plain sentence")
+        .ok_or("sentence not found")?;
+    let cell = grid.cell(row, col);
+    assert!(!cell.bold, "plain paragraph should not be bold: {cell:?}");
+    assert!(
+        !cell.italic,
+        "plain paragraph should not be italic: {cell:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn bold_and_italic_inline_formatting() -> Result<(), TestError> {
+    let adoc = "This has *bold* and _italic_ words.\n";
+    let grid = render_adoc(adoc)?;
+
+    let (row, col) = grid.find_text("bold").ok_or("'bold' not found")?;
+    assert_cells_bold(&grid, row, col..col + "bold".len());
+
+    let (row, col) = grid.find_text("italic").ok_or("'italic' not found")?;
+    assert_cells_italic(&grid, row, col..col + "italic".len());
+    Ok(())
+}
+
+#[test]
+fn unordered_list_shows_bullet_and_items() -> Result<(), TestError> {
+    let adoc = "* First item\n* Second item\n";
+    let grid = render_adoc(adoc)?;
+
+    let (row, _) = grid
+        .find_text("First item")
+        .ok_or("'First item' not found")?;
+    let text = grid.row_text(row);
+    // The terminal converter picks different bullet glyphs based on nesting
+    // and Unicode support; accept any of them.
+    assert!(
+        text.contains('\u{2022}')   // •
+            || text.contains('\u{25E6}') // ◦
+            || text.contains('\u{25AA}') // ▪
+            || text.contains('*'),
+        "row {row} missing bullet char; full row: {text:?}"
+    );
+
+    assert!(
+        grid.find_text("Second item").is_some(),
+        "second list item missing"
+    );
+    Ok(())
+}
+
+#[test]
+fn ordered_list_shows_numbers() -> Result<(), TestError> {
+    let adoc = ". First item\n. Second item\n";
+    let grid = render_adoc(adoc)?;
+
+    assert!(grid.find_text("1.").is_some(), "missing '1.' prefix");
+    assert!(grid.find_text("2.").is_some(), "missing '2.' prefix");
+    assert!(
+        grid.find_text("First item").is_some(),
+        "missing first item text"
+    );
+    assert!(
+        grid.find_text("Second item").is_some(),
+        "missing second item text"
+    );
+    Ok(())
+}
+
+#[test]
+fn note_admonition_renders_caption_and_body() -> Result<(), TestError> {
+    let adoc = "NOTE: A helpful note.\n";
+    let grid = render_adoc(adoc)?;
+
+    // The caption is either the word "NOTE" or the ℹ icon, depending on
+    // capability detection.
+    let has_caption = grid.find_text("NOTE").is_some() || grid.find_text("\u{2139}").is_some();
+    assert!(has_caption, "expected NOTE caption somewhere in grid");
+
+    assert!(
+        grid.find_text("A helpful note").is_some(),
+        "expected note body text"
+    );
+    Ok(())
+}
+
+#[test]
+fn warning_admonition_renders_caption_and_body() -> Result<(), TestError> {
+    let adoc = "WARNING: Be careful now.\n";
+    let grid = render_adoc(adoc)?;
+
+    let has_caption = grid.find_text("WARNING").is_some() || grid.find_text("\u{26A0}").is_some();
+    assert!(has_caption, "expected WARNING caption somewhere in grid");
+
+    assert!(
+        grid.find_text("Be careful now").is_some(),
+        "expected warning body text"
+    );
+    Ok(())
+}
+
+#[test]
+fn table_draws_box_borders_and_cells() -> Result<(), TestError> {
+    let adoc = "|===\n| A | B\n| 1 | 2\n|===\n";
+    let grid = render_adoc(adoc)?;
+
+    // Unicode box-drawing block: U+2500..=U+257F.
+    let has_box_char = grid.rows.iter().flatten().any(|cell| {
+        let code = u32::from(cell.ch);
+        (0x2500..=0x257F).contains(&code)
+    });
+    assert!(has_box_char, "expected table box-drawing characters");
+
+    assert!(grid.find_text("A").is_some(), "missing cell 'A'");
+    assert!(grid.find_text("B").is_some(), "missing cell 'B'");
+    assert!(grid.find_text("1").is_some(), "missing cell '1'");
+    assert!(grid.find_text("2").is_some(), "missing cell '2'");
+    Ok(())
+}
+
+#[test]
+fn source_block_preserves_content_verbatim() -> Result<(), TestError> {
+    let adoc = "----\nlet x = 42;\n----\n";
+    let grid = render_adoc(adoc)?;
+
+    assert!(
+        grid.find_text("let x = 42;").is_some(),
+        "expected source block content rendered verbatim"
+    );
+    Ok(())
+}
+
+#[test]
+fn url_macro_sets_hyperlink_on_link_text_when_osc8_enabled() -> Result<(), TestError> {
+    let adoc = "See https://example.com[Example Site] for details.\n";
+    let grid = render_adoc_osc8(adoc)?;
+
+    let (row, col) = grid
+        .find_text("Example Site")
+        .ok_or("'Example Site' not found in grid")?;
+    let text_len = "Example Site".len();
+
+    assert_cells_hyperlinked(&grid, row, col..col + text_len);
+
+    if col > 0 {
+        assert_cell_no_hyperlink(&grid, row, col - 1);
+    }
+    assert_cell_no_hyperlink(&grid, row, col + text_len);
+    Ok(())
+}
+
+#[test]
+fn url_macro_has_no_hyperlink_when_osc8_disabled() -> Result<(), TestError> {
+    let adoc = "See https://example.com[Example Site] for details.\n";
+    let grid = render_adoc(adoc)?;
+
+    let (row, col) = grid
+        .find_text("Example Site")
+        .ok_or("'Example Site' not found in grid")?;
+
+    for offset in 0.."Example Site".len() {
+        assert_cell_no_hyperlink(&grid, row, col + offset);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Parse converter output through the real Ghostty VT emulator and assert
on the rendered cell grid (char, bold/italic, OSC 8 hyperlink) instead
of diffing raw ANSI byte streams. This layer survives harmless SGR
reorderings and actually exercises the rendering pipeline a terminal
user experiences, catching bugs where the bytes look right but would
render wrong.

The existing fixture-based integration tests are kept as-is; this is
additive. Tests live in converters/terminal/tests/grid_test.rs and
cover section headers, paragraphs, bold/italic inline formatting,
ordered/unordered lists, NOTE and WARNING admonitions, tables,
source blocks, and OSC 8 hyperlink attribution (both with the
capability forced on and off).

- Adds libghostty-vt 0.1.1 as a dev-dependency of the terminal crate.
- Adds Processor::with_capabilities() so tests can force OSC 8 on
  regardless of the host TERM environment (mirrors the existing
  with_terminal_width() builder pattern).
- Installs Zig 0.15.1 via mlugg/setup-zig in the test-converters,
  clippy, and doctest CI jobs, which are the jobs that compile the
  dev-dependency through --all-targets / --doc.
- Updates acdc-converters-terminal CHANGELOG.