### PR TITLE
feat(cli): add timing summary table for multi-file conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-/target
+**/target
 /aux
 /.dev/archive/
 .worktrees/
-
-# Perf work — profiles and timing snapshots are regenerated from scripts/perf/
-/perf/profiles/
-/perf/results/
-/profile.json.gz
+/cargo-flamegraph.trace/

--- a/acdc-cli/CHANGELOG.md
+++ b/acdc-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Timing summary table for multi-file conversions** — when `convert` is invoked with
+  `--timings` and more than one input file, a summary table is printed after the
+  per-file output with parse time, convert time, total per-file time, and wall-clock
+  time across the batch. Single-file output is unchanged.
+
 ## [0.2.0] - 2026-03-28
 
 ### Added

--- a/acdc-cli/src/main.rs
+++ b/acdc-cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod error;
 mod subcommands;
+mod timing;
 
 #[derive(Parser)]
 #[command(name = "acdc")]
@@ -26,11 +27,11 @@ enum Commands {
 }
 
 fn setup_logging() {
-    use tracing_subscriber::{EnvFilter, prelude::*};
-
-    let env_filter = EnvFilter::try_from_env("ACDC_LOG").or_else(|_| EnvFilter::try_new("warn"));
-
-    if let Ok(filter) = env_filter {
+    // Only install a tracing subscriber when ACDC_LOG is explicitly set.
+    // Without a subscriber, tracing macros are near-zero-cost no-ops,
+    // avoiding per-call dispatch overhead on every parse/convert operation.
+    if let Ok(filter) = tracing_subscriber::EnvFilter::try_from_env("ACDC_LOG") {
+        use tracing_subscriber::prelude::*;
         let layer = tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
             .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))

--- a/acdc-cli/src/subcommands/convert.rs
+++ b/acdc-cli/src/subcommands/convert.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use acdc_converters_core::{
     Backend, Converter, Doctype, GeneratorMetadata, Options, OutputDestination,
@@ -8,7 +8,10 @@ use clap::{ArgAction, Args as ClapArgs};
 use miette::Report;
 use rayon::prelude::*;
 
-use crate::error;
+use crate::{
+    error,
+    timing::{TimingEntry, print_timing_table},
+};
 
 /// Convert `AsciiDoc` documents to various output formats
 #[derive(ClapArgs, Debug)]
@@ -284,78 +287,176 @@ where
         _ => &args.files,
     };
 
-    // PHASE 1: Parse all files in parallel (always - parsing is the expensive part)
-    let parse_results: Vec<(PathBuf, Result<acdc_parser::Document, acdc_parser::Error>)> =
-        files_to_process
-            .par_iter()
-            .map(|file| {
-                let parser_options =
-                    build_parser_options(args, &base_options, document_attributes.clone());
+    // Single-file fast path: skip rayon thread pool overhead entirely
+    if let [file] = files_to_process {
+        let parser_options = build_parser_options(args, &base_options, document_attributes.clone());
+        let parse_result = if base_options.timings() {
+            let now = std::time::Instant::now();
+            let result = acdc_parser::parse_file(file, &parser_options);
+            let elapsed = now.elapsed();
+            if result.is_ok() {
+                use acdc_converters_core::PrettyDuration;
+                eprintln!("  Parsed {} in {}", file.display(), elapsed.pretty_print());
+            }
+            result
+        } else {
+            acdc_parser::parse_file(file, &parser_options)
+        };
+        let processor = P::new(base_options, document_attributes);
+        let convert_result = match parse_result {
+            Ok(doc) => processor.convert(&doc, Some(file)),
+            Err(e) => Err(e.into()),
+        };
+        report_errors(std::iter::once((file.clone(), convert_result)));
+        return Ok(());
+    }
 
-                if base_options.timings() {
-                    let now = std::time::Instant::now();
-                    let result = acdc_parser::parse_file(file, &parser_options);
-                    let elapsed = now.elapsed();
-                    if result.is_ok() {
-                        use acdc_converters_core::PrettyDuration;
-                        eprintln!("  Parsed {} in {}", file.display(), elapsed.pretty_print());
-                    }
-                    (file.clone(), result)
-                } else {
-                    let result = acdc_parser::parse_file(file, &parser_options);
-                    (file.clone(), result)
-                }
-            })
-            .collect();
+    run_multi_file::<P>(
+        args,
+        &base_options,
+        document_attributes,
+        files_to_process,
+        parallelize,
+    );
+    Ok(())
+}
 
