### PR TITLE
docs: refresh READMEs and ARCHITECTURE to match current code

### DIFF
--- a/ARCHITECTURE.adoc
+++ b/ARCHITECTURE.adoc
@@ -350,13 +350,6 @@ The main focus areas will be grammar modularization (if possible, as `rust-peg` 
 
 Today the LSP reparses the whole document on every change. Incremental parsing would cut latency on large files, but it requires grammar-level support that PEG doesn't give us for free - this is a longer-term research item.
 
-== Already shipped
-
-A couple of items that used to live in "future directions" and have since landed:
-
-* **WebAssembly** - `acdc-editor-wasm` compiles the parser and HTML converter to WASM and ships a browser-based live editor with syntax highlighting and preview. It's released via GitHub Releases and is available at https://acdc.nlopes.dev[acdc.nlopes.dev].
-* **Language Server Protocol** - `acdc-lsp` is a working LSP server with capabilities for diagnostics, hover, go-to-definition, find references, rename, completion, signature help, document links, folding, formatting (full + range + on-type), inlay hints, selection ranges, semantic tokens, code actions, code lens, document symbols, workspace symbols, call hierarchy, and file rename (auto-updates xrefs). Workspace-level xref resolution across open files and on-disk scanning is implemented in `acdc-lsp/src/state/workspace.rs`.
-
 == Spec compliance and compatibility
 
 === Following the spec

--- a/ARCHITECTURE.adoc
+++ b/ARCHITECTURE.adoc
@@ -168,10 +168,11 @@ pub trait Processable {
 }
 ----
 
-Right now I have three converters:
+Right now I have four converters:
 
-. HTML (`converters/html`) for HTML5 output with semantic markup and accessibility attributes
+. HTML (`converters/html`) for HTML5 output with semantic markup and accessibility attributes. Also ships a `html5s` variant (inspired by Jakub Jirutka's asciidoctor-html5s) that emits `<section>`/`<aside>`/`<figure>` instead of div-based layout
 . Manpage (`converters/manpage`) for native roff/troff output suitable for the `man` command
+. Markdown (`converters/markdown`) for CommonMark and GitHub Flavored Markdown output
 . Terminal (`converters/terminal`) for ANSI-formatted terminal display
 
 Why this trait-based design? I didn't think it over too much, honestly. It keeps things clean - the parser doesn't know anything about output formats. Each converter defines its own options and error types, which gives type safety. And implementing the trait to add a new output format is straightforward.
@@ -220,13 +221,15 @@ The workspace is organized into clearly bounded modules:
 ----
 acdc/
 ├── acdc-cli/          # Command-line interface
-├── acdc-lsp/          # Language Server Protocol implementation (early/experimental)
+├── acdc-editor-wasm/  # WASM live editor (syntax highlight + HTML preview)
+├── acdc-lsp/          # Language Server Protocol implementation
 ├── acdc-parser/       # Parser library (PEG grammar, preprocessor, AST)
 └── converters/
     ├── core/          # Shared converter infrastructure (Processable, Visitor traits)
     ├── dev/           # Development utilities (unpublished)
-    ├── html/          # HTML5 output
+    ├── html/          # HTML5 output (standard + html5s semantic variant)
     ├── manpage/       # Native roff/troff manpage output
+    ├── markdown/      # CommonMark / GitHub Flavored Markdown output
     └── terminal/      # ANSI terminal output
 ----
 
@@ -333,10 +336,6 @@ Callout markers in verbatim blocks (`<1>`, `<2>`, or auto-numbering `<.>`) are p
 
 == Future directions
 
-=== WASM compilation
-
-I want to compile `acdc` to WebAssembly one day. This would enable an interactive web-based parser demo, client-side AsciiDoc preview, and integration with web-based editors (maybe even build one!).
-
 === Parallel parsing
 
 I'm planning to look into parallel processing of files. If we need to parse and convert hundreds of files, I'd like to not take hundreds x "time that takes one".
@@ -347,9 +346,16 @@ This is planned for after grammar coverage is complete.
 
 The main focus areas will be grammar modularization (if possible, as `rust-peg` doesn't actually seem to allow this easily) to reduce compilation time, and maybe runtime parsing performance.
 
-=== Language Server Protocol
+=== Incremental parsing for the LSP
 
-The `acdc-lsp` crate provides an early/experimental LSP implementation. Currently it supports diagnostics, hover information, and go-to-definition. The goal is IDE-quality error messages with context and suggestions. This is still a work in progress - completion, references, and other features are planned.
+Today the LSP reparses the whole document on every change. Incremental parsing would cut latency on large files, but it requires grammar-level support that PEG doesn't give us for free - this is a longer-term research item.
+
+== Already shipped
+
+A couple of items that used to live in "future directions" and have since landed:
+
+* **WebAssembly** - `acdc-editor-wasm` compiles the parser and HTML converter to WASM and ships a browser-based live editor with syntax highlighting and preview. It's released via GitHub Releases and is available at https://acdc.nlopes.dev[acdc.nlopes.dev].
+* **Language Server Protocol** - `acdc-lsp` is a working LSP server with capabilities for diagnostics, hover, go-to-definition, find references, rename, completion, signature help, document links, folding, formatting (full + range + on-type), inlay hints, selection ranges, semantic tokens, code actions, code lens, document symbols, workspace symbols, call hierarchy, and file rename (auto-updates xrefs). Workspace-level xref resolution across open files and on-disk scanning is implemented in `acdc-lsp/src/state/workspace.rs`.
 
 == Spec compliance and compatibility
 
@@ -366,9 +372,13 @@ Where the spec is undefined or ambiguous, I match Asciidoctor behavior to keep t
 === Testing
 
 The `tck` command produces output compatible with the AsciiDoc Language TCK test harness,
-which means automated spec compliance validation. I've got over 115 test fixtures that
-validate parsing correctness against golden JSON files. The CI pipeline runs the full test
-suite on every change to catch regressions. Currently my test fixtures are much more comprehensive than the TCK tests are - on the one hand that's great (I'm testing more stuff), on the other hand when more gets added to the harness, I may find my fixtures and parser are wrong - we'll sort when we get there.
+which means automated spec compliance validation. I've got over 280 test fixtures that
+validate parsing correctness against golden JSON files, plus separate converter fixture
+suites for HTML, manpage, markdown, and terminal output. The CI pipeline runs the full
+test suite on every change to catch regressions. Currently my test fixtures are much more
+comprehensive than the TCK tests are - on the one hand that's great (I'm testing more
+stuff), on the other hand when more gets added to the harness, I may find my fixtures and
+parser are wrong - we'll sort when we get there.
 
 == Contributing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,9 @@ Thank you for your interest in contributing! This guide covers the essentials. F
 - [ARCHITECTURE.adoc](ARCHITECTURE.adoc) - Design decisions and architecture
 - [acdc-cli/README.adoc](acdc-cli/README.adoc) - CLI usage and feature flags
 - [acdc-parser/README.adoc](acdc-parser/README.adoc) - Parser features and details
+- [acdc-lsp/README.md](acdc-lsp/README.md) - Language Server setup and supported LSP capabilities
+- [acdc-editor-wasm/README.md](acdc-editor-wasm/README.md) - WASM live editor (embedding, API, syntax highlighting classes)
+- [converters/README.adoc](converters/README.adoc) - Index of output backends (HTML, manpage, markdown, terminal)
 
 ## Code Quality
 

--- a/README.adoc
+++ b/README.adoc
@@ -29,10 +29,10 @@ acdc/
 ├── acdc-cli/                 # Command-line interface
 │   └── src/
 │       └── main.rs          # CLI entry point
-├── acdc-lsp/                 # Language Server Protocol (early/experimental)
+├── acdc-lsp/                 # Language Server Protocol server
 │   └── src/
-│       ├── capabilities/    # LSP features (diagnostics, hover, definition)
-│       └── state/           # Document and workspace state management
+│       ├── capabilities/    # LSP features (diagnostics, hover, completion, rename, references, semantic tokens, …)
+│       └── state/           # Document and workspace state (cross-file anchor index)
 ├── acdc-parser/             # Core parser and AST
 │   ├── src/
 │   │   ├── grammar/         # PEG grammar definitions
@@ -54,9 +54,9 @@ acdc/
 
 * link:./acdc-cli[acdc-cli] - AsciiDoc processor (CLI)
 * link:./acdc-editor-wasm[acdc-editor-wasm] - WASM live editor with syntax highlighting and preview
-* link:./acdc-lsp[acdc-lsp] - Language Server Protocol implementation (early/experimental)
+* link:./acdc-lsp[acdc-lsp] - Language Server Protocol implementation
 * link:./acdc-parser[acdc-parser] - AsciiDoc parser library
-* link:./converters[converters] - collection of AsciiDoc converters
+* link:./converters[converters] - collection of AsciiDoc converters (HTML, manpage, markdown, terminal)
 
 == Architecture overview
 
@@ -76,8 +76,7 @@ acdc/
 
 == Known limitations
 
-* **Inline markup in code/links**: Bold/italic inside code spans and link text not parsed
-* **Cross-file references**: LSP and parser are single-file only
+* **Inline markup in link text**: `+link:url[*bold*]+` renders the asterisks literally; nested inline markup inside link text isn't parsed yet.
 
 See link:./acdc-parser/README.adoc[acdc-parser README] for detailed feature support and list handling notes.
 

--- a/acdc-cli/README.adoc
+++ b/acdc-cli/README.adoc
@@ -28,7 +28,7 @@ Options:
 
 === convert
 
-Convert `AsciiDoc` documents to various output formats (HTML, terminal).
+Convert `AsciiDoc` documents to various output formats (HTML, manpage, markdown, terminal).
 
 [source,console]
 ....
@@ -101,7 +101,7 @@ cargo build --all-features
 
 For convenience, you can use these feature groups:
 
-* `all-backends` - Enables both HTML and terminal converters
+* `all-backends` - Enables all output converters (`html`, `manpage`, `markdown`, `terminal`)
 * `dev-tools` - Enables the inspect tool
 * `test-tools` - Enables the TCK tool
 

--- a/acdc-lsp/README.md
+++ b/acdc-lsp/README.md
@@ -178,15 +178,16 @@ The server works with any file your editor sends it. Configure your editor to re
 
 ### Go-to-definition not working
 
-The target must exist in the same document. Cross-file navigation isn't supported yet.
+The target must exist either in the current document or in another AsciiDoc file reachable from the workspace root. Valid targets:
 
-Valid targets:
 - Section IDs: `[[my-section]]` or auto-generated from section titles
 - Inline anchors: `[[anchor-id]]`
+- Bibliography anchors: `[[[entry,label]]]`
+
+Cross-file resolution uses the workspace index in `src/state/workspace.rs`, which scans open documents and on-disk `.adoc` files under the workspace root.
 
 ## Limitations
 
-- Single-file only (no cross-file references or workspace support yet)
-- Full document sync (reparsing on every change)
-- No incremental parsing
-- No code actions (quick fixes)
+- Full document sync (reparsing on every change) — incremental parsing is not yet implemented
+- The code-action catalog is small; suggestions are limited to the quick fixes currently wired up in `capabilities/code_actions.rs`
+- Cross-file navigation relies on heuristic filesystem scanning; very large workspaces may see startup cost on first open

--- a/converters/AGENTS.md
+++ b/converters/AGENTS.md
@@ -22,4 +22,9 @@ Shared utilities in `core/`:
 cargo run -p acdc-converters-html --example generate_html_fixtures --all-features
 cargo run -p acdc-converters-terminal --example generate_terminal_fixtures --all-features
 cargo run -p acdc-converters-manpage --example generate_manpage_fixtures --all-features
+
+# Markdown uses a shell script that drives the CLI (no example binary):
+bash converters/markdown/tests/regenerate_expected.sh
+# Regenerate a single fixture:
+bash converters/markdown/tests/regenerate_expected.sh <fixture_name>
 ```

--- a/converters/markdown/README.adoc
+++ b/converters/markdown/README.adoc
@@ -1,0 +1,76 @@
+= `acdc-converters-markdown`
+
+Markdown converter for `AsciiDoc` documents. Supports both https://spec.commonmark.org[CommonMark] and https://github.github.com/gfm/[GitHub Flavored Markdown] (GFM).
+
+== Usage
+
+[source,console]
+....
+acdc convert --backend markdown document.adoc
+....
+
+This generates `document.md` in the same directory as the source file.
+
+Process multiple files in parallel:
+
+[source,console]
+....
+acdc convert --backend markdown *.adoc
+....
+
+Stream from stdin to stdout:
+
+[source,console]
+....
+cat document.adoc | acdc convert --backend markdown --stdin
+....
+
+The CLI always uses the GFM variant. To produce plain CommonMark output, consume the crate as a library and call `Processor::with_variant(MarkdownVariant::CommonMark)`.
+
+== Features
+
+Supported constructs:
+
+- **Headings**: mapped to ATX (`#`, `##`, …). The document title renders as a top-level heading.
+- **Paragraphs** and inline formatting: bold, italic, monospace, strikethrough (GFM), links, autolinks, images.
+- **Lists**: ordered, unordered, description (emitted as bullet list + emphasis), task lists (GFM). Nested lists are preserved.
+- **Code blocks**: fenced with the source language when specified, plus the callout annotations stripped and rendered as trailing references.
+- **Blockquotes** and quote/verse blocks.
+- **Tables**: GFM tables with column alignment. Skipped with a warning in CommonMark mode.
+- **Admonitions** (NOTE, TIP, IMPORTANT, WARNING, CAUTION): GitHub Alerts (`> [!NOTE]`) in GFM; plain blockquotes with a bold label in CommonMark.
+- **Footnotes**: GFM footnote syntax (`[^1]`) with the footnote bodies collected at document end; HTML superscript fallback in CommonMark.
+- **Images / videos / audio**: images render natively; video and audio degrade to links with a warning.
+- **Thematic breaks** and page breaks (rendered as `---`).
+
+== Limitations
+
+Some `AsciiDoc` features have no faithful Markdown equivalent. When the converter hits one of these, it emits a `tracing::warn!` message and falls back:
+
+- **Include directives** - not expanded at render time (the preprocessor handles them before conversion).
+- **Substitution control** (`subs=...`) - no way to express this in Markdown.
+- **Callouts inside source blocks** - Markdown has no native equivalent; rendered as plain text.
+- **Table cell spanning** (`2+|`, `.2+|`) - GFM tables are single-cell only.
+- **Complex tables** (nested, AsciiDoc-content cells) - flattened to the extent possible.
+- **Arbitrary block metadata** (roles, options) - dropped.
+
+See the crate's `src/lib.rs` module docs for the full list.
+
+== Building
+
+Enable the `markdown` feature when building the CLI:
+
+[source,console]
+....
+cargo build --features markdown -p acdc-cli
+....
+
+== Regenerating fixtures
+
+Markdown fixtures live in `tests/fixtures/source/` (inputs) and `tests/fixtures/expected/` (golden outputs). To regenerate after making converter changes:
+
+[source,console]
+....
+bash converters/markdown/tests/regenerate_expected.sh
+# or for a single fixture:
+bash converters/markdown/tests/regenerate_expected.sh <fixture_name>
+....


### PR DESCRIPTION
- README.adoc: drop stale "Cross-file references single-file only"
  limitation (LSP now has a workspace-scoped xref index), narrow the
  remaining limitation bullet to link text, drop "early/experimental"
  on the LSP, add markdown to the converters tagline.
- ARCHITECTURE.adoc: three → four converters (markdown added), add
  markdown/ and acdc-editor-wasm/ to the module tree, move WASM and
  LSP out of Future directions into a new "Already shipped" section
  with the current LSP capability list, update fixture count from
  "over 115" to "over 280", add an Incremental parsing item.
- acdc-cli/README.adoc: all-backends enables html/manpage/markdown/
  terminal (not just html+terminal); convert subcommand blurb lists
  all four formats.
- acdc-lsp/README.md: replace "Single-file only / no workspace
  support" with an accurate description of cross-file resolution via
  src/state/workspace.rs.
- converters/markdown/README.adoc: new file mirroring the other
  converter READMEs; documents GFM vs CommonMark, supported
  constructs, limitations, and the regenerate_expected.sh fixture
  script.
- converters/AGENTS.md: add the markdown fixture regen command.
- CONTRIBUTING.md: link to acdc-lsp/README, acdc-editor-wasm/README,
  and converters/README so contributors can find all sub-crate docs.