-    // PHASE 2: Convert documents - either in parallel or sequentially
-    let results: Vec<(PathBuf, Result<(), P::Error>)> = if parallelize {
-        // Parallel conversion for converters with separate output files (e.g., HTML)
+fn run_multi_file<P>(
+    args: &Args,
+    base_options: &Options,
+    document_attributes: DocumentAttributes,
+    files_to_process: &[PathBuf],
+    parallelize: bool,
+) where
+    P: Converter,
+    P::Error: Send + 'static + From<acdc_parser::Error>,
+{
+    let show_timings = base_options.timings();
+    let multi_file = files_to_process.len() > 1;
+    let wall_clock_start = show_timings.then(std::time::Instant::now);
+
+    // Parse all files in parallel, collecting durations when timing
+    let parse_results: Vec<(
+        PathBuf,
+        Result<acdc_parser::Document, acdc_parser::Error>,
+        Option<Duration>,
+    )> = files_to_process
+        .par_iter()
+        .map(|file| {
+            let parser_options =
+                build_parser_options(args, base_options, document_attributes.clone());
+
+            if show_timings {
+                let now = std::time::Instant::now();
+                let result = acdc_parser::parse_file(file, &parser_options);
+                let elapsed = now.elapsed();
+                (file.clone(), result, Some(elapsed))
+            } else {
+                let result = acdc_parser::parse_file(file, &parser_options);
+                (file.clone(), result, None)
+            }
+        })
+        .collect();
+
+    // Convert documents, timing each conversion from the CLI side.
+    //
+    // For multi-file + timings: suppress the converter's per-file timing output since
+    // we'll print a summary table instead.
+    let converter_options = if show_timings && multi_file {
+        Options::builder()
+            .generator_metadata(base_options.generator_metadata().clone())
+            .doctype(base_options.doctype())
+            .safe_mode(base_options.safe_mode())
+            .timings(false)
+            .embedded(base_options.embedded())
+            .output_destination(base_options.output_destination().clone())
+            .backend(base_options.backend())
+            .build()
+    } else {
+        base_options.clone()
+    };
+
+    let file_results: Vec<FileResult<P::Error>> = if parallelize {
         parse_results
             .into_par_iter()
-            .map(|(file, parse_result)| {
-                let processor = P::new(base_options.clone(), document_attributes.clone());
-                let convert_result = match parse_result {
+            .map(|(file, parse_result, parse_dur)| {
+                let processor = P::new(converter_options.clone(), document_attributes.clone());
+                let now = std::time::Instant::now();
+                let result = match parse_result {
                     Ok(doc) => processor.convert(&doc, Some(&file)),
                     Err(e) => Err(e.into()),
                 };
-                (file, convert_result)
+                let convert_dur = show_timings.then(|| now.elapsed());
+                FileResult {
+                    path: file,
+                    result,
+                    parse_dur,
+                    convert_dur,
+                }
             })
             .collect()
     } else {
-        // Sequential conversion for converters that output to stdout (e.g., Terminal)
-        let processor = P::new(base_options, document_attributes);
+        let processor = P::new(converter_options, document_attributes);
         parse_results
             .into_iter()
-            .map(|(file, parse_result)| {
-                let convert_result = match parse_result {
+            .map(|(file, parse_result, parse_dur)| {
+                let now = std::time::Instant::now();
+                let result = match parse_result {
                     Ok(doc) => processor.convert(&doc, Some(&file)),
                     Err(e) => Err(e.into()),
                 };
-                (file, convert_result)
+                let convert_dur = show_timings.then(|| now.elapsed());
+                FileResult {
+                    path: file,
+                    result,
+                    parse_dur,
+                    convert_dur,
+                }
             })
             .collect()
     };
 
-    // Separate successes from errors
-    let (_successes, errors): (Vec<_>, Vec<_>) = results
-        .into_iter()
-        .partition(|(_file, result)| result.is_ok());
+    if show_timings && multi_file {
+        let wall_clock = wall_clock_start.map(|s| s.elapsed());
+        let timing_entries: Vec<_> = file_results
+            .iter()
+            .filter_map(|fr| {
+                Some(TimingEntry {
+                    path: fr.path.clone(),
+                    parse: fr.parse_dur?,
+                    convert: fr.convert_dur?,
+                })
+            })
+            .collect();
+        print_timing_table(&timing_entries, wall_clock);
+    }
 
-    // If there are errors, collect and display them
+    report_errors(file_results.into_iter().map(|fr| (fr.path, fr.result)));
+}
+
+struct FileResult<E> {
+    path: PathBuf,
+    result: Result<(), E>,
+    parse_dur: Option<Duration>,
+    convert_dur: Option<Duration>,
+}
+
+fn report_errors<E: std::error::Error + 'static>(
+    results: impl Iterator<Item = (PathBuf, Result<(), E>)>,
+) {
+    let errors: Vec<_> = results
+        .filter_map(|(file, result)| result.err().map(|e| (file, e)))
+        .collect();
+
     if !errors.is_empty() {
         eprintln!("\nFailed to process {} file(s):", errors.len());
-        for (idx, (file, result)) in errors.iter().enumerate() {
-            if let Err(error) = result {
-                eprintln!("\n{}. File: {}", idx + 1, file.display());
-                let report = error::display(error);
-                eprintln!("{report:?}");
-            }
+        for (idx, (file, err)) in errors.iter().enumerate() {
+            eprintln!("\n{}. File: {}", idx + 1, file.display());
+            let report = error::display(err);
+            eprintln!("{report:?}");
         }
         std::process::exit(1);
     }
-
-    Ok(())
 }
 
 /// Spawn a pager process, returning the child process.

--- a/acdc-cli/src/timing.rs
+++ b/acdc-cli/src/timing.rs
@@ -1,0 +1,81 @@
+use std::{path::PathBuf, time::Duration};
+
+use acdc_converters_core::PrettyDuration;
+
+pub(crate) struct TimingEntry {
+    pub(crate) path: PathBuf,
+    pub(crate) parse: Duration,
+    pub(crate) convert: Duration,
+}
+
+pub(crate) fn print_timing_table(entries: &[TimingEntry], wall_clock: Option<Duration>) {
+    if entries.is_empty() {
+        return;
+    }
+
+    let mut sorted: Vec<_> = entries.iter().collect();
+    sorted.sort_by_key(|e| e.parse + e.convert);
+
+    let name_width = sorted
+        .iter()
+        .map(|t| t.path.file_name().map_or(0, |n| n.to_string_lossy().len()))
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    let col = 12;
+    let separator_len = name_width + 2 + col * 3 + 4;
+
+    eprintln!(
+        "\n{:<nw$}  {:>cw$}  {:>cw$}  {:>cw$}",
+        "File",
+        "Parse",
+        "Convert",
+        "Total",
+        nw = name_width,
+        cw = col
+    );
+    eprintln!("{}", "\u{2500}".repeat(separator_len));
+
+    for entry in &sorted {
+        let total = entry.parse + entry.convert;
+        let name = entry.path.file_name().map_or_else(
+            || entry.path.display().to_string(),
+            |n| n.to_string_lossy().into_owned(),
+        );
+        eprintln!(
+            "{:<nw$}  {:>cw$}  {:>cw$}  {:>cw$}",
+            name,
+            entry.parse.pretty_print(),
+            entry.convert.pretty_print(),
+            total.pretty_print(),
+            nw = name_width,
+            cw = col
+        );
+    }
+
+    eprintln!("{}", "\u{2500}".repeat(separator_len));
+    let total_parse: Duration = entries.iter().map(|t| t.parse).sum();
+    let total_convert: Duration = entries.iter().map(|t| t.convert).sum();
+    let total_all = total_parse + total_convert;
+    let label = format!("Total ({} files)", entries.len());
+    eprintln!(
+        "{:<nw$}  {:>cw$}  {:>cw$}  {:>cw$}",
+        label,
+        total_parse.pretty_print(),
+        total_convert.pretty_print(),
+        total_all.pretty_print(),
+        nw = name_width,
+        cw = col
+    );
+
+    if let Some(wall) = wall_clock {
+        eprintln!(
+            "{:<nw$}  {:>cw$}",
+            "Wall clock",
+            wall.pretty_print(),
+            nw = name_width + 2 + col * 2 + 2,
+            cw = col
+        );
+    }
+}


### PR DESCRIPTION
Single-file output stays unchanged but with this PR we now have a table when given a list of files to parse and convert.
<img width="505" height="210" alt="Screenshot 2026-04-18 at 15 14 46" src="https://github.com/user-attachments/assets/ce3198fe-620c-43ce-bc3e-7984f3e6f120" />
