### PR TITLE
feat(html,terminal): animated [terminal%replay] blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - **Always `--all-features`**: all test/build/clippy commands
 - **Clippy pedantic**: `cargo clippy --all-targets --all-features -- --deny clippy::pedantic`
 - **Format before committing**: `cargo fmt --all`
+- **Compact imports**: merge imports from the same crate/module into one `use` with braces, e.g. `use std::{borrow::Cow, io::Write};` — not separate `use std::borrow::Cow;` / `use std::io::Write;` lines
 - **Update changelogs**: each crate has its own `CHANGELOG.md`; update `[Unreleased]` for affected crates
 - **Surface converter warnings structurally**: user-relevant converter warnings should use `Warning` / `Diagnostics`, not `tracing::warn!`
 - **Never use CLI for fixtures**: use the examples directly (CLI adds `last_updated` timestamps)

--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   colors follow the document `:dark-mode:` setting. This is an acdc-only block
   style: Asciidoctor treats `[terminal]` as a plain listing or literal block
   and emits the raw text (including any ANSI escape sequences) unrendered.
+- Feature-gated `[terminal%replay]` blocks render pre-recorded ANSI output as
+  an animated HTML replay. Replay blocks require explicit `cols`/`rows`
+  dimensions, support a `replay-duration-ms` playback override, never execute
+  commands, and fall back to a static terminal preview (with a warning) when
+  dimensions are missing or invalid. Playback scales to long recordings with
+  compact output and ends on the final frame. Like `[terminal]`, this is an
+  acdc-only block style that Asciidoctor renders as raw text.
 - User-facing converter warnings are now collected in `ConversionResult` for
   recoverable HTML conversion issues such as deprecated roles, docinfo option
   fallbacks, and stylesheet read/write failures.

--- a/converters/html/Cargo.toml
+++ b/converters/html/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [features]
 default = ["pre-spec-subs"]
 # Asciidoctor-compatible subs= attribute. Experimental - may be removed when AsciiDoc spec finalizes.
-pre-spec-subs = ["acdc-parser/pre-spec-subs"]
+pre-spec-subs = ["acdc-parser/pre-spec-subs", "acdc-converters-core/pre-spec-subs"]
 # Enable syntax highlighting for source blocks using syntect
 highlighting = ["dep:syntect"]
 # Render terminal-converter output into selectable HTML via libghostty-vt.

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -213,8 +213,14 @@ render paths:
   `:terminal-preview:` document attribute is not required.
 
 This is an acdc-only extension; Asciidoctor does not provide a
-`:terminal-preview:` attribute, a `[terminal]` block style, or equivalent
-built-in terminal preview feature.
+`:terminal-preview:` attribute, the `[terminal]` or `[terminal%replay]` block
+styles, or any equivalent built-in terminal preview or replay feature.
+
+NOTE: Terminal rendering is built directly into the HTML converter — the
+`terminal` Cargo feature of `acdc-converters-html`, backed by the
+`acdc-converters-terminal` crate — rather than being loaded as a plug-in. If
+acdc grows a first-class extension mechanism, this functionality may migrate to
+an extension instead of being compiled into the converter.
 
 Use `:terminal-preview:` when existing source blocks should look like terminal
 examples:
@@ -254,9 +260,31 @@ done
 The terminal session content is interpreted as terminal output, including ANSI
 escape sequences, and rendered as selectable styled HTML.
 
-`[terminal]` is an acdc-only block style. Asciidoctor renders it as a plain
-listing or literal block with the raw text (ANSI escapes included) left as-is,
-so documents that rely on it will not render the same under asciidoctor.
+Use `[terminal%replay]` when the block contains pre-recorded ANSI output that
+should be animated in HTML:
+
+[source,asciidoc]
+....
+[terminal%replay,cols=80,rows=24]
+----
+\x1b[32mDownloading\x1b[0m
+\x1b[32mComplete\x1b[0m
+----
+....
+
+Terminal replay is replay-only. acdc treats the block as recorded terminal
+data and does not execute commands, shells, scripts, VHS tapes, or other
+recording formats. Replay blocks require explicit terminal dimensions via
+`cols`/`rows` block attributes or `:terminal-cols:`/`:terminal-rows:`
+document attributes; invalid or missing dimensions fall back to a static
+terminal preview with a structured warning. Dense recordings are sampled so the
+generated HTML stays small even for long output, and playback ends on the final
+frame.
+
+`[terminal]` and `[terminal%replay]` are acdc-only block styles. Asciidoctor
+renders them as a plain listing or literal block with the raw text (ANSI escapes
+included) left as-is, so documents that rely on them will not render the same
+under asciidoctor.
 
 [cols="1,2", options="header"]
 |===
@@ -279,6 +307,12 @@ so documents that rely on it will not render the same under asciidoctor.
 
 | `[terminal,rows=N]`
 | Overrides the terminal grid height for one explicit terminal session block. When unset, acdc derives the height from the content.
+
+| `[terminal%replay,cols=N,rows=N]`
+| Renders pre-recorded ANSI terminal output as an animated replay. Replay blocks require fixed dimensions and never execute commands or recording files.
+
+| `[terminal%replay,replay-duration-ms=N]`
+| Overrides the generated replay's total playback duration in milliseconds.
 |===
 
 #### Syntax highlighting CSS

--- a/converters/html/samples/nextest_replay.adoc
+++ b/converters/html/samples/nextest_replay.adoc
@@ -1,0 +1,1531 @@
+= Nextest Replay Sample
+:author: ACDC
+:toc:
+
+This sample replays a captured `cargo nextest run --all-features --color always` run from this repository.
+The captured output includes Cargo output plus nextest output with ANSI color enabled. The visible run took about `3.230s` (`0.26s` Cargo + `2.970s` nextest summary), so `replay-duration-ms=1615` plays it back at 2x speed.
+
+The replay block contains recorded terminal output only. acdc does not execute commands while rendering this sample.
+
+[terminal%replay,cols=180,rows=40,replay-duration-ms=1615]
+----
+[1m[92m    Finished[0m ]8;;https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles\`test` profile [unoptimized + debuginfo]]8;;\ target(s) in 0.26s
+────────────
+[32;1m Nextest run[0m ID [1m8befcce5-42f3-4f72-89a1-f2f824b27cf7[0m with nextest profile: [1mdefault[0m
+[32;1m    Starting[0m [1m1513[0m tests across [1m18[0m binaries
+[32;1m        PASS[0m [   0.011s] (   1/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_to_upper_roman[0m
+[32;1m        PASS[0m [   0.017s] (   2/1513) [35;1macdc-cli::bin/acdc[0m [36msubcommands::convert::tests[0m[36m::[0m[34;1mskips_stdout_output[0m
+[32;1m        PASS[0m [   0.017s] (   3/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_appendix_tracker_resets_section_counters[0m
+[32;1m        PASS[0m [   0.019s] (   4/1513) [35;1macdc-cli::bin/acdc[0m [36msubcommands::convert::tests[0m[36m::[0m[34;1mskips_when_conversion_produced_no_file[0m
+[32;1m        PASS[0m [   0.019s] (   5/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_to_upper_roman_zero[0m
+[32;1m        PASS[0m [   0.021s] (   6/1513) [35;1macdc-cli::bin/acdc[0m [36msubcommands::convert::tests[0m[36m::[0m[34;1mopens_dynamic_manpage_style_output_path[0m
+[32;1m        PASS[0m [   0.023s] (   7/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_appendix_tracker_custom_caption[0m
+[32;1m        PASS[0m [   0.026s] (   8/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_part_tracker_with_signifier[0m
+[32;1m        PASS[0m [   0.026s] (   9/1513) [35;1macdc-converters-core[0m [36mdoctype::tests[0m[36m::[0m[34;1mtest_from_str[0m
+[32;1m        PASS[0m [   0.027s] (  10/1513) [35;1macdc-cli::bin/acdc[0m [36msubcommands::convert::tests[0m[36m::[0m[34;1mopens_reported_path_for_explicit_output_file[0m
+[32;1m        PASS[0m [   0.028s] (  11/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_part_tracker_resets_section_counters[0m
+[32;1m        PASS[0m [   0.028s] (  12/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_part_tracker_disabled_without_partnums[0m
+[32;1m        PASS[0m [   0.018s] (  13/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_clone_shares_state[0m
+[32;1m        PASS[0m [   0.030s] (  14/1513) [35;1macdc-converters-core[0m [36mdoctype::tests[0m[36m::[0m[34;1mtest_default[0m
+[32;1m        PASS[0m [   0.032s] (  15/1513) [35;1macdc-converters-core[0m [36mdoctype::tests[0m[36m::[0m[34;1mtest_display[0m
+[32;1m        PASS[0m [   0.016s] (  16/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_custom_sectnumlevels[0m
+[32;1m        PASS[0m [   0.035s] (  17/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_part_tracker_enabled_no_signifier[0m
+[32;1m        PASS[0m [   0.035s] (  18/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_appendix_tracker_default_caption[0m
+[32;1m        PASS[0m [   0.017s] (  19/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_disabled_by_default[0m
+[32;1m        PASS[0m [   0.017s] (  20/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_high_levels[0m
+[32;1m        PASS[0m [   0.016s] (  21/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_level_zero_returns_none[0m
+[32;1m        PASS[0m [   0.012s] (  22/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_respects_max_level[0m
+[32;1m        PASS[0m [   0.013s] (  23/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_reset[0m
+[32;1m        PASS[0m [   0.015s] (  24/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_resets_deeper_levels[0m
+[32;1m        PASS[0m [   0.025s] (  25/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_disabled_returns_none[0m
+[32;1m        PASS[0m [   0.045s] (  26/1513) [35;1macdc-cli::bin/acdc[0m [36msubcommands::convert::tests[0m[36m::[0m[34;1mopens_reported_paths_for_derived_outputs[0m
+[32;1m        PASS[0m [   0.015s] (  27/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_all_replacements_combined[0m
+[32;1m        PASS[0m [   0.026s] (  28/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_increments_correctly[0m
+[32;1m        PASS[0m [   0.017s] (  29/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_apostrophe_contraction[0m
+[32;1m        PASS[0m [   0.049s] (  30/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_appendix_tracker_disabled_caption[0m
+[32;1m        PASS[0m [   0.022s] (  31/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_sectnumlevels_zero_disables[0m
+[32;1m        PASS[0m [   0.018s] (  32/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_apostrophe_digit_after_not_converted[0m
+[32;1m        PASS[0m [   0.021s] (  33/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_apostrophe_decade[0m
+[32;1m        PASS[0m [   0.018s] (  34/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_arrow_left[0m
+[32;1m        PASS[0m [   0.031s] (  35/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_numbered_alias_enables_sectnums[0m
+[32;1m        PASS[0m [   0.020s] (  36/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_arrow_right[0m
+[32;1m        PASS[0m [   0.014s] (  37/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_ellipsis[0m
+[32;1m        PASS[0m [   0.012s] (  38/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_at_start[0m
+[32;1m        PASS[0m [   0.027s] (  39/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_apostrophe_escaped[0m
+[32;1m        PASS[0m [   0.023s] (  40/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_copyright[0m
+[32;1m        PASS[0m [   0.018s] (  41/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_at_end[0m
+[32;1m        PASS[0m [   0.030s] (  42/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_apostrophe_quotes_not_converted[0m
+[32;1m        PASS[0m [   0.016s] (  43/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_inline_span_leading[0m
+[32;1m        PASS[0m [   0.023s] (  44/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_double_arrow_right[0m
+[32;1m        PASS[0m [   0.026s] (  45/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_double_arrow_before_single[0m
+[32;1m        PASS[0m [   0.027s] (  46/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_double_arrow_left[0m
+[32;1m        PASS[0m [   0.017s] (  47/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_inline_span_trailing[0m
+[32;1m        PASS[0m [   0.021s] (  48/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_inline_span_spaced_middle[0m
+[32;1m        PASS[0m [   0.013s] (  49/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_no_match_trailing[0m
+[32;1m        PASS[0m [   0.014s] (  50/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_no_match_right_space[0m
+[32;1m        PASS[0m [   0.038s] (  51/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_caret_escape_preserved[0m
+[32;1m        PASS[0m [   0.013s] (  52/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_word_bounded[0m
+[32;1m        PASS[0m [   0.032s] (  53/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_digit_bounded[0m
+[32;1m        PASS[0m [   0.020s] (  54/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_no_match_left_space[0m
+[32;1m        PASS[0m [   0.057s] (  55/1513) [35;1macdc-converters-core[0m [36msection::tests[0m[36m::[0m[34;1mtest_tracker_nested_numbering[0m
+[32;1m        PASS[0m [   0.018s] (  56/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_spaced[0m
+[32;1m        PASS[0m [   0.017s] (  57/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_full_pipeline_with_escapes[0m
+[32;1m        PASS[0m [   0.030s] (  58/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_inline_span_word_bounded[0m
+[32;1m        PASS[0m [   0.012s] (  59/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_roundtrip_arrows[0m
+[32;1m        PASS[0m [   0.014s] (  60/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_roundtrip_escape_restore[0m
+[32;1m        PASS[0m [   0.029s] (  61/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_no_match_leading[0m
+[32;1m        PASS[0m [   0.010s] (  62/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_tilde_escape_preserved[0m
+[32;1m        PASS[0m [   0.018s] (  63/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_restore_escaped_patterns[0m
+[32;1m        PASS[0m [   0.016s] (  64/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_strip_pattern_escapes[0m
+[32;1m        PASS[0m [   0.023s] (  65/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_registered[0m
+[32;1m        PASS[0m [   0.032s] (  66/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_triple_dash_no_match[0m
+[32;1m        PASS[0m [   0.020s] (  67/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_strip_other_escapes[0m
+[32;1m        PASS[0m [   0.046s] (  68/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_em_dash_inline_span_standalone[0m
+[32;1m        PASS[0m [   0.032s] (  69/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_empty_and_no_escapes[0m
+[32;1m        PASS[0m [   0.021s] (  70/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_trademark[0m
+[32;1m        PASS[0m [   0.020s] (  71/1513) [35;1macdc-converters-core[0m [36mtable::tests::grid[0m[36m::[0m[34;1mtest_combined_span[0m
+[32;1m        PASS[0m [   0.013s] (  72/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_auto_with_percentage_over_100[0m
+[32;1m        PASS[0m [   0.019s] (  73/1513) [35;1macdc-converters-core[0m [36mtable::tests::grid[0m[36m::[0m[34;1mtest_rowspan[0m
+[32;1m        PASS[0m [   0.016s] (  74/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_all_auto_no_normalization[0m
+[32;1m        PASS[0m [   0.025s] (  75/1513) [35;1macdc-converters-core[0m [36mtable::tests::grid[0m[36m::[0m[34;1mtest_colspan[0m
+[32;1m        PASS[0m [   0.015s] (  76/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_complex_proportional[0m
+[32;1m        PASS[0m [   0.024s] (  77/1513) [35;1macdc-converters-core[0m [36mtable::tests::grid[0m[36m::[0m[34;1mtest_no_spans[0m
+[32;1m        PASS[0m [   0.013s] (  78/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_percentage_over_100_normalized[0m
+[32;1m        PASS[0m [   0.015s] (  79/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_percentage_under_100_normalized[0m
+[32;1m        PASS[0m [   0.047s] (  80/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_no_replacements[0m
+[32;1m        PASS[0m [   0.045s] (  81/1513) [35;1macdc-converters-core[0m [36msubstitutions::tests[0m[36m::[0m[34;1mtest_preserves_other_backslashes[0m
+[32;1m        PASS[0m [   0.015s] (  82/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_proportional_widths[0m
+[32;1m        PASS[0m [   0.012s] (  83/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_local_video_url_basic[0m
+[32;1m        PASS[0m [   0.010s] (  84/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_local_video_url_with_start[0m
+[32;1m        PASS[0m [   0.023s] (  85/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_percentage_exact_100_unchanged[0m
+[32;1m        PASS[0m [   0.016s] (  86/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_local_video_url_embed_returns_same_as_watch[0m
+[32;1m        PASS[0m [   0.011s] (  87/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_vimeo_embed_url_with_all_options[0m
+[32;1m        PASS[0m [   0.034s] (  88/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_auto_widths[0m
+[32;1m        PASS[0m [   0.040s] (  89/1513) [35;1macdc-converters-core[0m [36mtable::tests::grid[0m[36m::[0m[34;1mtest_footer_flag[0m
+[32;1m        PASS[0m [   0.018s] (  90/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_local_video_url_with_start_and_end[0m
+[32;1m        PASS[0m [   0.017s] (  91/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_vimeo_embed_url_basic[0m
+[32;1m        PASS[0m [   0.011s] (  92/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_vimeo_watch_url_with_start[0m
+[32;1m        PASS[0m [   0.012s] (  93/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_youtube_embed_url_basic[0m
+[32;1m        PASS[0m [   0.031s] (  94/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_percentage_widths[0m
+[32;1m        PASS[0m [   0.017s] (  95/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_vimeo_embed_url_with_loop_only[0m
+[32;1m        PASS[0m [   0.029s] (  96/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_both_youtube_and_vimeo_defaults_to_local[0m
+[32;1m        PASS[0m [   0.030s] (  97/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_empty_sources_returns_error[0m
+[32;1m        PASS[0m [   0.043s] (  98/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_equal_proportional_widths[0m
+[32;1m        PASS[0m [   0.045s] (  99/1513) [35;1macdc-converters-core[0m [36mtable::tests[0m[36m::[0m[34;1mtest_empty_columns[0m
+[32;1m        PASS[0m [   0.017s] ( 100/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_youtube_embed_url_with_all_params[0m
+[32;1m        PASS[0m [   0.025s] ( 101/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_vimeo_embed_url_with_autoplay_only[0m
+[32;1m        PASS[0m [   0.020s] ( 102/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_youtube_watch_url_basic[0m
+[32;1m        PASS[0m [   0.021s] ( 103/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_youtube_watch_url_with_start_and_end[0m
+[32;1m        PASS[0m [   0.019s] ( 104/1513) [35;1macdc-converters-html[0m [36mconstants::tests[0m[36m::[0m[34;1mtest_escape_ampersands_decimal_ncr[0m
+[32;1m        PASS[0m [   0.017s] ( 105/1513) [35;1macdc-converters-html[0m [36mconstants::tests[0m[36m::[0m[34;1mtest_escape_ampersands_edge_cases[0m
+[32;1m        PASS[0m [   0.029s] ( 106/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_youtube_embed_url_with_autoplay_only[0m
+[32;1m        PASS[0m [   0.018s] ( 107/1513) [35;1macdc-converters-html[0m [36mconstants::tests[0m[36m::[0m[34;1mtest_escape_ampersands_hex_ncr[0m
+[32;1m        PASS[0m [   0.028s] ( 108/1513) [35;1macdc-converters-html[0m [36mconstants::tests[0m[36m::[0m[34;1mtest_encode_html_entities[0m
+[32;1m        PASS[0m [   0.022s] ( 109/1513) [35;1macdc-converters-html[0m [36mconstants::tests[0m[36m::[0m[34;1mtest_escape_ampersands_invalid_entities[0m
+[32;1m        PASS[0m [   0.040s] ( 110/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_vimeo_watch_url_basic[0m
+[32;1m        PASS[0m [   0.020s] ( 111/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_example_block_collapsible[0m
+[32;1m        PASS[0m [   0.037s] ( 112/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_youtube_embed_url_with_loop_only[0m
+[32;1m        PASS[0m [   0.019s] ( 113/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_example_block_with_id_and_role[0m
+[32;1m        PASS[0m [   0.023s] ( 114/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_example_block_collapsible_without_title[0m
+[32;1m        PASS[0m [   0.030s] ( 115/1513) [35;1macdc-converters-html[0m [36mconstants::tests[0m[36m::[0m[34;1mtest_escape_ampersands_named_entities[0m
+[32;1m        PASS[0m [   0.042s] ( 116/1513) [35;1macdc-converters-core[0m [36mvideo::tests[0m[36m::[0m[34;1mtest_youtube_watch_url_with_start[0m
+[32;1m        PASS[0m [   0.026s] ( 117/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_block_renders_as_listingblock[0m
+[32;1m        PASS[0m [   0.045s] ( 118/1513) [35;1macdc-converters-html[0m [36mconstants::tests[0m[36m::[0m[34;1mtest_escape_ampersands_bare[0m
+[32;1m        PASS[0m [   0.022s] ( 119/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_literal_block_renders_as_literalblock[0m
+[32;1m        PASS[0m [   0.038s] ( 120/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_block_with_anchor_fallback[0m
+[32;1m        PASS[0m [   0.038s] ( 121/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_example_block_collapsible_open[0m
+[32;1m        PASS[0m [   0.032s] ( 122/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_block_without_listing_caption_renders_title_without_number[0m
+[32;1m        PASS[0m [   0.037s] ( 123/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_block_with_listing_caption_renders_title_with_number[0m
+[32;1m        PASS[0m [   0.041s] ( 124/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_block_with_id_and_role[0m
+[32;1m        PASS[0m [   0.031s] ( 125/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_open_block_with_id_and_role[0m
+[32;1m        PASS[0m [   0.031s] ( 126/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_literal_block_with_style_attribute[0m
+[32;1m        PASS[0m [   0.031s] ( 127/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_quote_block_with_id_and_role[0m
+[32;1m        PASS[0m [   0.034s] ( 128/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mdocinfo_filename_private_head[0m
+[32;1m        PASS[0m [   0.022s] ( 129/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mparse_comma_separated_combination[0m
+[32;1m        PASS[0m [   0.043s] ( 130/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_block_with_source_style_and_language[0m
+[32;1m        PASS[0m [   0.024s] ( 131/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mdocinfo_filename_shared_footer[0m
+[32;1m        PASS[0m [   0.027s] ( 132/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mdocinfo_filename_private_no_docname[0m
+[32;1m        PASS[0m [   0.028s] ( 133/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mdocinfo_filename_shared_header[0m
+[32;1m        PASS[0m [   0.028s] ( 134/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mdocinfo_filename_shared_head[0m
+[32;1m        PASS[0m [   0.019s] ( 135/1513) [35;1macdc-converters-html[0m [36minlines::tests[0m[36m::[0m[34;1mapostrophe_digit_after_not_converted[0m
+[32;1m        PASS[0m [   0.028s] ( 136/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mparse_granular_values[0m
+[32;1m        PASS[0m [   0.022s] ( 137/1513) [35;1macdc-converters-html[0m [36minlines::tests[0m[36m::[0m[34;1mapostrophe_decade[0m
+[32;1m        PASS[0m [   0.049s] ( 138/1513) [35;1macdc-converters-html[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_sidebar_block_with_id_and_role[0m
+[32;1m        PASS[0m [   0.032s] ( 139/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mparse_shared_expands_all_positions[0m
+[32;1m        PASS[0m [   0.034s] ( 140/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mparse_private_expands_all_positions[0m
+[32;1m        PASS[0m [   0.036s] ( 141/1513) [35;1macdc-converters-html[0m [36mdocinfo::tests[0m[36m::[0m[34;1mparse_unknown_value_ignored[0m
+[32;1m        PASS[0m [   0.021s] ( 142/1513) [35;1macdc-converters-html[0m [36minlines::tests[0m[36m::[0m[34;1mapostrophe_escaped_contraction[0m
+[32;1m        PASS[0m [   0.023s] ( 143/1513) [35;1macdc-converters-html[0m [36minlines::tests[0m[36m::[0m[34;1mapostrophe_escaped_stripped[0m
+[32;1m        PASS[0m [   0.024s] ( 144/1513) [35;1macdc-converters-html[0m [36minlines::tests[0m[36m::[0m[34;1mapostrophe_quotes_around_word[0m
+[32;1m        PASS[0m [   0.027s] ( 145/1513) [35;1macdc-converters-html[0m [36minlines::tests[0m[36m::[0m[34;1mapostrophe_in_contraction[0m
+[32;1m        PASS[0m [   0.021s] ( 146/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_class_mode_with_callouts[0m
+[32;1m        PASS[0m [   0.032s] ( 147/1513) [35;1macdc-converters-html[0m [36minlines::tests[0m[36m::[0m[34;1mapostrophe_escape_outside_word_context_preserved[0m
+[32;1m        PASS[0m [   0.028s] ( 148/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_extract_text_and_callouts_from_verbatim[0m
+[32;1m        PASS[0m [   0.027s] ( 149/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_extract_text_and_callouts_with_callouts[0m
+[32;1m        PASS[0m [   0.031s] ( 150/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_class_mode_produces_class_spans[0m
+[32;1m        PASS[0m [   0.023s] ( 151/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_css_unknown_theme_errors[0m
+[32;1m        PASS[0m [   0.023s] ( 152/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_unknown_language_fallback[0m
+[32;1m        PASS[0m [   0.022s] ( 153/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mauto_rows_follow_content_height_with_padding[0m
+[32;1m        PASS[0m [   0.025s] ( 154/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_rust_code[0m
+[32;1m        PASS[0m [   0.035s] ( 155/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_css_custom_theme[0m
+[32;1m        PASS[0m [   0.025s] ( 156/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mskips_terminal_preview_without_attribute[0m
+[32;1m        PASS[0m [   0.043s] ( 157/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_css_generates_stylesheet[0m
+[32;1m        PASS[0m [   0.047s] ( 158/1513) [35;1macdc-converters-html[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_code_with_callouts[0m
+[32;1m        PASS[0m [   0.043s] ( 159/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mescapes_terminal_text[0m
+[32;1m        PASS[0m [   0.041s] ( 160/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mliteral_terminal_session_block_renders_as_terminal_preview[0m
+[32;1m        PASS[0m [   0.047s] ( 161/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mdark_mode_uses_dark_terminal_preview_theme[0m
+[32;1m        PASS[0m [   0.046s] ( 162/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mlinkcss_uses_built_in_stylesheet_for_terminal_preview_styles[0m
+[32;1m        PASS[0m [   0.021s] ( 163/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mname_reflects_current_variant[0m
+[32;1m        PASS[0m [   0.044s] ( 164/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1msemantic_terminal_session_block_uses_semantic_wrapper[0m
+[32;1m        PASS[0m [   0.047s] ( 165/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1msemantic_html_can_include_selectable_terminal_preview[0m
+[32;1m        PASS[0m [   0.018s] ( 166/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mnew_defaults_to_standard[0m
+[32;1m        PASS[0m [   0.019s] ( 167/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_appendix_custom_caption[0m
+[32;1m        PASS[0m [   0.019s] ( 168/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_appendix_disabled_caption[0m
+[32;1m        PASS[0m [   0.052s] ( 169/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mstandard_html_can_include_selectable_terminal_preview[0m
+[32;1m        PASS[0m [   0.050s] ( 170/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mterminal_preview_preserves_syntax_colors[0m
+[32;1m        PASS[0m [   0.045s] ( 171/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mterminal_replay_requires_explicit_dimensions[0m
+[32;1m        PASS[0m [   0.047s] ( 172/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mterminal_replay_block_renders_multiple_frames[0m
+[32;1m        PASS[0m [   0.019s] ( 173/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_appendix_level0_demoted_to_sect1[0m
+[32;1m        PASS[0m [   0.054s] ( 174/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mterminal_replay_accepts_playback_duration_override[0m
+[32;1m        PASS[0m [   0.020s] ( 175/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_appendix_toc_entries[0m
+[32;1m        PASS[0m [   0.022s] ( 176/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_book_doctype_body_class[0m
+[32;1m        PASS[0m [   0.049s] ( 177/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mterminal_session_options_layer_block_dimensions_over_document_dimensions[0m
+[32;1m        PASS[0m [   0.020s] ( 178/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_book_with_parts[0m
+[32;1m        PASS[0m [   0.021s] ( 179/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_book_toc_includes_parts[0m
+[32;1m        PASS[0m [   0.052s] ( 180/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mterminal_session_block_does_not_require_preview_attribute[0m
+[32;1m        PASS[0m [   0.018s] ( 181/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_dark_mode_unset_no_dark_css[0m
+[32;1m        PASS[0m [   0.018s] ( 182/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_dark_mode_includes_dark_css_and_meta[0m
+[32;1m        PASS[0m [   0.020s] ( 183/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_convert_to_string_embedded_no_document_frame[0m
+[32;1m        PASS[0m [   0.057s] ( 184/1513) [35;1macdc-converters-html[0m [36mterminal_preview::tests[0m[36m::[0m[34;1mterminal_session_block_uses_block_dimensions[0m
+[32;1m        PASS[0m [   0.023s] ( 185/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_default_no_dark_css[0m
+[32;1m        PASS[0m [   0.020s] ( 186/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_section_numbering_nested[0m
+[32;1m        PASS[0m [   0.020s] ( 187/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_light_mode_no_dark_css[0m
+[32;1m        PASS[0m [   0.022s] ( 188/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_section_numbering_disabled_by_default[0m
+[32;1m        PASS[0m [   0.023s] ( 189/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_section_numbering_respects_sectnumlevels[0m
+[32;1m        PASS[0m [   0.025s] ( 190/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_section_numbering_enabled[0m
+[32;1m        PASS[0m [   0.022s] ( 191/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_toc_unnumbered_sections_skipped[0m
+[32;1m        PASS[0m [   0.022s] ( 192/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mwith_variant_switches_to_semantic[0m
+[32;1m        PASS[0m [   0.024s] ( 193/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_toc_section_numbers_disabled[0m
+[32;1m        PASS[0m [   0.025s] ( 194/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_unnumbered_section_styles[0m
+[32;1m        PASS[0m [   0.029s] ( 195/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_toc_section_numbers_enabled[0m
+[32;1m        PASS[0m [   0.024s] ( 196/1513) [35;1macdc-converters-html::integration_test[0m [36mcopycss[0m[36m::[0m[34;1membedded_mode_skips_copycss[0m
+[32;1m        PASS[0m [   0.023s] ( 197/1513) [35;1macdc-converters-html::integration_test[0m [36mcopycss[0m[36m::[0m[34;1mno_stylesheet_mode_skips_copycss[0m
+[32;1m        PASS[0m [   0.031s] ( 198/1513) [35;1macdc-converters-html[0m [36mtests[0m[36m::[0m[34;1mtest_toc_nested_numbering[0m
+[32;1m        PASS[0m [   0.030s] ( 199/1513) [35;1macdc-converters-html::integration_test[0m [34;1mdeprecated_role_warning_is_returned_in_conversion_result[0m
+[32;1m        PASS[0m [   0.035s] ( 200/1513) [35;1macdc-converters-html::integration_test[0m [36mcopycss[0m[36m::[0m[34;1mlinkcss_with_default_stylesheet_writes_builtin_css[0m
+[32;1m        PASS[0m [   0.022s] ( 201/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mgranular_shared_head_only[0m
+[32;1m        PASS[0m [   0.032s] ( 202/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mattribute_substitution_in_docinfo[0m
+[32;1m        PASS[0m [   0.022s] ( 203/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mdocinfo_bare_attribute_defaults_to_private[0m
+[32;1m        PASS[0m [   0.043s] ( 204/1513) [35;1macdc-converters-html::integration_test[0m [36mcopycss[0m[36m::[0m[34;1mcopycss_value_used_as_source_path[0m
+[32;1m        PASS[0m [   0.020s] ( 205/1513) [35;1macdc-converters-html::integration_test[0m [36mstylesheet_modes[0m[36m::[0m[34;1mdefault_mode_includes_embedded_css[0m
+[32;1m        PASS[0m [   0.017s] ( 206/1513) [35;1macdc-converters-html::integration_test[0m [36mstylesheet_modes[0m[36m::[0m[34;1mlinkcss_mode_links_stylesheet[0m
+[32;1m        PASS[0m [   0.018s] ( 207/1513) [35;1macdc-converters-html::integration_test[0m [36mstylesheet_modes[0m[36m::[0m[34;1mno_stylesheet_mode_preserves_font_awesome[0m
+[32;1m        PASS[0m [   0.016s] ( 208/1513) [35;1macdc-converters-html::integration_test[0m [36mstylesheet_modes[0m[36m::[0m[34;1mno_stylesheet_mode_preserves_mathjax[0m
+[32;1m        PASS[0m [   0.018s] ( 209/1513) [35;1macdc-converters-html::integration_test[0m [36mstylesheet_modes[0m[36m::[0m[34;1mno_stylesheet_mode_suppresses_css_and_fonts[0m
+[32;1m        PASS[0m [   0.018s] ( 210/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1mattribute_substitution_applied_with_highlighting[0m
+[32;1m        PASS[0m [   0.044s] ( 211/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1membedded_mode_skips_docinfo[0m
+[32;1m        PASS[0m [   0.040s] ( 212/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mmissing_file_no_error[0m
+[32;1m        PASS[0m [   0.017s] ( 213/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1mclass_mode_embeds_css_in_head[0m
+[32;1m        PASS[0m [   0.018s] ( 214/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1mclass_mode_produces_class_spans[0m
+[32;1m        PASS[0m [   0.046s] ( 215/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mprivate_footer_docinfo_injected[0m
+[32;1m        PASS[0m [   0.039s] ( 216/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mshared_head_docinfo_injected[0m
+[32;1m        PASS[0m [   0.050s] ( 217/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mdocinfodir_overrides_source_dir[0m
+[32;1m        PASS[0m [   0.039s] ( 218/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mshared_footer_docinfo_injected[0m
+[32;1m        PASS[0m [   0.043s] ( 219/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mprivate_head_docinfo_injected[0m
+[32;1m        PASS[0m [   0.043s] ( 220/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mprivate_header_docinfo_injected[0m
+[32;1m        PASS[0m [   0.044s] ( 221/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1msecure_safe_mode_disables_docinfo[0m
+[32;1m        PASS[0m [   0.040s] ( 222/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mshared_header_docinfo_injected[0m
+[32;1m        PASS[0m [   0.052s] ( 223/1513) [35;1macdc-converters-html::integration_test[0m [36mdocinfo[0m[36m::[0m[34;1mcombined_shared_and_private[0m
+[32;1m        PASS[0m [   0.017s] ( 224/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1mclass_mode_with_custom_theme_embeds_that_theme_css[0m
+[32;1m        PASS[0m [   0.018s] ( 225/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1mclass_mode_with_linkcss_links_stylesheet[0m
+[32;1m        PASS[0m [   0.019s] ( 226/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1mclass_mode_with_linkcss_and_stylesdir[0m
+[32;1m        PASS[0m [   0.022s] ( 227/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1minline_mode_uses_style_attributes[0m
+[32;1m        PASS[0m [   0.022s] ( 228/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1minline_mode_with_linkcss_no_syntax_link[0m
+[32;1m        PASS[0m [   0.018s] ( 229/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_07_tests_fixtures_source_html_embedded_button_macro_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 230/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_01__UP__UP_acdc_parser_fixtures_tests_description_list_followed_by_[0m
+[32;1m        PASS[0m [   0.019s] ( 231/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_08_tests_fixtures_source_html_embedded_callout_icons_font_adoc[0m
+[32;1m        PASS[0m [   0.019s] ( 232/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_11_tests_fixtures_source_html_embedded_index_catalog_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 233/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_02__UP__UP_acdc_parser_fixtures_tests_description_list_mixed_conten[0m
+[32;1m        PASS[0m [   0.026s] ( 234/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_03__UP__UP_acdc_parser_fixtures_tests_footnotes_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 235/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_12_tests_fixtures_source_html_embedded_index_catalog_not_last_adoc[0m
+[32;1m        PASS[0m [   0.028s] ( 236/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_04__UP__UP_acdc_parser_fixtures_tests_single_quoted_attribute_value[0m
+[32;1m        PASS[0m [   0.028s] ( 237/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_05__UP__UP_acdc_parser_fixtures_tests_table_multi_cell_per_line_ado[0m
+[32;1m        PASS[0m [   0.029s] ( 238/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_09_tests_fixtures_source_html_embedded_description_list_implicit_co[0m
+[32;1m        PASS[0m [   0.033s] ( 239/1513) [35;1macdc-converters-html::integration_test[0m [36msyntax_highlighting[0m[36m::[0m[34;1msyntect_style_overrides_theme[0m
+[32;1m        PASS[0m [   0.031s] ( 240/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_10_tests_fixtures_source_html_embedded_description_list_styles_adoc[0m
+[32;1m        PASS[0m [   0.032s] ( 241/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_06_tests_fixtures_source_html_embedded_book_parts_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 242/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_13_tests_fixtures_source_html_embedded_keyboard_macro_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 243/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_14_tests_fixtures_source_html_embedded_table_cell_styles_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 244/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_15_tests_fixtures_source_html_embedded_toc_auto_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 245/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_18_tests_fixtures_source_html_embedded_toc_inlines_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 246/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_17_tests_fixtures_source_html_embedded_toc_custom_class_left_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 247/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_19_tests_fixtures_source_html_embedded_toc_left_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 248/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_16_tests_fixtures_source_html_embedded_toc_custom_class_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 249/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_21_tests_fixtures_source_html_embedded_toc_right_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 250/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_20_tests_fixtures_source_html_embedded_toc_macro_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 251/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_22_tests_fixtures_source_html5s_embedded_admonition_note_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 252/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_23_tests_fixtures_source_html5s_embedded_admonition_warning_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 253/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_26_tests_fixtures_source_html5s_embedded_example_block_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 254/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_25_tests_fixtures_source_html5s_embedded_audio_untitled_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 255/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_24_tests_fixtures_source_html5s_embedded_audio_titled_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 256/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_30_tests_fixtures_source_html5s_embedded_image_self_link_label_defa[0m
+[32;1m        PASS[0m [   0.022s] ( 257/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_28_tests_fixtures_source_html5s_embedded_image_figure_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 258/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_27_tests_fixtures_source_html5s_embedded_example_collapsible_adoc[0m
+[32;1m        PASS[0m [   0.019s] ( 259/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_34_tests_fixtures_source_html5s_embedded_list_titled_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 260/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_29_tests_fixtures_source_html5s_embedded_image_self_link_label_cust[0m
+[32;1m        PASS[0m [   0.021s] ( 261/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_32_tests_fixtures_source_html5s_embedded_inline_line_through_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 262/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_33_tests_fixtures_source_html5s_embedded_inline_menu_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 263/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_31_tests_fixtures_source_html5s_embedded_inline_image_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 264/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_35_tests_fixtures_source_html5s_embedded_list_untitled_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 265/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_36_tests_fixtures_source_html5s_embedded_ordered_list_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 266/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_38_tests_fixtures_source_html5s_embedded_paragraph_untitled_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 267/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_37_tests_fixtures_source_html5s_embedded_paragraph_titled_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 268/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_40_tests_fixtures_source_html5s_embedded_section_basic_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 269/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_42_tests_fixtures_source_html5s_embedded_stem_force_asciimath_adoc[0m
+[32;1m        PASS[0m [   0.026s] ( 270/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_39_tests_fixtures_source_html5s_embedded_quote_block_with_url_citat[0m
+[32;1m        PASS[0m [   0.023s] ( 271/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_41_tests_fixtures_source_html5s_embedded_sidebar_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 272/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_43_tests_fixtures_source_html5s_embedded_stem_force_latexmath_adoc[0m
+[32;1m        PASS[0m [   0.019s] ( 273/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_standalone_with_fixtures[0m[36m::[0m[34;1mpath_1_tests_fixtures_source_html_standalone_author_attribute_overrides[0m
+[32;1m        PASS[0m [   0.025s] ( 274/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_45_tests_fixtures_source_html5s_embedded_video_titled_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 275/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_46_tests_fixtures_source_html5s_embedded_video_untitled_adoc[0m
+[32;1m        PASS[0m [   0.026s] ( 276/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_with_fixtures[0m[36m::[0m[34;1mpath_44_tests_fixtures_source_html5s_embedded_verse_block_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 277/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_standalone_with_fixtures[0m[36m::[0m[34;1mpath_4_tests_fixtures_source_html_standalone_firstname_lastname_alone_a[0m
+[32;1m        PASS[0m [   0.022s] ( 278/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_standalone_with_fixtures[0m[36m::[0m[34;1mpath_3_tests_fixtures_source_html_standalone_author_from_attribute_with[0m
+[32;1m        PASS[0m [   0.024s] ( 279/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_standalone_with_fixtures[0m[36m::[0m[34;1mpath_2_tests_fixtures_source_html_standalone_author_from_attribute_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 280/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_02__UP__UP_acdc_parser_fixtures_tests_anchor_with_spaces_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 281/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_01__UP__UP_acdc_parser_fixtures_tests_admonition_block_adoc[0m
+[32;1m        PASS[0m [   0.019s] ( 282/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_04__UP__UP_acdc_parser_fixtures_tests_delimited_block_adoc[0m
+[32;1m        PASS[0m [   0.094s] ( 283/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_html5s_standalone_with_fixtures[0m[36m::[0m[34;1mpath_1_tests_fixtures_source_html_standalone_outline_adoc[0m
+[32;1m        PASS[0m [   0.026s] ( 284/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_03__UP__UP_acdc_parser_fixtures_tests_basic_image_block_adoc[0m
+[32;1m        PASS[0m [   0.019s] ( 285/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_07__UP__UP_acdc_parser_fixtures_tests_document_title_with_bold_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 286/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_06__UP__UP_acdc_parser_fixtures_tests_document_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 287/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_08__UP__UP_acdc_parser_fixtures_tests_document_title_with_inline_ma[0m
+[32;1m        PASS[0m [   0.028s] ( 288/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_05__UP__UP_acdc_parser_fixtures_tests_description_list_mixed_conten[0m
+[32;1m        PASS[0m [   0.022s] ( 289/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_10__UP__UP_acdc_parser_fixtures_tests_escaped_superscript_subscript[0m
+[32;1m        PASS[0m [   0.023s] ( 290/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_09__UP__UP_acdc_parser_fixtures_tests_document_title_with_inline_su[0m
+[32;1m        PASS[0m [   0.018s] ( 291/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_14__UP__UP_acdc_parser_fixtures_tests_link_with_bold_text_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 292/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_11__UP__UP_acdc_parser_fixtures_tests_footnotes_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 293/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_13__UP__UP_acdc_parser_fixtures_tests_image_block_attributes_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 294/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_12__UP__UP_acdc_parser_fixtures_tests_header_with_metadata_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 295/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_16__UP__UP_acdc_parser_fixtures_tests_link_with_mixed_markup_text_a[0m
+[32;1m        PASS[0m [   0.023s] ( 296/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_15__UP__UP_acdc_parser_fixtures_tests_link_with_italic_text_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 297/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_19__UP__UP_acdc_parser_fixtures_tests_link_with_whitespace_text_ado[0m
+[32;1m        PASS[0m [   0.022s] ( 298/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_20__UP__UP_acdc_parser_fixtures_tests_macros_with_quoted_attributes[0m
+[32;1m        PASS[0m [   0.024s] ( 299/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_17__UP__UP_acdc_parser_fixtures_tests_link_with_monospace_text_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 300/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_18__UP__UP_acdc_parser_fixtures_tests_link_with_passthrough_text_ad[0m
+[32;1m        PASS[0m [   0.022s] ( 301/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_22__UP__UP_acdc_parser_fixtures_tests_ordered_list_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 302/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_21__UP__UP_acdc_parser_fixtures_tests_nested_sections_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 303/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_23__UP__UP_acdc_parser_fixtures_tests_quote_block_with_paragraphs_a[0m
+[32;1m        PASS[0m [   0.023s] ( 304/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_24__UP__UP_acdc_parser_fixtures_tests_single_quoted_attribute_value[0m
+[32;1m        PASS[0m [   0.025s] ( 305/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_25__UP__UP_acdc_parser_fixtures_tests_source_block_complete_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 306/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_26__UP__UP_acdc_parser_fixtures_tests_source_block_with_attribute_i[0m
+[32;1m        PASS[0m [   0.022s] ( 307/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_27__UP__UP_acdc_parser_fixtures_tests_stem_blocks_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 308/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_30__UP__UP_acdc_parser_fixtures_tests_subs_post_replacements_disabl[0m
+[32;1m        PASS[0m [   0.023s] ( 309/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_28__UP__UP_acdc_parser_fixtures_tests_subs_callouts_disabled_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 310/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_29__UP__UP_acdc_parser_fixtures_tests_subs_callouts_explicit_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 311/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_31__UP__UP_acdc_parser_fixtures_tests_subs_post_replacements_explic[0m
+[32;1m        PASS[0m [   0.024s] ( 312/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_34__UP__UP_acdc_parser_fixtures_tests_subs_replacements_disabled_ad[0m
+[32;1m        PASS[0m [   0.020s] ( 313/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_37__UP__UP_acdc_parser_fixtures_tests_subs_specialchars_explicit_ad[0m
+[32;1m        PASS[0m [   0.029s] ( 314/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_32__UP__UP_acdc_parser_fixtures_tests_subs_quotes_disabled_adoc[0m
+[32;1m        PASS[0m [   0.026s] ( 315/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_36__UP__UP_acdc_parser_fixtures_tests_subs_specialchars_disabled_ad[0m
+[32;1m        PASS[0m [   0.033s] ( 316/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_33__UP__UP_acdc_parser_fixtures_tests_subs_quotes_explicit_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 317/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_41_tests_fixtures_source_html_embedded_admonition_font_icons_adoc[0m
+[32;1m        PASS[0m [   0.026s] ( 318/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_38__UP__UP_acdc_parser_fixtures_tests_table_multi_cell_per_line_ado[0m
+[32;1m        PASS[0m [   0.024s] ( 319/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_40__UP__UP_acdc_parser_fixtures_tests_url_macro_adoc[0m
+[32;1m        PASS[0m [   0.029s] ( 320/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_39__UP__UP_acdc_parser_fixtures_tests_unordered_list_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 321/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_42_tests_fixtures_source_html_embedded_arrow_replacements_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 322/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_43_tests_fixtures_source_html_embedded_autolink_trailing_punct_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 323/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_46_tests_fixtures_source_html_embedded_callout_icons_font_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 324/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_47_tests_fixtures_source_html_embedded_character_replacement_passth[0m
+[32;1m        PASS[0m [   0.042s] ( 325/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_35__UP__UP_acdc_parser_fixtures_tests_subs_replacements_explicit_ad[0m
+[32;1m        PASS[0m [   0.028s] ( 326/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_45_tests_fixtures_source_html_embedded_button_macro_adoc[0m
+[32;1m        PASS[0m [   0.028s] ( 327/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_44_tests_fixtures_source_html_embedded_book_parts_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 328/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_50_tests_fixtures_source_html_embedded_description_list_styles_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 329/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_52_tests_fixtures_source_html_embedded_example_collapsible_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 330/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_48_tests_fixtures_source_html_embedded_character_replacement_plus_a[0m
+[32;1m        PASS[0m [   0.027s] ( 331/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_51_tests_fixtures_source_html_embedded_escaped_character_replacemen[0m
+[32;1m        PASS[0m [   0.029s] ( 332/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_49_tests_fixtures_source_html_embedded_description_list_implicit_co[0m
+[32;1m        PASS[0m [   0.027s] ( 333/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_53_tests_fixtures_source_html_embedded_hide_uri_scheme_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 334/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_55_tests_fixtures_source_html_embedded_icon_font_packs_adoc[0m
+[32;1m        PASS[0m [   0.107s] ( 335/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_standalone_with_fixtures[0m[36m::[0m[34;1mpath_5_tests_fixtures_source_html_standalone_outline_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 336/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_57_tests_fixtures_source_html_embedded_include_with_indent_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 337/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_56_tests_fixtures_source_html_embedded_icon_font_packs_default_adoc[0m
+[32;1m        PASS[0m [   0.031s] ( 338/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_54_tests_fixtures_source_html_embedded_html_entity_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 339/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_60_tests_fixtures_source_html_embedded_keyboard_macro_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 340/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_59_tests_fixtures_source_html_embedded_index_catalog_not_last_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 341/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_63_tests_fixtures_source_html_embedded_paragraph_hardbreaks_adoc[0m
+[32;1m        PASS[0m [   0.031s] ( 342/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_58_tests_fixtures_source_html_embedded_index_catalog_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 343/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_64_tests_fixtures_source_html_embedded_passthrough_block_subs_overr[0m
+[32;1m        PASS[0m [   0.031s] ( 344/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_62_tests_fixtures_source_html_embedded_mixed_list_nesting_adoc[0m
+[32;1m        PASS[0m [   0.028s] ( 345/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_65_tests_fixtures_source_html_embedded_quote_block_with_url_citatio[0m
+[32;1m        PASS[0m [   0.034s] ( 346/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_61_tests_fixtures_source_html_embedded_link_macro_role_and_bare_ado[0m
+[32;1m        PASS[0m [   0.026s] ( 347/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_66_tests_fixtures_source_html_embedded_quote_with_url_attribution_a[0m
+[32;1m        PASS[0m [   0.029s] ( 348/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_67_tests_fixtures_source_html_embedded_quoted_paragraph_adoc[0m
+[32;1m        PASS[0m [   0.030s] ( 349/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_68_tests_fixtures_source_html_embedded_section_anchors_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 350/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_70_tests_fixtures_source_html_embedded_source_block_with_subs_remov[0m
+[32;1m        PASS[0m [   0.028s] ( 351/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_71_tests_fixtures_source_html_embedded_source_block_with_subs_stack[0m
+[32;1m        PASS[0m [   0.034s] ( 352/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_69_tests_fixtures_source_html_embedded_source_block_with_subs_inlin[0m
+[32;1m        PASS[0m [   0.030s] ( 353/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_72_tests_fixtures_source_html_embedded_styled_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.029s] ( 354/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_74_tests_fixtures_source_html_embedded_subs_attributes_quotes_chain[0m
+[32;1m        PASS[0m [   0.026s] ( 355/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_76_tests_fixtures_source_html_embedded_subs_explicit_no_macros_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 356/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_79_tests_fixtures_source_html_embedded_subs_paragraph_remove_quotes[0m
+[32;1m        PASS[0m [   0.035s] ( 357/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_73_tests_fixtures_source_html_embedded_subs_attributes_listing_adoc[0m
+[32;1m        PASS[0m [   0.031s] ( 358/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_75_tests_fixtures_source_html_embedded_subs_default_listing_adoc[0m
+[32;1m        PASS[0m [   0.028s] ( 359/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_78_tests_fixtures_source_html_embedded_subs_none_listing_adoc[0m
+[32;1m        PASS[0m [   0.032s] ( 360/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_77_tests_fixtures_source_html_embedded_subs_macros_disabled_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 361/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_82_tests_fixtures_source_html_embedded_subs_specialchars_listing_ad[0m
+[32;1m        PASS[0m [   0.030s] ( 362/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_80_tests_fixtures_source_html_embedded_subs_quotes_listing_adoc[0m
+[32;1m        PASS[0m [   0.026s] ( 363/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_83_tests_fixtures_source_html_embedded_table_a_cell_nested_with_tra[0m
+[32;1m        PASS[0m [   0.026s] ( 364/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_84_tests_fixtures_source_html_embedded_table_cell_styles_adoc[0m
+[32;1m        PASS[0m [   0.030s] ( 365/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_81_tests_fixtures_source_html_embedded_subs_replacements_listing_ad[0m
+[32;1m        PASS[0m [   0.026s] ( 366/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_86_tests_fixtures_source_html_embedded_toc_custom_class_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 367/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_87_tests_fixtures_source_html_embedded_toc_custom_class_left_adoc[0m
+[32;1m        PASS[0m [   0.030s] ( 368/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_85_tests_fixtures_source_html_embedded_toc_auto_adoc[0m
+[32;1m        PASS[0m [   0.025s] ( 369/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_88_tests_fixtures_source_html_embedded_toc_inlines_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 370/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_90_tests_fixtures_source_html_embedded_toc_macro_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 371/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_92_tests_fixtures_source_html_embedded_url_ampersand_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 372/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_89_tests_fixtures_source_html_embedded_toc_left_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 373/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_93_tests_fixtures_source_html_embedded_url_macro_url_display_text_a[0m
+[32;1m        PASS[0m [   0.020s] ( 374/1513) [35;1macdc-converters-html::integration_test[0m [36mtoc_footnote[0m[36m::[0m[34;1mtoc_footnote_id_not_duplicated[0m
+[32;1m        PASS[0m [   0.017s] ( 375/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_escape_quoted[0m
+[32;1m        PASS[0m [   0.029s] ( 376/1513) [35;1macdc-converters-html::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_91_tests_fixtures_source_html_embedded_toc_right_adoc[0m
+[32;1m        PASS[0m [   0.018s] ( 377/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_collapse_whitespace_strips_leading[0m
+[32;1m        PASS[0m [   0.023s] ( 378/1513) [35;1macdc-converters-html::integration_test[0m [36mwebfonts[0m[36m::[0m[34;1mdefault_includes_google_fonts[0m
+[32;1m        PASS[0m [   0.014s] ( 379/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_manify_em_dash[0m
+[32;1m        PASS[0m [   0.021s] ( 380/1513) [35;1macdc-converters-html::integration_test[0m [36mwebfonts[0m[36m::[0m[34;1mwebfonts_disabled_suppresses_font_link[0m
+[32;1m        PASS[0m [   0.026s] ( 381/1513) [35;1macdc-converters-html::integration_test[0m [36mwebfonts[0m[36m::[0m[34;1mwebfonts_custom_value_uses_custom_url[0m
+[32;1m        PASS[0m [   0.016s] ( 382/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_manify_hyphen[0m
+[32;1m        PASS[0m [   0.013s] ( 383/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_manify_plain_text[0m
+[32;1m        PASS[0m [   0.014s] ( 384/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_uppercase_title[0m
+[32;1m        PASS[0m [   0.020s] ( 385/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_manify_backslash[0m
+[32;1m        PASS[0m [   0.022s] ( 386/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_manify_leading_period[0m
+[32;1m        PASS[0m [   0.019s] ( 387/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_manify_quotes[0m
+[32;1m        PASS[0m [   0.014s] ( 388/1513) [35;1macdc-converters-manpage[0m [36msection::tests[0m[36m::[0m[34;1mtest_uppercase_section[0m
+[32;1m        PASS[0m [   0.016s] ( 389/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_embedded_with_fixtures[0m[36m::[0m[34;1mpath_2__UP__UP_acdc_parser_fixtures_tests_subs_replacements_explicit_ad[0m
+[32;1m        PASS[0m [   0.022s] ( 390/1513) [35;1macdc-converters-manpage[0m [36mescape::tests[0m[36m::[0m[34;1mtest_manify_preserve_whitespace[0m
+[32;1m        PASS[0m [   0.017s] ( 391/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_02_tests_fixtures_source_custom_linkstyle_adoc[0m
+[32;1m        PASS[0m [   0.015s] ( 392/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_04_tests_fixtures_source_icon_macros_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 393/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_embedded_with_fixtures[0m[36m::[0m[34;1mpath_3_tests_fixtures_source_embedded_media_and_inlines_adoc[0m
+[32;1m        PASS[0m [   0.015s] ( 394/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_09_tests_fixtures_source_stem_blocks_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 395/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_01_tests_fixtures_source_comprehensive_adoc[0m
+[32;1m        PASS[0m [   0.017s] ( 396/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_10_tests_fixtures_source_styled_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.014s] ( 397/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_12_tests_fixtures_source_table_cell_rowspan_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 398/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_03_tests_fixtures_source_email_trailing_punct_adoc[0m
+[32;1m        PASS[0m [   0.024s] ( 399/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_06_tests_fixtures_source_inline_image_adoc[0m
+[32;1m        PASS[0m [   0.032s] ( 400/1513) [35;1macdc-converters-manpage::integration_test[0m [34;1msection_order_warning_is_returned_in_conversion_result[0m
+[32;1m        PASS[0m [   0.015s] ( 401/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_14_tests_fixtures_source_table_complex_cells_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 402/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_05_tests_fixtures_source_index_terms_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 403/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_11_tests_fixtures_source_table_cell_colspan_adoc[0m
+[32;1m        PASS[0m [   0.030s] ( 404/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_07_tests_fixtures_source_minimal_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 405/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_08_tests_fixtures_source_nonconforming_title_adoc[0m
+[32;1m        PASS[0m [   0.037s] ( 406/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_embedded_with_fixtures[0m[36m::[0m[34;1mpath_4_tests_fixtures_source_embedded_with_author_and_footnotes_adoc[0m
+[32;1m        PASS[0m [   0.019s] ( 407/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_16_tests_fixtures_source_volume_5_adoc[0m
+[32;1m        PASS[0m [   0.020s] ( 408/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_15_tests_fixtures_source_video_audio_adoc[0m
+[32;1m        PASS[0m [   0.018s] ( 409/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_18_tests_fixtures_source_with_author_adoc[0m
+[32;1m        PASS[0m [   0.013s] ( 410/1513) [35;1macdc-converters-markdown[0m [36mtests[0m[36m::[0m[34;1mnew_defaults_to_gfm[0m
+[32;1m        PASS[0m [   0.045s] ( 411/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_embedded_with_fixtures[0m[36m::[0m[34;1mpath_1__UP__UP_acdc_parser_fixtures_tests_subs_replacements_disabled_ad[0m
+[32;1m        PASS[0m [   0.021s] ( 412/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_17_tests_fixtures_source_volume_numbers_adoc[0m
+[32;1m        PASS[0m [   0.030s] ( 413/1513) [35;1macdc-converters-manpage::integration_test[0m [36mtest_with_fixtures[0m[36m::[0m[34;1mpath_13_tests_fixtures_source_table_cell_span_combined_adoc[0m
+[32;1m        PASS[0m [   0.017s] ( 414/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_01_tests_fixtures_source_admonitions_adoc[0m
+[32;1m        PASS[0m [   0.018s] ( 415/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_commonmark_variant[0m[36m::[0m[34;1mpath_1_tests_fixtures_source_commonmark_no_tables_adoc[0m
+[32;1m        PASS[0m [   0.019s] ( 416/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_02_tests_fixtures_source_basic_document_adoc[0m
+[32;1m        PASS[0m [   0.018s] ( 417/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_05_tests_fixtures_source_collapsible_adoc[0m
+[32;1m        PASS[0m [   0.018s] ( 418/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_06_tests_fixtures_source_commonmark_no_tables_adoc[0m
+[32;1m        PASS[0m [   0.017s] ( 419/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_07_tests_fixtures_source_complex_document_adoc[0m
+[32;1m        PASS[0m [   0.017s] ( 420/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_09_tests_fixtures_source_github_features_adoc[0m
+[32;1m        PASS[0m [   0.022s] ( 421/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_04_tests_fixtures_source_code_blocks_adoc[0m
+[32;1m        PASS[0m [   0.016s] ( 422/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_10_tests_fixtures_source_headings_sections_adoc[0m
+[32;1m        PASS[0m [   0.021s] ( 423/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_08_tests_fixtures_source_edge_cases_adoc[0m
+[32;1m        PASS[0m [   0.027s] ( 424/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_03_tests_fixtures_source_blockquotes_adoc[0m
+[32;1m        PASS[0m [   0.017s] ( 425/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_13_tests_fixtures_source_lists_adoc[0m
+[32;1m        PASS[0m [   0.018s] ( 426/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_12_tests_fixtures_source_links_images_adoc[0m
+[32;1m        PASS[0m [   0.014s] ( 427/1513) [35;1macdc-converters-terminal[0m [36mappearance::theme::tests[0m[36m::[0m[34;1mtest_color_scheme_creation[0m
+[32;1m        PASS[0m [   0.037s] ( 428/1513) [35;1macdc-converters-markdown[0m [36mtests[0m[36m::[0m[34;1mwith_variant_switches_to_commonmark[0m
+[32;1m        PASS[0m [   0.018s] ( 429/1513) [35;1macdc-converters-terminal[0m [36mappearance::capabilities::tests[0m[36m::[0m[34;1mtest_unicode_detection[0m
+[32;1m        PASS[0m [   0.020s] ( 430/1513) [35;1macdc-converters-terminal[0m [36mappearance::capabilities::tests[0m[36m::[0m[34;1mtest_osc8_detection[0m
+[32;1m        PASS[0m [   0.018s] ( 431/1513) [35;1macdc-converters-terminal[0m [36mappearance::theme::tests[0m[36m::[0m[34;1mtest_syntect_theme_names[0m
+[32;1m        PASS[0m [   0.027s] ( 432/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_14_tests_fixtures_source_tables_adoc[0m
+[32;1m        PASS[0m [   0.018s] ( 433/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_empty_listing_block[0m
+[32;1m        PASS[0m [   0.035s] ( 434/1513) [35;1macdc-converters-markdown::integration_test[0m [36mtest_gfm_fixtures[0m[36m::[0m[34;1mpath_11_tests_fixtures_source_inline_formatting_adoc[0m
+[32;1m        PASS[0m [   0.023s] ( 435/1513) [35;1macdc-converters-terminal[0m [36mappearance::theme::tests[0m[36m::[0m[34;1mtest_theme_detection[0m
+[32;1m        PASS[0m [   0.017s] ( 436/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_example_block_with_title[0m
+[32;1m        PASS[0m [   0.031s] ( 437/1513) [35;1macdc-converters-terminal[0m [36mappearance::capabilities::tests[0m[36m::[0m[34;1mtest_capabilities_detection[0m
+[32;1m        PASS[0m [   0.018s] ( 438/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_block_with_title[0m
+[32;1m        PASS[0m [   0.019s] ( 439/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_with_special_characters[0m
+[32;1m        PASS[0m [   0.025s] ( 440/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_example_block_numbering_sequence[0m
+[32;1m        PASS[0m [   0.022s] ( 441/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_listing_block_basic[0m
+[32;1m        PASS[0m [   0.014s] ( 442/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_open_block_basic[0m
+[32;1m        PASS[0m [   0.032s] ( 443/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_comment_block_not_rendered[0m
+[32;1m        PASS[0m [   0.030s] ( 444/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_example_block_basic[0m
+[32;1m        PASS[0m [   0.046s] ( 445/1513) [35;1macdc-converters-markdown::integration_test[0m [34;1munsupported_block_warning_is_returned_in_conversion_result[0m
+[32;1m        PASS[0m [   0.037s] ( 446/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_empty_quote_block[0m
+[32;1m        PASS[0m [   0.026s] ( 447/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_literal_block_basic[0m
+[32;1m        PASS[0m [   0.028s] ( 448/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_literal_block_with_title[0m
+[32;1m        PASS[0m [   0.025s] ( 449/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_nested_example_with_listing[0m
+[32;1m        PASS[0m [   0.016s] ( 450/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_sidebar_block_with_title[0m
+[32;1m        PASS[0m [   0.017s] ( 451/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_sidebar_block_multiple_paragraphs[0m
+[32;1m        PASS[0m [   0.022s] ( 452/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_quote_block_with_title[0m
+[32;1m        PASS[0m [   0.027s] ( 453/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_open_block_with_title[0m
+[32;1m        PASS[0m [   0.028s] ( 454/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_quote_block_basic[0m
+[32;1m        PASS[0m [   0.019s] ( 455/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_stem_block_placeholder[0m
+[32;1m        PASS[0m [   0.025s] ( 456/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_sidebar_block_basic[0m
+[32;1m        PASS[0m [   0.019s] ( 457/1513) [35;1macdc-converters-terminal[0m [36mdocument::tests[0m[36m::[0m[34;1mtest_render_document_with_blocks[0m
+[32;1m        PASS[0m [   0.030s] ( 458/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_quote_block_multiple_paragraphs[0m
+[32;1m        PASS[0m [   0.018s] ( 459/1513) [35;1macdc-converters-terminal[0m [36mdocument::tests[0m[36m::[0m[34;1mtest_render_document_with_header[0m
+[32;1m        PASS[0m [   0.027s] ( 460/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_verse_block_with_title[0m
+[32;1m        PASS[0m [   0.021s] ( 461/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_cross_reference_with_text[0m
+[32;1m        PASS[0m [   0.026s] ( 462/1513) [35;1macdc-converters-terminal[0m [36mdocument::tests[0m[36m::[0m[34;1mtest_render_document[0m
+[32;1m        PASS[0m [   0.020s] ( 463/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_curved_apostrophe_text[0m
+[32;1m        PASS[0m [   0.042s] ( 464/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_pass_block_basic[0m
+[32;1m        PASS[0m [   0.033s] ( 465/1513) [35;1macdc-converters-terminal[0m [36mdelimited::tests[0m[36m::[0m[34;1mtest_verse_block_basic[0m
+[32;1m        PASS[0m [   0.020s] ( 466/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_highlight_text[0m
+[32;1m        PASS[0m [   0.030s] ( 467/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_bold_text[0m
+[32;1m        PASS[0m [   0.018s] ( 468/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_image_macro_placeholder[0m
+[32;1m        PASS[0m [   0.016s] ( 469/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_line_break[0m
+[32;1m        PASS[0m [   0.030s] ( 470/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_cross_reference_without_text[0m
+[32;1m        PASS[0m [   0.027s] ( 471/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_curved_quotation_text[0m
+[32;1m        PASS[0m [   0.025s] ( 472/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_inline_anchor_invisible[0m
+[32;1m        PASS[0m [   0.030s] ( 473/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_highlight_text_with_underline_role[0m
+[32;1m        PASS[0m [   0.020s] ( 474/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_monospace_text[0m
+[32;1m        PASS[0m [   0.021s] ( 475/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_nested_formatting[0m
+[32;1m        PASS[0m [   0.018s] ( 476/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_standalone_curved_apostrophe[0m
+[32;1m        PASS[0m [   0.025s] ( 477/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_mixed_formatting[0m
+[32;1m        PASS[0m [   0.029s] ( 478/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_keyboard_macro[0m
+[32;1m        PASS[0m [   0.035s] ( 479/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_italic_text[0m
+[32;1m        PASS[0m [   0.020s] ( 480/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_subscript_renders_unicode[0m
+[32;1m        PASS[0m [   0.025s] ( 481/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_subscript_fallback_for_letters[0m
+[32;1m        PASS[0m [   0.025s] ( 482/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_subscript_fallback_for_unsupported_chars[0m
+[32;1m        PASS[0m [   0.023s] ( 483/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_subscript_text[0m
+[32;1m        PASS[0m [   0.023s] ( 484/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_superscript_fallback_for_letters[0m
+[32;1m        PASS[0m [   0.032s] ( 485/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_plain_text[0m
+[32;1m        PASS[0m [   0.024s] ( 486/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_superscript_fallback_for_unsupported_chars[0m
+[32;1m        PASS[0m [   0.020s] ( 487/1513) [35;1macdc-converters-terminal[0m [36mparagraph::tests[0m[36m::[0m[34;1mextract_line_break_as_newline[0m
+[32;1m        PASS[0m [   0.042s] ( 488/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_link_macro[0m
+[32;1m        PASS[0m [   0.016s] ( 489/1513) [35;1macdc-converters-terminal[0m [36mreplay::tests[0m[36m::[0m[34;1mexplicit_timestamps_must_be_ordered[0m
+[32;1m        PASS[0m [   0.025s] ( 490/1513) [35;1macdc-converters-terminal[0m [36mparagraph::tests[0m[36m::[0m[34;1mextract_bold_text_from_literal[0m
+[32;1m        PASS[0m [   0.026s] ( 491/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_superscript_text[0m
+[32;1m        PASS[0m [   0.024s] ( 492/1513) [35;1macdc-converters-terminal[0m [36mparagraph::tests[0m[36m::[0m[34;1mextract_mixed_plain_and_formatted[0m
+[32;1m        PASS[0m [   0.024s] ( 493/1513) [35;1macdc-converters-terminal[0m [36mreplay::tests[0m[36m::[0m[34;1mansi_chunks_produce_ordered_frames_with_default_timing[0m
+[32;1m        PASS[0m [   0.022s] ( 494/1513) [35;1macdc-converters-terminal[0m [36mreplay::tests[0m[36m::[0m[34;1midentical_visible_states_are_deduplicated[0m
+[32;1m        PASS[0m [   0.026s] ( 495/1513) [35;1macdc-converters-terminal[0m [36mparagraph::tests[0m[36m::[0m[34;1mextract_nested_formatting[0m
+[32;1m        PASS[0m [   0.022s] ( 496/1513) [35;1macdc-converters-terminal[0m [36mreplay::tests[0m[36m::[0m[34;1minvalid_dimensions_are_structured_errors[0m
+[32;1m        PASS[0m [   0.019s] ( 497/1513) [35;1macdc-converters-terminal[0m [36msection::tests[0m[36m::[0m[34;1mextract_callout_ref[0m
+[32;1m        PASS[0m [   0.019s] ( 498/1513) [35;1macdc-converters-terminal[0m [36msection::tests[0m[36m::[0m[34;1mextract_link_macro_with_text[0m
+[32;1m        PASS[0m [   0.025s] ( 499/1513) [35;1macdc-converters-terminal[0m [36mreplay::tests[0m[36m::[0m[34;1mtiming_boundary_can_preserve_a_pause[0m
+[32;1m        PASS[0m [   0.027s] ( 500/1513) [35;1macdc-converters-terminal[0m [36mreplay::tests[0m[36m::[0m[34;1mleading_timing_boundary_does_not_emit_blank_frame[0m
+[32;1m        PASS[0m [   0.018s] ( 501/1513) [35;1macdc-converters-terminal[0m [36msection::tests[0m[36m::[0m[34;1mextract_standalone_curved_apostrophe[0m
+[32;1m        PASS[0m [   0.019s] ( 502/1513) [35;1macdc-converters-terminal[0m [36msection::tests[0m[36m::[0m[34;1mextract_verbatim_text_in_title[0m
+[32;1m        PASS[0m [   0.024s] ( 503/1513) [35;1macdc-converters-terminal[0m [36msection::tests[0m[36m::[0m[34;1mextract_link_macro_without_text[0m
+[32;1m        PASS[0m [   0.029s] ( 504/1513) [35;1macdc-converters-terminal[0m [36msection::tests[0m[36m::[0m[34;1mextract_bold_wrapping_plain_text[0m
+[32;1m        PASS[0m [   0.027s] ( 505/1513) [35;1macdc-converters-terminal[0m [36msection::tests[0m[36m::[0m[34;1mextract_mixed_content[0m
+[32;1m        PASS[0m [   0.021s] ( 506/1513) [35;1macdc-converters-terminal[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_python_code[0m
+[32;1m        PASS[0m [   0.048s] ( 507/1513) [35;1macdc-converters-terminal[0m [36minlines::tests[0m[36m::[0m[34;1mtest_superscript_renders_unicode[0m
+[32;1m        PASS[0m [   0.016s] ( 508/1513) [35;1macdc-converters-terminal[0m [36mtable::tests[0m[36m::[0m[34;1mtest_table_with_column_styles[0m
+[32;1m        PASS[0m [   0.028s] ( 509/1513) [35;1macdc-converters-terminal[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_extract_text_from_verbatim[0m
+[32;1m        PASS[0m [   0.026s] ( 510/1513) [35;1macdc-converters-terminal[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_javascript_code[0m
+[32;1m        PASS[0m [   0.026s] ( 511/1513) [35;1macdc-converters-terminal[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_unknown_language_fallback[0m
+[32;1m        PASS[0m [   0.029s] ( 512/1513) [35;1macdc-converters-terminal[0m [36msyntax::tests[0m[36m::[0m[34;1mtest_highlight_rust_code[0m
+[32;1m        PASS[0m [   0.020s] ( 513/1513) [35;1macdc-converters-terminal[0m [36mtable::tests[0m[36m::[0m[34;1mtest_table_with_footer[0m
+[32;1m        PASS[0m [   0.020s] ( 514/1513) [35;1macdc-converters-terminal[0m [36mtable::tests[0m[36m::[0m[34;1mtest_table_with_rowspan[0m
+[32;1m        PASS[0m [   0.026s] ( 515/1513) [35;1macdc-converters-terminal[0m [36mtable::tests[0m[36m::[0m[34;1mtest_table_with_colspan[0m
+[32;1m        PASS[0m [   0.030s] ( 516/1513) [35;1macdc-converters-terminal[0m [36mtable::tests[0m[36m::[0m[34;1mtest_table_with_alignment[0m
+[32;1m        PASS[0m [   0.020s] ( 517/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mansi_reset_clears_active_state[0m
+[32;1m        PASS[0m [   0.020s] ( 518/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mansi_bold_wraps_with_state_reapplied[0m
+[32;1m        PASS[0m [   0.020s] ( 519/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mempty_input[0m
+[32;1m        PASS[0m [   0.025s] ( 520/1513) [35;1macdc-converters-terminal[0m [36mtable::tests[0m[36m::[0m[34;1mtest_table_without_footer[0m
+[32;1m        PASS[0m [   0.018s] ( 521/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mlong_single_word_not_broken[0m
+[32;1m        PASS[0m [   0.020s] ( 522/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mexisting_newlines_preserved[0m
+[32;1m        PASS[0m [   0.016s] ( 523/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mpad_to_width_adds_spaces[0m
+[32;1m        PASS[0m [   0.022s] ( 524/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mmultiple_ansi_attributes_preserved[0m
+[32;1m        PASS[0m [   0.016s] ( 525/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mplain_text_wraps_at_word_boundaries[0m
+[32;1m        PASS[0m [   0.023s] ( 526/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mosc_sequences_passed_through[0m
+[32;1m        PASS[0m [   0.039s] ( 527/1513) [35;1macdc-converters-terminal[0m [36mtable::tests[0m[36m::[0m[34;1mtest_table_with_combined_span[0m
+[32;1m        PASS[0m [   0.020s] ( 528/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mpad_to_width_no_op_when_wide_enough[0m
+[32;1m        PASS[0m [   0.021s] ( 529/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mpad_to_width_cjk[0m
+[32;1m        PASS[0m [   0.031s] ( 530/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mno_wrapping_needed_for_short_text[0m
+[32;1m        PASS[0m [   0.036s] ( 531/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mbold_cancelled_mid_wrap_not_reapplied[0m
+[32;1m        PASS[0m [   0.018s] ( 532/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_bold_off_cancels_bold[0m
+[32;1m        PASS[0m [   0.019s] ( 533/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_cancellation_preserves_unrelated_codes[0m
+[32;1m        PASS[0m [   0.018s] ( 534/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_italic_off_cancels_italic[0m
+[32;1m        PASS[0m [   0.022s] ( 535/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_default_bg_cancels_all_background[0m
+[32;1m        PASS[0m [   0.021s] ( 536/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_default_fg_cancels_extended_foreground[0m
+[32;1m        PASS[0m [   0.021s] ( 537/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_inverse_off_cancels_inverse[0m
+[32;1m        PASS[0m [   0.023s] ( 538/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_default_fg_cancels_all_foreground[0m
+[32;1m        PASS[0m [   0.024s] ( 539/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_default_bg_cancels_extended_background[0m
+[32;1m        PASS[0m [   0.019s] ( 540/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_new_fg_replaces_old_fg[0m
+[32;1m        PASS[0m [   0.019s] ( 541/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_new_bg_replaces_old_bg[0m
+[32;1m        PASS[0m [   0.021s] ( 542/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mvisible_len_cjk_double_width[0m
+[32;1m        PASS[0m [   0.022s] ( 543/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1msgr_underline_off_cancels_underline[0m
+[32;1m        PASS[0m [   0.021s] ( 544/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mwrap_cjk_text[0m
+[32;1m        PASS[0m [   0.022s] ( 545/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mvisible_len_skips_osc[0m
+[32;1m        PASS[0m [   0.025s] ( 546/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mvisible_len_cjk_with_ansi[0m
+[32;1m        PASS[0m [   0.024s] ( 547/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mzero_max_width_returns_unchanged[0m
+[32;1m        PASS[0m [   0.033s] ( 548/1513) [35;1macdc-converters-terminal[0m [36mwrap::tests[0m[36m::[0m[34;1mvisible_len_skips_csi[0m
+[32;1m        PASS[0m [   0.035s] ( 549/1513) [35;1macdc-converters-terminal::headless_terminal_test[0m [34;1minline_styles_survive_terminal_emulation[0m
+[32;1m        PASS[0m [   0.040s] ( 550/1513) [35;1macdc-converters-terminal::headless_terminal_test[0m [34;1madmonition_renders_caption_and_border_cells[0m
+[32;1m        PASS[0m [   0.045s] ( 551/1513) [35;1macdc-converters-terminal::headless_terminal_test[0m [34;1msmoke_renders_plain_text_into_cells[0m
+[32;1m        PASS[0m [   0.042s] ( 552/1513) [35;1macdc-converters-terminal::headless_terminal_test[0m [34;1mtable_content_renders_after_terminal_emulation[0m
+[32;1m        PASS[0m [   0.049s] ( 553/1513) [35;1macdc-converters-terminal::headless_terminal_test[0m [34;1mlists_render_visible_markers[0m
+[32;1m        PASS[0m [   0.050s] ( 554/1513) [35;1macdc-converters-terminal::headless_terminal_test[0m [34;1msource_blocks_and_callouts_render_visible_cells[0m
+[32;1m        PASS[0m [   0.054s] ( 555/1513) [35;1macdc-converters-terminal::headless_terminal_test[0m [34;1msection_header_is_bold_and_rendered_with_rules[0m
+[32;1m        PASS[0m [   0.043s] ( 556/1513) [35;1macdc-converters-terminal::integration_test[0m [36mdocument[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.051s] ( 557/1513) [35;1macdc-converters-terminal::integration_test[0m [36madmonition_block[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.049s] ( 558/1513) [35;1macdc-converters-terminal::integration_test[0m [36mdelimited_block[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.050s] ( 559/1513) [35;1macdc-converters-terminal::integration_test[0m [36mescaped_superscript_subscript[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.058s] ( 560/1513) [35;1macdc-converters-terminal::integration_test[0m [36mbasic_image_block[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.055s] ( 561/1513) [35;1macdc-converters-terminal::integration_test[0m [36mdescription_list_mixed_content[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.053s] ( 562/1513) [35;1macdc-converters-terminal::integration_test[0m [36mfootnotes[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.049s] ( 563/1513) [35;1macdc-converters-terminal::integration_test[0m [36mindex_section[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.051s] ( 564/1513) [35;1macdc-converters-terminal::integration_test[0m [36mmacros_with_quoted_attributes[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.069s] ( 565/1513) [35;1macdc-converters-terminal::integration_test[0m [36mcomprehensive[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.060s] ( 566/1513) [35;1macdc-converters-terminal::integration_test[0m [34;1mimage_failure_warning_is_returned_in_conversion_result[0m
+[32;1m        PASS[0m [   0.051s] ( 567/1513) [35;1macdc-converters-terminal::integration_test[0m [36mnested_sections[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.048s] ( 568/1513) [35;1macdc-converters-terminal::integration_test[0m [36mordered_list[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.045s] ( 569/1513) [35;1macdc-converters-terminal::integration_test[0m [36mquote_block_with_paragraphs[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.017s] ( 570/1513) [35;1macdc-lsp[0m [36mcapabilities::call_hierarchy::tests[0m[36m::[0m[34;1mtest_incoming_calls_from_open_documents[0m
+[32;1m        PASS[0m [   0.016s] ( 571/1513) [35;1macdc-lsp[0m [36mcapabilities::call_hierarchy::tests[0m[36m::[0m[34;1mtest_no_incoming_calls[0m
+[32;1m        PASS[0m [   0.018s] ( 572/1513) [35;1macdc-lsp[0m [36mcapabilities::call_hierarchy::tests[0m[36m::[0m[34;1mtest_incoming_calls_multiple_ranges[0m
+[32;1m        PASS[0m [   0.018s] ( 573/1513) [35;1macdc-lsp[0m [36mcapabilities::call_hierarchy::tests[0m[36m::[0m[34;1mtest_no_outgoing_calls[0m
+[32;1m        PASS[0m [   0.013s] ( 574/1513) [35;1macdc-lsp[0m [36mcapabilities::call_hierarchy::tests[0m[36m::[0m[34;1mtest_outgoing_calls[0m
+[32;1m        PASS[0m [   0.044s] ( 575/1513) [35;1macdc-converters-terminal::integration_test[0m [36msubs_replacements_explicit[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.051s] ( 576/1513) [35;1macdc-converters-terminal::integration_test[0m [36msource_block_with_attribute_in_title[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.015s] ( 577/1513) [35;1macdc-lsp[0m [36mcapabilities::call_hierarchy::tests[0m[36m::[0m[34;1mtest_prepare_fallback_to_current_document[0m
+[32;1m        PASS[0m [   0.052s] ( 578/1513) [35;1macdc-converters-terminal::integration_test[0m [36msource_block_complete[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.012s] ( 579/1513) [35;1macdc-lsp[0m [36mcapabilities::call_hierarchy::tests[0m[36m::[0m[34;1mtest_prepare_on_include_directive[0m
+[32;1m        PASS[0m [   0.047s] ( 580/1513) [35;1macdc-converters-terminal::integration_test[0m [36msubs_replacements_disabled[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.012s] ( 581/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_all_block_types_offered[0m
+[32;1m        PASS[0m [   0.048s] ( 582/1513) [35;1macdc-converters-terminal::integration_test[0m [36mtable_cell_colspan[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.012s] ( 583/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_compute_code_actions_combines_all[0m
+[32;1m        PASS[0m [   0.012s] ( 584/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_no_quickfix_when_no_unresolved_xref[0m
+[32;1m        PASS[0m [   0.041s] ( 585/1513) [35;1macdc-converters-terminal::integration_test[0m [36murl_macro[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.013s] ( 586/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_no_toc_when_already_present[0m
+[32;1m        PASS[0m [   0.053s] ( 587/1513) [35;1macdc-converters-terminal::integration_test[0m [36mtable_cell_rowspan[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.043s] ( 588/1513) [35;1macdc-converters-terminal::integration_test[0m [36munordered_list[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.059s] ( 589/1513) [35;1macdc-converters-terminal::integration_test[0m [36mstyled_paragraphs[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.015s] ( 590/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_no_wrap_for_empty_selection[0m
+[32;1m        PASS[0m [   0.050s] ( 591/1513) [35;1macdc-converters-terminal::integration_test[0m [36mtable_cell_span_combined[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.047s] ( 592/1513) [35;1macdc-converters-terminal::integration_test[0m [36mtable_multi_cell_per_line[0m[36m::[0m[34;1mtest[0m
+[32;1m        PASS[0m [   0.016s] ( 593/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_quickfix_anchor_id_extraction[0m
+[32;1m        PASS[0m [   0.015s] ( 594/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_quickfix_for_unresolved_xref[0m
+[32;1m        PASS[0m [   0.016s] ( 595/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_quickfix_inserts_at_top_when_no_sections[0m
+[32;1m        PASS[0m [   0.020s] ( 596/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_no_toc_when_no_sections[0m
+[32;1m        PASS[0m [   0.013s] ( 597/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_wrap_in_sidebar_block[0m
+[32;1m        PASS[0m [   0.017s] ( 598/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_toc_insertion_at_top_without_title[0m
+[32;1m        PASS[0m [   0.019s] ( 599/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_toc_generation_offered[0m
+[32;1m        PASS[0m [   0.014s] ( 600/1513) [35;1macdc-lsp[0m [36mcapabilities::code_lens::tests[0m[36m::[0m[34;1mtest_attribute_with_no_references[0m
+[32;1m        PASS[0m [   0.015s] ( 601/1513) [35;1macdc-lsp[0m [36mcapabilities::code_lens::tests[0m[36m::[0m[34;1mtest_section_with_references[0m
+[32;1m        PASS[0m [   0.017s] ( 602/1513) [35;1macdc-lsp[0m [36mcapabilities::code_lens::tests[0m[36m::[0m[34;1mtest_cross_file_references[0m
+[32;1m        PASS[0m [   0.015s] ( 603/1513) [35;1macdc-lsp[0m [36mcapabilities::code_lens::tests[0m[36m::[0m[34;1mtest_section_with_zero_references[0m
+[32;1m        PASS[0m [   0.025s] ( 604/1513) [35;1macdc-lsp[0m [36mcapabilities::code_lens::tests[0m[36m::[0m[34;1mtest_attribute_definition_lens[0m
+[32;1m        PASS[0m [   0.018s] ( 605/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_anchors[0m
+[32;1m        PASS[0m [   0.016s] ( 606/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_include_paths_nonexistent_dir[0m
+[32;1m        PASS[0m [   0.015s] ( 607/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_macro_snippets_image_at_line_start[0m
+[32;1m        PASS[0m [   0.029s] ( 608/1513) [35;1macdc-lsp[0m [36mcapabilities::code_lens::tests[0m[36m::[0m[34;1mtest_multiple_sections[0m
+[32;1m        PASS[0m [   0.014s] ( 609/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_macro_snippets_no_match[0m
+[32;1m        PASS[0m [   0.019s] ( 610/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_macro_snippets_kbd[0m
+[32;1m        PASS[0m [   0.036s] ( 611/1513) [35;1macdc-lsp[0m [36mcapabilities::code_actions::tests[0m[36m::[0m[34;1mtest_wrap_multiline_selection[0m
+[32;1m        PASS[0m [   0.034s] ( 612/1513) [35;1macdc-lsp[0m [36mcapabilities::code_lens::tests[0m[36m::[0m[34;1mtest_auto_generated_section_id[0m
+[32;1m        PASS[0m [   0.017s] ( 613/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_detect_attribute_reference_context[0m
+[32;1m        PASS[0m [   0.016s] ( 614/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_detect_include_context[0m
+[32;1m        PASS[0m [   0.034s] ( 615/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_include_paths_dir_retriggers[0m
+[32;1m        PASS[0m [   0.031s] ( 616/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_include_paths_subdirectory[0m
+[32;1m        PASS[0m [   0.026s] ( 617/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_detect_attribute_definition_context[0m
+[32;1m        PASS[0m [   0.028s] ( 618/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_macro_snippets_mid_line_no_block[0m
+[32;1m        PASS[0m [   0.019s] ( 619/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_detect_macro_snippet_mid_line[0m
+[32;1m        PASS[0m [   0.036s] ( 620/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_include_paths_lists_files_and_dirs[0m
+[32;1m        PASS[0m [   0.015s] ( 621/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_xref_context_beats_macro_snippet[0m
+[32;1m        PASS[0m [   0.016s] ( 622/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_no_context_after_closed[0m
+[32;1m        PASS[0m [   0.017s] ( 623/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_no_macro_snippet_inside_macro[0m
+[32;1m        PASS[0m [   0.028s] ( 624/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_detect_macro_snippet_at_line_start[0m
+[32;1m        PASS[0m [   0.025s] ( 625/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_detect_xref_context[0m
+[32;1m        PASS[0m [   0.017s] ( 626/1513) [35;1macdc-lsp[0m [36mcapabilities::definition::tests[0m[36m::[0m[34;1mtest_collect_media_sources_multiple[0m
+[32;1m        PASS[0m [   0.014s] ( 627/1513) [35;1macdc-lsp[0m [36mcapabilities::definition::tests[0m[36m::[0m[34;1mtest_collect_xrefs[0m
+[32;1m        PASS[0m [   0.024s] ( 628/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_no_macro_snippet_single_char[0m
+[32;1m        PASS[0m [   0.013s] ( 629/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_conditional_active_no_diagnostic[0m
+[32;1m        PASS[0m [   0.017s] ( 630/1513) [35;1macdc-lsp[0m [36mcapabilities::definition::tests[0m[36m::[0m[34;1mtest_cross_file_xref_definition[0m
+[32;1m        PASS[0m [   0.054s] ( 631/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_include_paths_filter[0m
+[32;1m        PASS[0m [   0.054s] ( 632/1513) [35;1macdc-lsp[0m [36mcapabilities::completion::tests[0m[36m::[0m[34;1mtest_complete_include_paths_adoc_sorted_first[0m
+[32;1m        PASS[0m [   0.015s] ( 633/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_conditional_inactive_diagnostic[0m
+[32;1m        PASS[0m [   0.013s] ( 634/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_missing_image_produces_warning[0m
+[32;1m        PASS[0m [   0.019s] ( 635/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_absolute_path_ignores_imagesdir[0m
+[32;1m        PASS[0m [   0.030s] ( 636/1513) [35;1macdc-lsp[0m [36mcapabilities::definition::tests[0m[36m::[0m[34;1mtest_collect_media_sources_inline_image[0m
+[32;1m        PASS[0m [   0.027s] ( 637/1513) [35;1macdc-lsp[0m [36mcapabilities::definition::tests[0m[36m::[0m[34;1mtest_collect_section_anchors[0m
+[32;1m        PASS[0m [   0.013s] ( 638/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_name_source_skipped[0m
+[32;1m        PASS[0m [   0.018s] ( 639/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_existing_image_no_warning[0m
+[32;1m        PASS[0m [   0.015s] ( 640/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_nested_section_level_mismatch_becomes_warning[0m
+[32;1m        PASS[0m [   0.012s] ( 641/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_section_level_jump_down_one_ok[0m
+[32;1m        PASS[0m [   0.022s] ( 642/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_imagesdir_prepended_to_relative_paths[0m
+[32;1m        PASS[0m [   0.037s] ( 643/1513) [35;1macdc-lsp[0m [36mcapabilities::definition::tests[0m[36m::[0m[34;1mtest_collect_media_sources_block_image[0m
+[32;1m        PASS[0m [   0.016s] ( 644/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_section_level_first_section_skip[0m
+[32;1m        PASS[0m [   0.016s] ( 645/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_resolved_xref_no_warning[0m
+[32;1m        PASS[0m [   0.031s] ( 646/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_duplicate_anchor_warning[0m
+[32;1m        PASS[0m [   0.019s] ( 647/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_positioning_converts_to_zero_indexed[0m
+[32;1m        PASS[0m [   0.012s] ( 648/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_unresolved_xref_warning[0m
+[32;1m        PASS[0m [   0.013s] ( 649/1513) [35;1macdc-lsp[0m [36mcapabilities::document_links::tests[0m[36m::[0m[34;1mtest_collect_mailto[0m
+[32;1m        PASS[0m [   0.022s] ( 650/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_section_level_going_up_no_warning[0m
+[32;1m        PASS[0m [   0.015s] ( 651/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_url_source_skipped[0m
+[32;1m        PASS[0m [   0.022s] ( 652/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_section_level_large_skip[0m
+[32;1m        PASS[0m [   0.019s] ( 653/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_url_include_skipped[0m
+[32;1m        PASS[0m [   0.014s] ( 654/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_anchor_preservation[0m
+[32;1m        PASS[0m [   0.024s] ( 655/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_section_level_valid_progression_no_warnings[0m
+[32;1m        PASS[0m [   0.038s] ( 656/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_missing_include_produces_warning[0m
+[32;1m        PASS[0m [   0.042s] ( 657/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_existing_include_no_warning[0m
+[32;1m        PASS[0m [   0.018s] ( 658/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_compute_relative_path_parent_directory[0m
+[32;1m        PASS[0m [   0.015s] ( 659/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_cross_directory_move_xref[0m
+[32;1m        PASS[0m [   0.028s] ( 660/1513) [35;1macdc-lsp[0m [36mcapabilities::diagnostics::tests[0m[36m::[0m[34;1mtest_unique_anchor_no_warning[0m
+[32;1m        PASS[0m [   0.025s] ( 661/1513) [35;1macdc-lsp[0m [36mcapabilities::document_links::tests[0m[36m::[0m[34;1mtest_include_directives_as_links[0m
+[32;1m        PASS[0m [   0.027s] ( 662/1513) [35;1macdc-lsp[0m [36mcapabilities::document_links::tests[0m[36m::[0m[34;1mtest_collect_urls[0m
+[32;1m        PASS[0m [   0.024s] ( 663/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_compute_relative_path_same_dir[0m
+[32;1m        PASS[0m [   0.013s] ( 664/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_no_matching_references[0m
+[32;1m        PASS[0m [   0.027s] ( 665/1513) [35;1macdc-lsp[0m [36mcapabilities::document_links::tests[0m[36m::[0m[34;1mtest_resolve_relative_uri[0m
+[32;1m        PASS[0m [   0.023s] ( 666/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_compute_relative_path_sibling_directory[0m
+[32;1m        PASS[0m [   0.025s] ( 667/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_compute_relative_path_subdirectory[0m
+[32;1m        PASS[0m [   0.014s] ( 668/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_workspace_state_update[0m
+[32;1m        PASS[0m [   0.023s] ( 669/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_include_rewriting[0m
+[32;1m        PASS[0m [   0.013s] ( 670/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_collapse_multiple_blank_lines[0m
+[32;1m        PASS[0m [   0.014s] ( 671/1513) [35;1macdc-lsp[0m [36mcapabilities::folding::tests[0m[36m::[0m[34;1mtest_section_folding[0m
+[32;1m        PASS[0m [   0.015s] ( 672/1513) [35;1macdc-lsp[0m [36mcapabilities::folding::tests[0m[36m::[0m[34;1mtest_open_block_folding[0m
+[32;1m        PASS[0m [   0.017s] ( 673/1513) [35;1macdc-lsp[0m [36mcapabilities::folding::tests[0m[36m::[0m[34;1mtest_delimited_block_folding[0m
+[32;1m        PASS[0m [   0.014s] ( 674/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_final_newline_added[0m
+[32;1m        PASS[0m [   0.011s] ( 675/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_format_empty_document[0m
+[32;1m        PASS[0m [   0.022s] ( 676/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_block_separation_inserted[0m
+[32;1m        PASS[0m [   0.015s] ( 677/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_final_newline_trimmed[0m
+[32;1m        PASS[0m [   0.017s] ( 678/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_format_full_document[0m
+[32;1m        PASS[0m [   0.037s] ( 679/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_disk_scan_finds_references[0m
+[32;1m        PASS[0m [   0.022s] ( 680/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_collapse_two_blank_lines[0m
+[32;1m        PASS[0m [   0.032s] ( 681/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_same_file_xrefs_unaffected[0m
+[32;1m        PASS[0m [   0.013s] ( 682/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_no_trim_in_literal_block[0m
+[32;1m        PASS[0m [   0.043s] ( 683/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_multiple_documents[0m
+[32;1m        PASS[0m [   0.016s] ( 684/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_no_trim_in_listing_block[0m
+[32;1m        PASS[0m [   0.021s] ( 685/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_no_separation_between_consecutive_attributes[0m
+[32;1m        PASS[0m [   0.015s] ( 686/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_range_formatting_only_affects_range[0m
+[32;1m        PASS[0m [   0.032s] ( 687/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_final_newline_respects_option[0m
+[32;1m        PASS[0m [   0.017s] ( 688/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_single_blank_line_unchanged[0m
+[32;1m        PASS[0m [   0.014s] ( 689/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_trim_trailing_tabs[0m
+[32;1m        PASS[0m [   0.028s] ( 690/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_no_collapse_in_verbatim[0m
+[32;1m        PASS[0m [   0.025s] ( 691/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_parse_failed_document_still_formats[0m
+[32;1m        PASS[0m [   0.050s] ( 692/1513) [35;1macdc-lsp[0m [36mcapabilities::file_rename::tests[0m[36m::[0m[34;1mtest_same_directory_rename_xref[0m
+[32;1m        PASS[0m [   0.023s] ( 693/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_text_based_multiple_protected_ranges[0m
+[32;1m        PASS[0m [   0.016s] ( 694/1513) [35;1macdc-lsp[0m [36mcapabilities::hover::tests[0m[36m::[0m[34;1mtest_hover_on_xref[0m
+[32;1m        PASS[0m [   0.018s] ( 695/1513) [35;1macdc-lsp[0m [36mcapabilities::hover::tests[0m[36m::[0m[34;1mtest_hover_on_undefined_attribute_ref[0m
+[32;1m        PASS[0m [   0.022s] ( 696/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_text_based_protected_ranges[0m
+[32;1m        PASS[0m [   0.037s] ( 697/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_idempotent[0m
+[32;1m        PASS[0m [   0.016s] ( 698/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_attribute_hint_undefined[0m
+[32;1m        PASS[0m [   0.016s] ( 699/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_hints_filtered_by_range[0m
+[32;1m        PASS[0m [   0.024s] ( 700/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_attribute_hint_empty_value[0m
+[32;1m        PASS[0m [   0.018s] ( 701/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_multiple_hints[0m
+[32;1m        PASS[0m [   0.026s] ( 702/1513) [35;1macdc-lsp[0m [36mcapabilities::formatting::tests[0m[36m::[0m[34;1mtest_trim_trailing_whitespace[0m
+[32;1m        PASS[0m [   0.025s] ( 703/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_attribute_hint_resolved[0m
+[32;1m        PASS[0m [   0.014s] ( 704/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_xref_with_xreflabel[0m
+[32;1m        PASS[0m [   0.027s] ( 705/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_attribute_hint_truncation[0m
+[32;1m        PASS[0m [   0.017s] ( 706/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_xref_hint_unresolved[0m
+[32;1m        PASS[0m [   0.014s] ( 707/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_example_block[0m
+[32;1m        PASS[0m [   0.034s] ( 708/1513) [35;1macdc-lsp[0m [36mcapabilities::hover::tests[0m[36m::[0m[34;1mtest_hover_on_attribute_ref[0m
+[32;1m        PASS[0m [   0.017s] ( 709/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_listing_block[0m
+[32;1m        PASS[0m [   0.022s] ( 710/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_comment_block[0m
+[32;1m        PASS[0m [   0.028s] ( 711/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_xref_hint_explicit_text_skipped[0m
+[32;1m        PASS[0m [   0.031s] ( 712/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_position_in_range_basic[0m
+[32;1m        PASS[0m [   0.018s] ( 713/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_longer_delimiter[0m
+[32;1m        PASS[0m [   0.023s] ( 714/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_literal_block[0m
+[32;1m        PASS[0m [   0.013s] ( 715/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mcallout_auto_continuation[0m
+[32;1m        PASS[0m [   0.029s] ( 716/1513) [35;1macdc-lsp[0m [36mcapabilities::inlay_hints::tests[0m[36m::[0m[34;1mtest_xref_hint_with_title[0m
+[32;1m        PASS[0m [   0.013s] ( 717/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mcallout_numeric_continuation[0m
+[32;1m        PASS[0m [   0.021s] ( 718/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_passthrough_block[0m
+[32;1m        PASS[0m [   0.025s] ( 719/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_markdown_code_with_language[0m
+[32;1m        PASS[0m [   0.023s] ( 720/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_quote_block[0m
+[32;1m        PASS[0m [   0.016s] ( 721/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mdetect_delimiter_variations[0m
+[32;1m        PASS[0m [   0.022s] ( 722/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_tilde_block[0m
+[32;1m        PASS[0m [   0.031s] ( 723/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_markdown_code[0m
+[32;1m        PASS[0m [   0.030s] ( 724/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_open_block[0m
+[32;1m        PASS[0m [   0.028s] ( 725/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mauto_close_sidebar_block[0m
+[32;1m        PASS[0m [   0.014s] ( 726/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mno_auto_close_when_already_paired[0m
+[32;1m        PASS[0m [   0.026s] ( 727/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mcursor_at_line_zero_returns_none[0m
+[32;1m        PASS[0m [   0.016s] ( 728/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mnext_marker_preserves_others[0m
+[32;1m        PASS[0m [   0.018s] ( 729/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mno_auto_close_for_closing_delimiter[0m
+[32;1m        PASS[0m [   0.024s] ( 730/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mnext_marker_callout[0m
+[32;1m        PASS[0m [   0.016s] ( 731/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mno_continuation_on_plain_text[0m
+[32;1m        PASS[0m [   0.018s] ( 732/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mno_continuation_on_heading[0m
+[32;1m        PASS[0m [   0.018s] ( 733/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mordered_dot_continuation[0m
+[32;1m        PASS[0m [   0.023s] ( 734/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mno_continuation_in_listing_block[0m
+[32;1m        PASS[0m [   0.034s] ( 735/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mempty_unordered_removes_marker[0m
+[32;1m        PASS[0m [   0.019s] ( 736/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mordered_nested_dot_continuation[0m
+[32;1m        PASS[0m [   0.016s] ( 737/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mthree_dashes_not_a_delimiter[0m
+[32;1m        PASS[0m [   0.013s] ( 738/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1munordered_star_continuation[0m
+[32;1m        PASS[0m [   0.012s] ( 739/1513) [35;1macdc-lsp[0m [36mcapabilities::references::tests[0m[36m::[0m[34;1mtest_find_references_from_anchor[0m
+[32;1m        PASS[0m [   0.024s] ( 740/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mordered_numeric_continuation[0m
+[32;1m        PASS[0m [   0.040s] ( 741/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mignores_non_newline_trigger[0m
+[32;1m        PASS[0m [   0.027s] ( 742/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mordered_numeric_increment[0m
+[32;1m        PASS[0m [   0.024s] ( 743/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1msingle_backtick_not_a_delimiter[0m
+[32;1m        PASS[0m [   0.015s] ( 744/1513) [35;1macdc-lsp[0m [36mcapabilities::rename::tests[0m[36m::[0m[34;1mtest_compute_rename[0m
+[32;1m        PASS[0m [   0.020s] ( 745/1513) [35;1macdc-lsp[0m [36mcapabilities::references::tests[0m[36m::[0m[34;1mtest_cross_file_references[0m
+[32;1m        PASS[0m [   0.017s] ( 746/1513) [35;1macdc-lsp[0m [36mcapabilities::references::tests[0m[36m::[0m[34;1mtest_find_references_without_declaration[0m
+[32;1m        PASS[0m [   0.025s] ( 747/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1munordered_dash_continuation[0m
+[32;1m        PASS[0m [   0.031s] ( 748/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mpreserves_leading_whitespace[0m
+[32;1m        PASS[0m [   0.049s] ( 749/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mnext_marker_numeric[0m
+[32;1m        PASS[0m [   0.015s] ( 750/1513) [35;1macdc-lsp[0m [36mcapabilities::rename::tests[0m[36m::[0m[34;1mtest_prepare_rename_on_xref[0m
+[32;1m        PASS[0m [   0.024s] ( 751/1513) [35;1macdc-lsp[0m [36mcapabilities::references::tests[0m[36m::[0m[34;1mtest_find_references_from_xref[0m
+[32;1m        PASS[0m [   0.023s] ( 752/1513) [35;1macdc-lsp[0m [36mcapabilities::rename::tests[0m[36m::[0m[34;1mtest_prepare_rename_invalid_position[0m
+[32;1m        PASS[0m [   0.019s] ( 753/1513) [35;1macdc-lsp[0m [36mcapabilities::selection_range::tests[0m[36m::[0m[34;1mtest_basic_section_selection[0m
+[32;1m        PASS[0m [   0.011s] ( 754/1513) [35;1macdc-lsp[0m [36mcapabilities::semantic_tokens::tests[0m[36m::[0m[34;1mtest_conditional_inactive_tokens[0m
+[32;1m        PASS[0m [   0.018s] ( 755/1513) [35;1macdc-lsp[0m [36mcapabilities::selection_range::tests[0m[36m::[0m[34;1mtest_nested_inline_markup[0m
+[32;1m        PASS[0m [   0.037s] ( 756/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1mtwo_backticks_not_a_delimiter[0m
+[32;1m        PASS[0m [   0.021s] ( 757/1513) [35;1macdc-lsp[0m [36mcapabilities::selection_range::tests[0m[36m::[0m[34;1mtest_chain_is_strictly_expanding[0m
+[32;1m        PASS[0m [   0.026s] ( 758/1513) [35;1macdc-lsp[0m [36mcapabilities::rename::tests[0m[36m::[0m[34;1mtest_prepare_rename_on_anchor[0m
+[32;1m        PASS[0m [   0.014s] ( 759/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1maudio_block_form[0m
+[32;1m        PASS[0m [   0.024s] ( 760/1513) [35;1macdc-lsp[0m [36mcapabilities::selection_range::tests[0m[36m::[0m[34;1mtest_list_item_selection[0m
+[32;1m        PASS[0m [   0.015s] ( 761/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mbtn_single_param[0m
+[32;1m        PASS[0m [   0.013s] ( 762/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mbuild_label_link_inline[0m
+[32;1m        PASS[0m [   0.022s] ( 763/1513) [35;1macdc-lsp[0m [36mcapabilities::semantic_tokens::tests[0m[36m::[0m[34;1mtest_legend_has_expected_types[0m
+[32;1m        PASS[0m [   0.021s] ( 764/1513) [35;1macdc-lsp[0m [36mcapabilities::semantic_tokens::tests[0m[36m::[0m[34;1mtest_xref_tokens[0m
+[32;1m        PASS[0m [   0.046s] ( 765/1513) [35;1macdc-lsp[0m [36mcapabilities::on_type_formatting::tests[0m[36m::[0m[34;1munordered_star_nested_continuation[0m
+[32;1m        PASS[0m [   0.028s] ( 766/1513) [35;1macdc-lsp[0m [36mcapabilities::semantic_tokens::tests[0m[36m::[0m[34;1mtest_conditional_active_no_disabled_tokens[0m
+[32;1m        PASS[0m [   0.015s] ( 767/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mextract_macro_name_block[0m
+[32;1m        PASS[0m [   0.033s] ( 768/1513) [35;1macdc-lsp[0m [36mcapabilities::selection_range::tests[0m[36m::[0m[34;1mtest_no_ast_fallback[0m
+[32;1m        PASS[0m [   0.036s] ( 769/1513) [35;1macdc-lsp[0m [36mcapabilities::selection_range::tests[0m[36m::[0m[34;1mtest_multiple_positions[0m
+[32;1m        PASS[0m [   0.022s] ( 770/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mcount_commas_empty[0m
+[32;1m        PASS[0m [   0.020s] ( 771/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mcount_commas_simple[0m
+[32;1m        PASS[0m [   0.016s] ( 772/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mextract_macro_name_none[0m
+[32;1m        PASS[0m [   0.013s] ( 773/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mfind_unmatched_bracket_nested[0m
+[32;1m        PASS[0m [   0.013s] ( 774/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mfind_unmatched_bracket_none[0m
+[32;1m        PASS[0m [   0.011s] ( 775/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mimage_block_second_param[0m
+[32;1m        PASS[0m [   0.033s] ( 776/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mbuild_label_image_block[0m
+[32;1m        PASS[0m [   0.014s] ( 777/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mimage_block_first_param[0m
+[32;1m        PASS[0m [   0.024s] ( 778/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mextract_macro_name_with_prefix[0m
+[32;1m        PASS[0m [   0.013s] ( 779/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mimage_block_third_param[0m
+[32;1m        PASS[0m [   0.014s] ( 780/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mimage_with_prefix_text[0m
+[32;1m        PASS[0m [   0.013s] ( 781/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1minclude_named_params[0m
+[32;1m        PASS[0m [   0.036s] ( 782/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mcount_commas_quoted[0m
+[32;1m        PASS[0m [   0.018s] ( 783/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mimage_inline_first_param[0m
+[32;1m        PASS[0m [   0.049s] ( 784/1513) [35;1macdc-lsp[0m [36mcapabilities::semantic_tokens::tests[0m[36m::[0m[34;1mtest_section_tokens[0m
+[32;1m        PASS[0m [   0.013s] ( 785/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mmultiline_not_supported[0m
+[32;1m        PASS[0m [   0.026s] ( 786/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1micon_inline[0m
+[32;1m        PASS[0m [   0.016s] ( 787/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mlink_inline[0m
+[32;1m        PASS[0m [   0.037s] ( 788/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mextract_macro_name_inline[0m
+[32;1m        PASS[0m [   0.015s] ( 789/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mno_match_outside_brackets[0m
+[32;1m        PASS[0m [   0.016s] ( 790/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mno_match_after_closing_bracket[0m
+[32;1m        PASS[0m [   0.026s] ( 791/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1minclude_match_named_param[0m
+[32;1m        PASS[0m [   0.038s] ( 792/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mfind_unmatched_bracket_simple[0m
+[32;1m        PASS[0m [   0.013s] ( 793/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mquoted_commas_not_counted[0m
+[32;1m        PASS[0m [   0.026s] ( 794/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mkbd_single_param_stays_at_zero[0m
+[32;1m        PASS[0m [   0.016s] ( 795/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mstem_single_param[0m
+[32;1m        PASS[0m [   0.047s] ( 796/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mfind_unmatched_bracket_all_matched[0m
+[32;1m        PASS[0m [   0.015s] ( 797/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mvideo_no_inline_form[0m
+[32;1m        PASS[0m [   0.020s] ( 798/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mvideo_block_form[0m
+[32;1m        PASS[0m [   0.022s] ( 799/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mtoc_no_params[0m
+[32;1m        PASS[0m [   0.013s] ( 800/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_document_symbols_extraction[0m
+[32;1m        PASS[0m [   0.027s] ( 801/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mno_match_unknown_macro[0m
+[32;1m        PASS[0m [   0.015s] ( 802/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_comment_excluded[0m
+[32;1m        PASS[0m [   0.038s] ( 803/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mmailto_inline[0m
+[32;1m        PASS[0m [   0.028s] ( 804/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mpass_single_param[0m
+[32;1m        PASS[0m [   0.025s] ( 805/1513) [35;1macdc-lsp[0m [36mcapabilities::signature_help::tests[0m[36m::[0m[34;1mxref_inline[0m
+[32;1m        PASS[0m [   0.020s] ( 806/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_image_symbols[0m
+[32;1m        PASS[0m [   0.018s] ( 807/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_paragraph_preview_truncation[0m
+[32;1m        PASS[0m [   0.023s] ( 808/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_admonition_symbols[0m
+[32;1m        PASS[0m [   0.014s] ( 809/1513) [35;1macdc-lsp[0m [36mcapabilities::workspace_symbols::tests[0m[36m::[0m[34;1mtest_extract_symbols_anchors[0m
+[32;1m        PASS[0m [   0.016s] ( 810/1513) [35;1macdc-lsp[0m [36mcapabilities::workspace_symbols::tests[0m[36m::[0m[34;1mtest_extract_symbols_document_attributes[0m
+[32;1m        PASS[0m [   0.017s] ( 811/1513) [35;1macdc-lsp[0m [36mcapabilities::workspace_symbols::tests[0m[36m::[0m[34;1mtest_extract_symbols_discrete_header[0m
+[32;1m        PASS[0m [   0.018s] ( 812/1513) [35;1macdc-lsp[0m [36mcapabilities::workspace_symbols::tests[0m[36m::[0m[34;1mtest_extract_symbols_sections[0m
+[32;1m        PASS[0m [   0.012s] ( 813/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_offset_in_location[0m
+[32;1m        PASS[0m [   0.014s] ( 814/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_position_to_offset_with_unicode[0m
+[32;1m        PASS[0m [   0.015s] ( 815/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_resolve_relative_uri_dot_segment[0m
+[32;1m        PASS[0m [   0.025s] ( 816/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_location_to_range_default_is_zero[0m
+[32;1m        PASS[0m [   0.015s] ( 817/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_resolve_relative_uri_simple[0m
+[32;1m        PASS[0m [   0.016s] ( 818/1513) [35;1macdc-lsp[0m [36mlimits::tests[0m[36m::[0m[34;1mcount_lines_bounded_counts_newlines[0m
+[32;1m        PASS[0m [   0.021s] ( 819/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_resolve_relative_uri_parent_traversal[0m
+[32;1m        PASS[0m [   0.039s] ( 820/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_delimited_block_symbols[0m
+[32;1m        PASS[0m [   0.010s] ( 821/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_attribute_refs_ignores_invalid_names[0m
+[32;1m        PASS[0m [   0.039s] ( 822/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_list_symbols[0m
+[32;1m        PASS[0m [   0.014s] ( 823/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_attribute_refs_in_definition_value[0m
+[32;1m        PASS[0m [   0.018s] ( 824/1513) [35;1macdc-lsp[0m [36mlimits::tests[0m[36m::[0m[34;1mread_bounded_rejects_oversized_file[0m
+[32;1m        PASS[0m [   0.036s] ( 825/1513) [35;1macdc-lsp[0m [36mcapabilities::symbols::tests[0m[36m::[0m[34;1mtest_paragraph_symbols[0m
+[32;1m        PASS[0m [   0.014s] ( 826/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_attribute_refs_location[0m
+[32;1m        PASS[0m [   0.022s] ( 827/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_attribute_refs_basic[0m
+[32;1m        PASS[0m [   0.035s] ( 828/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_position_to_offset_simple[0m
+[32;1m        PASS[0m [   0.029s] ( 829/1513) [35;1macdc-lsp[0m [36mlimits::tests[0m[36m::[0m[34;1mcount_lines_bounded_returns_zero_for_missing_file[0m
+[32;1m        PASS[0m [   0.029s] ( 830/1513) [35;1macdc-lsp[0m [36mlimits::tests[0m[36m::[0m[34;1mread_bounded_accepts_small_file[0m
+[32;1m        PASS[0m [   0.033s] ( 831/1513) [35;1macdc-lsp[0m [36mconvert::tests[0m[36m::[0m[34;1mtest_uri_filename[0m
+[32;1m        PASS[0m [   0.019s] ( 832/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_attribute_refs_skips_definition_name[0m
+[32;1m        PASS[0m [   0.016s] ( 833/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_ifdef_inactive[0m
+[32;1m        PASS[0m [   0.022s] ( 834/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_and_operation[0m
+[32;1m        PASS[0m [   0.015s] ( 835/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_ifndef_inactive[0m
+[32;1m        PASS[0m [   0.017s] ( 836/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_multiple[0m
+[32;1m        PASS[0m [   0.021s] ( 837/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_escaped[0m
+[32;1m        PASS[0m [   0.015s] ( 838/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_includes_basic[0m
+[32;1m        PASS[0m [   0.031s] ( 839/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_attribute_refs_multiple_on_same_line[0m
+[32;1m        PASS[0m [   0.018s] ( 840/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_or_operation[0m
+[32;1m        PASS[0m [   0.018s] ( 841/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_single_line[0m
+[32;1m        PASS[0m [   0.027s] ( 842/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_ifndef[0m
+[32;1m        PASS[0m [   0.013s] ( 843/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_includes_with_attributes[0m
+[32;1m        PASS[0m [   0.019s] ( 844/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_includes_multiple[0m
+[32;1m        PASS[0m [   0.012s] ( 845/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_anchor_index_cleaned_on_document_remove[0m
+[32;1m        PASS[0m [   0.013s] ( 846/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_anchor_index_updated_on_document_reparse[0m
+[32;1m        PASS[0m [   0.018s] ( 847/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_all_anchors_across_documents[0m
+[32;1m        PASS[0m [   0.016s] ( 848/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_anchor_index_updated_on_document_change[0m
+[32;1m        PASS[0m [   0.015s] ( 849/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_find_anchor_in_document[0m
+[32;1m        PASS[0m [   0.014s] ( 850/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_missing_include_diagnostic[0m
+[32;1m        PASS[0m [   0.018s] ( 851/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_discover_adoc_files[0m
+[32;1m        PASS[0m [   0.015s] ( 852/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_parser_warning_becomes_lsp_diagnostic[0m
+[32;1m        PASS[0m [   0.028s] ( 853/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_includes_with_path[0m
+[32;1m        PASS[0m [   0.014s] ( 854/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_section_level_skip_diagnostic[0m
+[32;1m        PASS[0m [   0.035s] ( 855/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_includes_location[0m
+[32;1m        PASS[0m [   0.020s] ( 856/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_nested_section_level_skip_diagnostic[0m
+[32;1m        PASS[0m [   0.015s] ( 857/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_asciidoc_extension[0m
+[32;1m        PASS[0m [   0.019s] ( 858/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_symbol_index_lifecycle[0m
+[32;1m        PASS[0m [   0.067s] ( 859/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_attribute_refs_escaped[0m
+[32;1m        PASS[0m [   0.056s] ( 860/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_conditionals_ifdef_active[0m
+[32;1m        PASS[0m [   0.041s] ( 861/1513) [35;1macdc-lsp[0m [36mstate::document::tests[0m[36m::[0m[34;1mtest_extract_includes_no_includes[0m
+[32;1m        PASS[0m [   0.041s] ( 862/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1moversized_open_document_is_gated[0m
+[32;1m        PASS[0m [   0.022s] ( 863/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_workspace_symbol_query[0m
+[32;1m        PASS[0m [   0.018s] ( 864/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_cross_file_with_anchor[0m
+[32;1m        PASS[0m [   0.014s] ( 865/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_local_anchor[0m
+[32;1m        PASS[0m [   0.016s] ( 866/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_hash_only_file[0m
+[32;1m        PASS[0m [   0.020s] ( 867/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_cross_file_without_anchor[0m
+[32;1m        PASS[0m [   0.017s] ( 868/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_path_with_slash[0m
+[32;1m        PASS[0m [   0.041s] ( 869/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_missing_image_diagnostic[0m
+[32;1m        PASS[0m [   0.025s] ( 870/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_cross_file_with_path[0m
+[32;1m        PASS[0m [   0.013s] ( 871/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1msplit_escaped_backslash_not_before_separator[0m
+[32;1m        PASS[0m [   0.040s] ( 872/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mtest_section_level_valid_no_diagnostic[0m
+[32;1m        PASS[0m [   0.031s] ( 873/1513) [35;1macdc-lsp[0m [36mstate::xref_target::tests[0m[36m::[0m[34;1mtest_explicit_local_anchor[0m
+[32;1m        PASS[0m [   0.014s] ( 874/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1msplit_escaped_multiple_escapes[0m
+[32;1m        PASS[0m [   0.015s] ( 875/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1msplit_escaped_positions_tracked[0m
+[32;1m        PASS[0m [   0.025s] ( 876/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1ma_cell_preserves_blank_line_inside_nested_table_content[0m
+[32;1m        PASS[0m [   0.013s] ( 877/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1mtrailing_text_becomes_continuation_paragraph_of_last_cell[0m
+[32;1m        PASS[0m [   0.019s] ( 878/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1msplit_escaped_psv_with_escape[0m
+[32;1m        PASS[0m [   0.025s] ( 879/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1msplit_escaped_dsv_no_escapes[0m
+[32;1m        PASS[0m [   0.026s] ( 880/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1msplit_escaped_dsv_with_escape[0m
+[32;1m        PASS[0m [   0.015s] ( 881/1513) [35;1macdc-parser[0m [36merror::tests[0m[36m::[0m[34;1mtest_error_invalid_admonition_variant_display[0m
+[32;1m        PASS[0m [   0.019s] ( 882/1513) [35;1macdc-parser[0m [36merror::tests[0m[36m::[0m[34;1mtest_error_detail_display[0m
+[32;1m        PASS[0m [   0.016s] ( 883/1513) [35;1macdc-parser[0m [36merror::tests[0m[36m::[0m[34;1mtest_error_mismatched_delimiters_display[0m
+[32;1m        PASS[0m [   0.028s] ( 884/1513) [35;1macdc-parser[0m [36mblocks::table::tests[0m[36m::[0m[34;1msplit_escaped_psv_no_escapes[0m
+[32;1m        PASS[0m [   0.013s] ( 885/1513) [35;1macdc-parser[0m [36merror::tests[0m[36m::[0m[34;1mtest_error_parse_display[0m
+[32;1m        PASS[0m [   0.012s] ( 886/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_author[0m
+[32;1m        PASS[0m [   0.012s] ( 887/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_authors[0m
+[32;1m        PASS[0m [   0.013s] ( 888/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_block_macro_trailing_content_emits_warning[0m
+[32;1m        PASS[0m [   0.022s] ( 889/1513) [35;1macdc-parser[0m [36merror::tests[0m[36m::[0m[34;1mtest_error_nested_section_level_mismatch_display[0m
+[32;1m        PASS[0m [   0.012s] ( 890/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_compound_last_name[0m
+[32;1m        PASS[0m [   0.015s] ( 891/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_compound_first_name[0m
+[32;1m        PASS[0m [   0.013s] ( 892/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_compound_middle_name[0m
+[32;1m        PASS[0m [   0.011s] ( 893/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document_attribute_with_id[0m
+[32;1m        PASS[0m [   0.013s] ( 894/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document[0m
+[32;1m        PASS[0m [   0.010s] ( 895/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document_empty_attribute_list[0m
+[32;1m        PASS[0m [   0.011s] ( 896/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document_attribute_with_id_mixed_with_quotes[0m
+[32;1m        PASS[0m [   0.013s] ( 897/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document_attribute_with_id_mixed[0m
+[32;1m        PASS[0m [   0.011s] ( 898/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document_title_and_subtitle[0m
+[32;1m        PASS[0m [   0.012s] ( 899/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document_title[0m
+[32;1m        PASS[0m [   0.013s] ( 900/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_document_empty_attribute_list_with_discrete[0m
+[32;1m        PASS[0m [   0.011s] ( 901/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_first_section_level_1_no_warning[0m
+[32;1m        PASS[0m [   0.012s] ( 902/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_first_section_without_doc_title_does_not_warn[0m
+[32;1m        PASS[0m [   0.013s] ( 903/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_first_section_not_level_1_emits_warning[0m
+[32;1m        PASS[0m [   0.011s] ( 904/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_index_term_flow[0m
+[32;1m        PASS[0m [   0.012s] ( 905/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_index_term_concealed[0m
+[32;1m        PASS[0m [   0.014s] ( 906/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_header_with_title_and_authors[0m
+[32;1m        PASS[0m [   0.011s] ( 907/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_revision_full[0m
+[32;1m        PASS[0m [   0.012s] ( 908/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_multiple_compound_authors[0m
+[32;1m        PASS[0m [   0.014s] ( 909/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_macro_attributes_allow_literal_special_chars[0m
+[32;1m        PASS[0m [   0.011s] ( 910/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_revision_no_date_no_remark[0m
+[32;1m        PASS[0m [   0.012s] ( 911/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_revision_with_date_no_remark[0m
+[32;1m        PASS[0m [   0.014s] ( 912/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_revision_no_date_with_remark[0m
+[32;1m        PASS[0m [   0.012s] ( 913/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_disabled_by_default[0m
+[32;1m        PASS[0m [   0.013s] ( 914/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_all_underline_characters[0m
+[32;1m        PASS[0m [   0.014s] ( 915/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_document_title[0m
+[32;1m        PASS[0m [   0.012s] ( 916/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_manpage_style_document[0m
+[32;1m        PASS[0m [   0.013s] ( 917/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_section[0m
+[32;1m        PASS[0m [   0.014s] ( 918/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_sibling_sections[0m
+[32;1m        PASS[0m [   0.011s] ( 919/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_single_section_per_level[0m
+[32;1m        PASS[0m [   0.012s] ( 920/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_shorthand_id_role_combined[0m
+[32;1m        PASS[0m [   0.015s] ( 921/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_setext_with_description_lists[0m
+[32;1m        PASS[0m [   0.012s] ( 922/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_shorthand_just_roles[0m
+[32;1m        PASS[0m [   0.012s] ( 923/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_shorthand_id_role_option_combined[0m
+[32;1m        PASS[0m [   0.012s] ( 924/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_shorthand_style_id_role[0m
+[32;1m        PASS[0m [   0.015s] ( 925/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_shorthand_multiple_roles[0m
+[32;1m        PASS[0m [   0.012s] ( 926/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_toc_empty_document[0m
+[32;1m        PASS[0m [   0.015s] ( 927/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_terminated_table_does_not_warn[0m
+[32;1m        PASS[0m [   0.012s] ( 928/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_toc_tree[0m
+[32;1m        PASS[0m [   0.013s] ( 929/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_trailing_content_warning_falls_back_to_entry_file[0m
+[32;1m        PASS[0m [   0.015s] ( 930/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_toc_simple[0m
+[32;1m        PASS[0m [   0.012s] ( 931/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_unterminated_excl_table_emits_warning[0m
+[32;1m        PASS[0m [   0.015s] ( 932/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_trailing_content_warning_resolves_source_range[0m
+[32;1m        PASS[0m [   0.016s] ( 933/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_unicode_author_name[0m
+[32;1m        PASS[0m [   0.013s] ( 934/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_unterminated_pipe_table_empty_through_parse_entry[0m
+[32;1m        PASS[0m [   0.015s] ( 935/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_unterminated_pipe_table_emits_warning[0m
+[32;1m        PASS[0m [   0.011s] ( 936/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_warning_in_ascii_cell_points_at_inner_token[0m
+[32;1m        PASS[0m [   0.012s] ( 937/1513) [35;1macdc-parser[0m [36mgrammar::document::tests[0m[36m::[0m[34;1mtest_unterminated_pipe_table_with_no_content_emits_warning[0m
+[32;1m        PASS[0m [   0.010s] ( 938/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_all_character_replacement_attributes[0m
+[32;1m        PASS[0m [   0.012s] ( 939/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_all_passthroughs_with_attribute[0m
+[32;1m        PASS[0m [   0.013s] ( 940/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_character_replacement_in_context[0m
+[32;1m        PASS[0m [   0.012s] ( 941/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_counter_reference_collects_warning[0m
+[32;1m        PASS[0m [   0.013s] ( 942/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_counter_reference_deduplication_is_per_position[0m
+[32;1m        PASS[0m [   0.010s] ( 943/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_greedy_matching_single_plus_passthrough[0m
+[32;1m        PASS[0m [   0.012s] ( 944/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_nested_passthrough_with_nested_attributes[0m
+[32;1m        PASS[0m [   0.013s] ( 945/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_distinct_counter_references_produce_separate_warnings[0m
+[32;1m        PASS[0m [   0.014s] ( 946/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_line_breaks[0m
+[32;1m        PASS[0m [   0.013s] ( 947/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_pass_macro_a_with_macros_disabled_expands_attributes[0m
+[32;1m        PASS[0m [   0.012s] ( 948/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_pass_macro_no_subs_with_macros_disabled_preserves_attributes[0m
+[32;1m        PASS[0m [   0.012s] ( 949/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_pass_macro_q_with_macros_disabled_preserves_content[0m
+[32;1m        PASS[0m [   0.017s] ( 950/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_pass_macro_a_q_with_macros_disabled_expands_attributes[0m
+[32;1m        PASS[0m [   0.011s] ( 951/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_attribute_in_link[0m
+[32;1m        PASS[0m [   0.012s] ( 952/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_pass_macro_with_mixed_content[0m
+[32;1m        PASS[0m [   0.013s] ( 953/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_complex_example[0m
+[32;1m        PASS[0m [   0.012s] ( 954/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_inline_passthrough_double[0m
+[32;1m        PASS[0m [   0.013s] ( 955/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_inline_passthrough_multiple[0m
+[32;1m        PASS[0m [   0.014s] ( 956/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_inline_in_attributes[0m
+[32;1m        PASS[0m [   0.013s] ( 957/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_inline_passthrough_single[0m
+[32;1m        PASS[0m [   0.010s] ( 958/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_section_with_passthrough[0m
+[32;1m        PASS[0m [   0.015s] ( 959/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_inline_passthrough_single_plus[0m
+[32;1m        PASS[0m [   0.013s] ( 960/1513) [35;1macdc-parser[0m [36mgrammar::inline_preprocessor::tests[0m[36m::[0m[34;1mtest_preprocess_inline_passthrough_triple[0m
+[32;1m        PASS[0m [   0.010s] ( 961/1513) [35;1macdc-parser[0m [36mgrammar::line_map::tests[0m[36m::[0m[34;1mtest_line_map_beyond_input[0m
+[32;1m        PASS[0m [   0.011s] ( 962/1513) [35;1macdc-parser[0m [36mgrammar::line_map::tests[0m[36m::[0m[34;1mtest_line_map_asciidoc_example[0m
+[32;1m        PASS[0m [   0.012s] ( 963/1513) [35;1macdc-parser[0m [36mgrammar::line_map::tests[0m[36m::[0m[34;1mtest_line_map_empty_input[0m
+[32;1m        PASS[0m [   0.010s] ( 964/1513) [35;1macdc-parser[0m [36mgrammar::line_map::tests[0m[36m::[0m[34;1mtest_line_map_empty_lines[0m
+[32;1m        PASS[0m [   0.012s] ( 965/1513) [35;1macdc-parser[0m [36mgrammar::line_map::tests[0m[36m::[0m[34;1mtest_line_map_multiple_lines[0m
+[32;1m        PASS[0m [   0.010s] ( 966/1513) [35;1macdc-parser[0m [36mgrammar::location_mapping::tests[0m[36m::[0m[34;1mlonger_text_before_subscript_unaffected[0m
+[32;1m        PASS[0m [   0.012s] ( 967/1513) [35;1macdc-parser[0m [36mgrammar::line_map::tests[0m[36m::[0m[34;1mtest_line_map_single_line[0m
+[32;1m        PASS[0m [   0.012s] ( 968/1513) [35;1macdc-parser[0m [36mgrammar::line_map::tests[0m[36m::[0m[34;1mtest_line_map_utf8_content[0m
+[32;1m        PASS[0m [   0.011s] ( 969/1513) [35;1macdc-parser[0m [36mgrammar::location_mapping::tests[0m[36m::[0m[34;1msubscript_after_single_char_has_monotonic_positions[0m
+[32;1m        PASS[0m [   0.012s] ( 970/1513) [35;1macdc-parser[0m [36mgrammar::location_mapping::tests[0m[36m::[0m[34;1mshort_text_before_subscript_no_constrained_heuristic[0m
+[32;1m        PASS[0m [   0.011s] ( 971/1513) [35;1macdc-parser[0m [36mgrammar::location_mapping::tests[0m[36m::[0m[34;1msubscript_before_single_char_has_monotonic_positions[0m
+[32;1m        PASS[0m [   0.012s] ( 972/1513) [35;1macdc-parser[0m [36mgrammar::location_mapping::tests[0m[36m::[0m[34;1msuperscript_after_single_char_has_monotonic_positions[0m
+[32;1m        PASS[0m [   0.014s] ( 973/1513) [35;1macdc-parser[0m [36mgrammar::location_mapping::tests[0m[36m::[0m[34;1msuperscript_before_single_char_has_monotonic_positions[0m
+[32;1m        PASS[0m [   0.012s] ( 974/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_derive_name_section_attrs_no_separator[0m
+[32;1m        PASS[0m [   0.013s] ( 975/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_derive_name_section_attrs[0m
+[32;1m        PASS[0m [   0.011s] ( 976/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_parse_manpage_title_volume_5[0m
+[32;1m        PASS[0m [   0.012s] ( 977/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_parse_manpage_title_simple[0m
+[32;1m        PASS[0m [   0.013s] ( 978/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_parse_manpage_title_invalid[0m
+[32;1m        PASS[0m [   0.012s] ( 979/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_parse_manpage_title_with_letter[0m
+[32;1m        PASS[0m [   0.012s] ( 980/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_sanitize_mantitle_collapses_hyphens[0m
+[32;1m        PASS[0m [   0.014s] ( 981/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_parse_manpage_title_with_hyphen[0m
+[32;1m        PASS[0m [   0.014s] ( 982/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_sanitize_mantitle_mixed_chars[0m
+[32;1m        PASS[0m [   0.011s] ( 983/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_sanitize_mantitle_simple[0m
+[32;1m        PASS[0m [   0.013s] ( 984/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_sanitize_mantitle_preserves_underscores[0m
+[32;1m        PASS[0m [   0.014s] ( 985/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_sanitize_mantitle_trims_hyphens[0m
+[32;1m        PASS[0m [   0.011s] ( 986/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_constrained_bold_pattern[0m
+[32;1m        PASS[0m [   0.012s] ( 987/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_constrained_italic_pattern[0m
+[32;1m        PASS[0m [   0.014s] ( 988/1513) [35;1macdc-parser[0m [36mgrammar::manpage::tests[0m[36m::[0m[34;1mtest_sanitize_mantitle_with_special_chars[0m
+[32;1m        PASS[0m [   0.011s] ( 989/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_empty_input[0m
+[32;1m        PASS[0m [   0.013s] ( 990/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_constrained_monospace_pattern[0m
+[32;1m        PASS[0m [   0.014s] ( 991/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_escaped_subscript_not_parsed[0m
+[32;1m        PASS[0m [   0.011s] ( 992/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_escaped_superscript_not_parsed[0m
+[32;1m        PASS[0m [   0.012s] ( 993/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_highlight_pattern[0m
+[32;1m        PASS[0m [   0.013s] ( 994/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_multiple_formats_in_sequence[0m
+[32;1m        PASS[0m [   0.012s] ( 995/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_subscript_pattern[0m
+[32;1m        PASS[0m [   0.013s] ( 996/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_plain_text_only[0m
+[32;1m        PASS[0m [   0.014s] ( 997/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_superscript_pattern[0m
+[32;1m        PASS[0m [   0.012s] ( 998/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_unconstrained_bold_pattern[0m
+[32;1m        PASS[0m [   0.013s] ( 999/1513) [35;1macdc-parser[0m [36mgrammar::passthrough_processing::tests[0m[36m::[0m[34;1mtest_unconstrained_italic_pattern[0m
+[32;1m        PASS[0m [   0.013s] (1000/1513) [35;1macdc-parser[0m [36mgrammar::state::tests[0m[36m::[0m[34;1madd_warning_deduplicates_identical_messages[0m
+[32;1m        PASS[0m [   0.011s] (1001/1513) [35;1macdc-parser[0m [36mgrammar::state::tests[0m[36m::[0m[34;1madd_warning_preserves_distinct_messages[0m
+[32;1m        PASS[0m [   0.012s] (1002/1513) [35;1macdc-parser[0m [36mgrammar::state::tests[0m[36m::[0m[34;1madd_warning_preserves_insertion_order[0m
+[32;1m        PASS[0m [   0.014s] (1003/1513) [35;1macdc-parser[0m [36mgrammar::state::tests[0m[36m::[0m[34;1madd_warning_is_shared_across_inline_subparses[0m
+[32;1m        PASS[0m [   0.010s] (1004/1513) [35;1macdc-parser[0m [36mgrammar::state::tests[0m[36m::[0m[34;1mcreate_error_source_location_falls_back_to_current_file[0m
+[32;1m        PASS[0m [   0.011s] (1005/1513) [35;1macdc-parser[0m [36mgrammar::state::tests[0m[36m::[0m[34;1memit_warnings_outputs_via_tracing[0m
+[32;1m        PASS[0m [   0.013s] (1006/1513) [35;1macdc-parser[0m [36mgrammar::state::tests[0m[36m::[0m[34;1mcreate_error_source_location_resolves_included_file[0m
+[32;1m        PASS[0m [   0.010s] (1007/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_ensure_boundary_forward[0m
+[32;1m        PASS[0m [   0.011s] (1008/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_ensure_boundary_forward_mixed[0m
+[32;1m        PASS[0m [   0.014s] (1009/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_ensure_boundary[0m
+[32;1m        PASS[0m [   0.015s] (1010/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_ensure_boundary_forward_beyond_input[0m
+[32;1m        PASS[0m [   0.012s] (1011/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_safe_decrement_ascii[0m
+[32;1m        PASS[0m [   0.013s] (1012/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_safe_decrement_mixed[0m
+[32;1m        PASS[0m [   0.015s] (1013/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_safe_decrement_emoji[0m
+[32;1m        PASS[0m [   0.013s] (1014/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_snap_backward_mid_char[0m
+[32;1m        PASS[0m [   0.014s] (1015/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_safe_decrement_with_newline[0m
+[32;1m        PASS[0m [   0.011s] (1016/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_snap_backward_on_boundary[0m
+[32;1m        PASS[0m [   0.012s] (1017/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_snap_forward_mid_char[0m
+[32;1m        PASS[0m [   0.014s] (1018/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_snap_beyond_input[0m
+[32;1m        PASS[0m [   0.011s] (1019/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_snap_forward_on_boundary[0m
+[32;1m        PASS[0m [   0.012s] (1020/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_step_backward[0m
+[32;1m        PASS[0m [   0.013s] (1021/1513) [35;1macdc-parser[0m [36mgrammar::utf8_utils::tests[0m[36m::[0m[34;1mtest_step_forward[0m
+[32;1m        PASS[0m [   0.011s] (1022/1513) [35;1macdc-parser[0m [36mmodel::media::tests[0m[36m::[0m[34;1msource_display_no_trailing_slash_when_absent[0m
+[32;1m        PASS[0m [   0.012s] (1023/1513) [35;1macdc-parser[0m [36mmodel::media::tests[0m[36m::[0m[34;1msource_display_preserves_path_trailing_slash[0m
+[32;1m        PASS[0m [   0.013s] (1024/1513) [35;1macdc-parser[0m [36mmodel::media::tests[0m[36m::[0m[34;1msource_display_preserves_path_without_trailing_slash[0m
+[32;1m        PASS[0m [   0.011s] (1025/1513) [35;1macdc-parser[0m [36mmodel::media::tests[0m[36m::[0m[34;1msource_display_preserves_query_without_path[0m
+[32;1m        PASS[0m [   0.013s] (1026/1513) [35;1macdc-parser[0m [36mmodel::media::tests[0m[36m::[0m[34;1msource_display_preserves_trailing_slash[0m
+[32;1m        PASS[0m [   0.013s] (1027/1513) [35;1macdc-parser[0m [36mmodel::media::tests[0m[36m::[0m[34;1msource_display_preserves_trailing_slash_with_query[0m
+[32;1m        PASS[0m [   0.011s] (1028/1513) [35;1macdc-parser[0m [36mmodel::section::tests[0m[36m::[0m[34;1mtest_id_from_title_preserves_underscores[0m
+[32;1m        PASS[0m [   0.012s] (1029/1513) [35;1macdc-parser[0m [36mmodel::section::tests[0m[36m::[0m[34;1mtest_id_from_title[0m
+[32;1m        PASS[0m [   0.013s] (1030/1513) [35;1macdc-parser[0m [36mmodel::section::tests[0m[36m::[0m[34;1mtest_section_generate_id[0m
+[32;1m        PASS[0m [   0.011s] (1031/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_01_explicit_specialchars_disables_macros[0m
+[32;1m        PASS[0m [   0.012s] (1032/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_02_explicit_specialchars_disables_attributes[0m
+[32;1m        PASS[0m [   0.013s] (1033/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_03_explicit_specialchars_disables_post_replacements[0m
+[32;1m        PASS[0m [   0.011s] (1034/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_05_explicit_specialchars_disables_callouts[0m
+[32;1m        PASS[0m [   0.012s] (1035/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_04_explicit_specialchars_disables_quotes[0m
+[32;1m        PASS[0m [   0.010s] (1036/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_09_explicit_quotes[0m
+[32;1m        PASS[0m [   0.012s] (1037/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_08_explicit_post_replacements[0m
+[32;1m        PASS[0m [   0.267s] (1038/1513) [35;1macdc-lsp[0m [36mstate::workspace::tests[0m[36m::[0m[34;1mupdate_document_does_not_accumulate_state[0m
+[32;1m        PASS[0m [   0.013s] (1039/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_07_explicit_attributes[0m
+[32;1m        PASS[0m [   0.012s] (1040/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_11_short_alias_p_enables_post_replacements[0m
+[32;1m        PASS[0m [   0.013s] (1041/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_10_explicit_callouts[0m
+[32;1m        PASS[0m [   0.014s] (1042/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_12_short_alias_q_enables_quotes[0m
+[32;1m        PASS[0m [   0.020s] (1043/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_06_explicit_macros[0m
+[32;1m        PASS[0m [   0.013s] (1044/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_14_baseline_normal_includes_attributes[0m
+[32;1m        PASS[0m [   0.014s] (1045/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_13_baseline_normal_includes_macros[0m
+[32;1m        PASS[0m [   0.015s] (1046/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_15_baseline_normal_includes_post_replacements[0m
+[32;1m        PASS[0m [   0.013s] (1047/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_18_modifier_remove_macros[0m
+[32;1m        PASS[0m [   0.014s] (1048/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_16_baseline_normal_includes_quotes[0m
+[32;1m        PASS[0m [   0.016s] (1049/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_17_baseline_verbatim_includes_callouts[0m
+[32;1m        PASS[0m [   0.011s] (1050/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_19_modifier_remove_attributes[0m
+[32;1m        PASS[0m [   0.013s] (1051/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_21_modifier_remove_quotes[0m
+[32;1m        PASS[0m [   0.013s] (1052/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_20_modifier_remove_post_replacements[0m
+[32;1m        PASS[0m [   0.015s] (1053/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_22_modifier_remove_callouts[0m
+[32;1m        PASS[0m [   0.011s] (1054/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_26_modifier_add_quotes[0m
+[32;1m        PASS[0m [   0.012s] (1055/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_23_modifier_add_macros[0m
+[32;1m        PASS[0m [   0.013s] (1056/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_25_modifier_add_post_replacements[0m
+[32;1m        PASS[0m [   0.015s] (1057/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_24_modifier_add_attributes[0m
+[32;1m        PASS[0m [   0.013s] (1058/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_28_none_disables_macros[0m
+[32;1m        PASS[0m [   0.015s] (1059/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_27_modifier_add_callouts[0m
+[32;1m        PASS[0m [   0.015s] (1060/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_29_none_disables_attributes[0m
+[32;1m        PASS[0m [   0.011s] (1061/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_all_individual_types[0m
+[32;1m        PASS[0m [   0.011s] (1062/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_append_modifier[0m
+[32;1m        PASS[0m [   0.018s] (1063/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_30_none_disables_post_replacements[0m
+[32;1m        PASS[0m [   0.017s] (1064/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_32_none_disables_callouts[0m
+[32;1m        PASS[0m [   0.012s] (1065/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_asciidoctor_example[0m
+[32;1m        PASS[0m [   0.020s] (1066/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests::is_disabled_matches_spec[0m[36m::[0m[34;1mcase_31_none_disables_quotes[0m
+[32;1m        PASS[0m [   0.016s] (1067/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_append_normal_group[0m
+[32;1m        PASS[0m [   0.011s] (1068/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_combined_modifiers[0m
+[32;1m        PASS[0m [   0.013s] (1069/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_duplicates_ignored[0m
+[32;1m        PASS[0m [   0.013s] (1070/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_mixed_modifier_list[0m
+[32;1m        PASS[0m [   0.011s] (1071/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_modifier_only_at_end[0m
+[32;1m        PASS[0m [   0.012s] (1072/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_none[0m
+[32;1m        PASS[0m [   0.017s] (1073/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_empty_string[0m
+[32;1m        PASS[0m [   0.013s] (1074/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_none_with_whitespace[0m
+[32;1m        PASS[0m [   0.011s] (1075/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_ordering_preserved[0m
+[32;1m        PASS[0m [   0.018s] (1076/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_modifier_in_middle[0m
+[32;1m        PASS[0m [   0.016s] (1077/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_normal_expands[0m
+[32;1m        PASS[0m [   0.016s] (1078/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_normal_in_list_expands[0m
+[32;1m        PASS[0m [   0.015s] (1079/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_prepend_modifier[0m
+[32;1m        PASS[0m [   0.015s] (1080/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_remove_all_verbatim[0m
+[32;1m        PASS[0m [   0.014s] (1081/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_remove_normal_group[0m
+[32;1m        PASS[0m [   0.013s] (1082/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_shorthand_list[0m
+[32;1m        PASS[0m [   0.017s] (1083/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_remove_modifier[0m
+[32;1m        PASS[0m [   0.014s] (1084/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_shorthand_types[0m
+[32;1m        PASS[0m [   0.013s] (1085/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_specialchars[0m
+[32;1m        PASS[0m [   0.012s] (1086/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_unknown_is_skipped[0m
+[32;1m        PASS[0m [   0.017s] (1087/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_specialcharacters_alias[0m
+[32;1m        PASS[0m [   0.014s] (1088/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_unknown_mixed_with_valid[0m
+[32;1m        PASS[0m [   0.013s] (1089/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_verbatim_expands[0m
+[32;1m        PASS[0m [   0.019s] (1090/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_specialchars_shorthand[0m
+[32;1m        PASS[0m [   0.012s] (1091/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_resolve_explicit_ignores_baseline[0m
+[32;1m        PASS[0m [   0.011s] (1092/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_resolve_modifiers_with_verbatim_baseline[0m
+[32;1m        PASS[0m [   0.016s] (1093/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_resolve_attribute_references[0m
+[32;1m        PASS[0m [   0.015s] (1094/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_resolve_modifiers_with_normal_baseline[0m
+[32;1m        PASS[0m [   0.014s] (1095/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_substitute_single_pass_expansion[0m
+[32;1m        PASS[0m [   0.012s] (1096/1513) [35;1macdc-parser[0m [36mpreprocessor::attribute::tests[0m[36m::[0m[34;1mtest_definition_time_attribute_expansion[0m
+[32;1m        PASS[0m [   0.012s] (1097/1513) [35;1macdc-parser[0m [36mpreprocessor::attribute::tests[0m[36m::[0m[34;1mtest_parse_complex_name[0m
+[32;1m        PASS[0m [   0.012s] (1098/1513) [35;1macdc-parser[0m [36mpreprocessor::attribute::tests[0m[36m::[0m[34;1mtest_parse_empty_value[0m
+[32;1m        PASS[0m [   0.025s] (1099/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_parse_subs_with_spaces[0m
+[32;1m        PASS[0m [   0.012s] (1100/1513) [35;1macdc-parser[0m [36mpreprocessor::attribute::tests[0m[36m::[0m[34;1mtest_parse_unset_attribute[0m
+[32;1m        PASS[0m [   0.015s] (1101/1513) [35;1macdc-parser[0m [36mpreprocessor::attribute::tests[0m[36m::[0m[34;1mtest_parse_simple_attribute[0m
+[32;1m        PASS[0m [   0.021s] (1102/1513) [35;1macdc-parser[0m [36mmodel::substitution::tests[0m[36m::[0m[34;1mtest_utf8_boundary_handling[0m
+[32;1m        PASS[0m [   0.015s] (1103/1513) [35;1macdc-parser[0m [36mpreprocessor::attribute::tests[0m[36m::[0m[34;1mtest_undefined_attribute_kept_literal[0m
+[32;1m        PASS[0m [   0.012s] (1104/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_endif_no_attribute[0m
+[32;1m        PASS[0m [   0.013s] (1105/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_endif[0m
+[32;1m        PASS[0m [   0.011s] (1106/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifdef_single_attribute[0m
+[32;1m        PASS[0m [   0.013s] (1107/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifdef_with_content[0m
+[32;1m        PASS[0m [   0.018s] (1108/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifdef_and_attributes[0m
+[32;1m        PASS[0m [   0.012s] (1109/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifeval_greater_than_string_vs_number[0m
+[32;1m        PASS[0m [   0.014s] (1110/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifeval_simple_math[0m
+[32;1m        PASS[0m [   0.018s] (1111/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifdef_or_attributes[0m
+[32;1m        PASS[0m [   0.013s] (1112/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifeval_str_equality[0m
+[32;1m        PASS[0m [   0.014s] (1113/1513) [35;1macdc-parser[0m [36mpreprocessor::conditional::tests[0m[36m::[0m[34;1mtest_ifndef[0m
+[32;1m        PASS[0m [   0.013s] (1114/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_apply_indent_empty_lines[0m
+[32;1m        PASS[0m [   0.014s] (1115/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_apply_indent_mixed_whitespace[0m
+[32;1m        PASS[0m [   0.015s] (1116/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_apply_indent_basic[0m
+[32;1m        PASS[0m [   0.013s] (1117/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_include_with_attributes[0m
+[32;1m        PASS[0m [   0.014s] (1118/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_apply_indent_zero[0m
+[32;1m        PASS[0m [   0.012s] (1119/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_include_with_tags_attribute[0m
+[32;1m        PASS[0m [   0.013s] (1120/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_include_with_indent[0m
+[32;1m        PASS[0m [   0.014s] (1121/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_include_with_negated_tag[0m
+[32;1m        PASS[0m [   0.012s] (1122/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_include_with_url[0m
+[32;1m        PASS[0m [   0.014s] (1123/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_quoted_attributes[0m
+[32;1m        PASS[0m [   0.015s] (1124/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_include_with_wildcard[0m
+[32;1m        PASS[0m [   0.013s] (1125/1513) [35;1macdc-parser[0m [36mpreprocessor::include::tests[0m[36m::[0m[34;1mtest_parse_simple_include[0m
+[32;1m        PASS[0m [   0.012s] (1126/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_apply_tag_filters_double_wildcard[0m
+[32;1m        PASS[0m [   0.013s] (1127/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_apply_tag_filters_select_untagged[0m
+[32;1m        PASS[0m [   0.014s] (1128/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_apply_tag_filters_multiple_tags[0m
+[32;1m        PASS[0m [   0.015s] (1129/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_apply_tag_filters_negation[0m
+[32;1m        PASS[0m [   0.012s] (1130/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_apply_tag_filters_single_tag[0m
+[32;1m        PASS[0m [   0.014s] (1131/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_apply_tag_filters_wildcard[0m
+[32;1m        PASS[0m [   0.015s] (1132/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_extract_tag_directive_at_line_start[0m
+[32;1m        PASS[0m [   0.012s] (1133/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_extract_tag_directive_invalid[0m
+[32;1m        PASS[0m [   0.013s] (1134/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_extract_tag_directive_complex_names[0m
+[32;1m        PASS[0m [   0.011s] (1135/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_extract_tag_directive_various_comment_styles[0m
+[32;1m        PASS[0m [   0.016s] (1136/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_extract_tag_directive_simple[0m
+[32;1m        PASS[0m [   0.012s] (1137/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_extract_tag_directive_word_boundary[0m
+[32;1m        PASS[0m [   0.011s] (1138/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_find_tag_regions_multiple[0m
+[32;1m        PASS[0m [   0.012s] (1139/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_find_tag_regions_single[0m
+[32;1m        PASS[0m [   0.013s] (1140/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_tag_filter_parse_negated[0m
+[32;1m        PASS[0m [   0.012s] (1141/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_bad_endif_directive[0m
+[32;1m        PASS[0m [   0.013s] (1142/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_tag_filter_parse_with_whitespace[0m
+[32;1m        PASS[0m [   0.018s] (1143/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_tag_filter_parse_simple[0m
+[32;1m        PASS[0m [   0.017s] (1144/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_explicit_encoding_override[0m
+[32;1m        PASS[0m [   0.018s] (1145/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_tag_filter_parse_wildcards[0m
+[32;1m        PASS[0m [   0.011s] (1146/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_tag_with_lines[0m
+[32;1m        PASS[0m [   0.023s] (1147/1513) [35;1macdc-parser[0m [36mpreprocessor::tag::tests[0m[36m::[0m[34;1mtest_find_tag_regions_nested[0m
+[32;1m        PASS[0m [   0.014s] (1148/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_select_untagged_only[0m
+[32;1m        PASS[0m [   0.019s] (1149/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_good_endif_directive[0m
+[32;1m        PASS[0m [   0.012s] (1150/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_utf16_file[0m
+[32;1m        PASS[0m [   0.011s] (1151/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_indent_and_tag[0m
+[32;1m        PASS[0m [   0.014s] (1152/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_double_wildcard[0m
+[32;1m        PASS[0m [   0.013s] (1153/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_indent_zero[0m
+[32;1m        PASS[0m [   0.017s] (1154/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_indent[0m
+[32;1m        PASS[0m [   0.014s] (1155/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_multiple_tags[0m
+[32;1m        PASS[0m [   0.011s] (1156/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_nested_tag[0m
+[32;1m        PASS[0m [   0.013s] (1157/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_single_tag[0m
+[32;1m        PASS[0m [   0.013s] (1158/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_process[0m
+[32;1m        PASS[0m [   0.015s] (1159/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_nested_include_relative_paths[0m
+[32;1m        PASS[0m [   0.014s] (1160/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_unknown_encoding_error[0m
+[32;1m        PASS[0m [   0.018s] (1161/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_include_with_wildcard_excluding_tag[0m
+[32;1m        PASS[0m [   0.016s] (1162/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_utf16be_bom_detection[0m
+[32;1m        PASS[0m [   0.013s] (1163/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_utf16le_bom_detection[0m
+[32;1m        PASS[0m [   0.014s] (1164/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_utf8_bom_detection[0m
+[32;1m        PASS[0m [   0.023s] (1165/1513) [35;1macdc-parser[0m [36mpreprocessor::tests[0m[36m::[0m[34;1mtest_utf8_no_bom[0m
+[32;1m        PASS[0m [   0.059s] (1166/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1minline_parser_never_panics[0m
+[32;1m        PASS[0m [   0.016s] (1167/1513) [35;1macdc-parser[0m [36msafe_mode::tests[0m[36m::[0m[34;1mtest_from_str[0m
+[32;1m        PASS[0m [   0.086s] (1168/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mall_locations_in_bounds[0m
+[32;1m        PASS[0m [   0.087s] (1169/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mbyte_offsets_utf8_safe[0m
+[32;1m        PASS[0m [   0.088s] (1170/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mparser_never_panics[0m
+[32;1m        PASS[0m [   0.099s] (1171/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mdelimited_block_positions_monotonic[0m
+[32;1m        PASS[0m [   0.014s] (1172/1513) [35;1macdc-parser[0m [36msafe_mode::tests[0m[36m::[0m[34;1mtest_ordering[0m
+[32;1m        PASS[0m [   0.014s] (1173/1513) [35;1macdc-parser[0m [36mtests::attribute_resolution_tests[0m[36m::[0m[34;1mtest_chained_attribute_resolution[0m
+[32;1m        PASS[0m [   0.014s] (1174/1513) [35;1macdc-parser[0m [36mtests::attribute_resolution_tests[0m[36m::[0m[34;1mtest_definition_time_resolution_bar_defined_after[0m
+[32;1m        PASS[0m [   0.011s] (1175/1513) [35;1macdc-parser[0m [36mtests::attribute_resolution_tests[0m[36m::[0m[34;1mtest_definition_time_resolution_bar_defined_first[0m
+[32;1m        PASS[0m [   0.011s] (1176/1513) [35;1macdc-parser[0m [36mtests::empty_document_tests[0m[36m::[0m[34;1mtest_document_with_content_after_whitespace[0m
+[32;1m        PASS[0m [   0.012s] (1177/1513) [35;1macdc-parser[0m [36mtests::empty_document_tests[0m[36m::[0m[34;1mtest_unicode_characters[0m
+[32;1m        PASS[0m [   0.015s] (1178/1513) [35;1macdc-parser[0m [36mtests::empty_document_tests[0m[36m::[0m[34;1mtest_whitespace_only_documents[0m
+[32;1m        PASS[0m [   0.012s] (1179/1513) [35;1macdc-parser[0m [36mtests::parse_result_tests[0m[36m::[0m[34;1msection_level_out_of_sequence_surfaces_on_parse_result[0m
+[32;1m        PASS[0m [   0.019s] (1180/1513) [35;1macdc-parser[0m [36mtests::parse_result_tests[0m[36m::[0m[34;1mmissing_include_warning_surfaces_on_parse_result[0m
+[32;1m        PASS[0m [   0.011s] (1181/1513) [35;1macdc-parser[0m [36mtests::parse_result_tests[0m[36m::[0m[34;1msubs_attribute_always_surfaces_a_warning[0m
+[32;1m        PASS[0m [   0.011s] (1182/1513) [35;1macdc-parser[0m [36mtests::parse_result_tests[0m[36m::[0m[34;1mvalid_document_has_no_warnings[0m
+[32;1m        PASS[0m [   0.012s] (1183/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_002_fixtures_tests_admonition_paragraph_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1184/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_001_fixtures_tests_admonition_block_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1185/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_003_fixtures_tests_admonition_with_title_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1186/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_004_fixtures_tests_admonition_without_title_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1187/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_005_fixtures_tests_all_formatting_in_passthrough_constrained_adoc[0m
+[32;1m        PASS[0m [   0.141s] (1188/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mdescription_list_positions_monotonic[0m
+[32;1m        PASS[0m [   0.012s] (1189/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_006_fixtures_tests_all_formatting_in_passthrough_super_sub_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1190/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_008_fixtures_tests_anchor_attribute_substitution_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1191/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_007_fixtures_tests_all_formatting_in_passthrough_unconstrained_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1192/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_009_fixtures_tests_anchor_with_spaces_adoc[0m
+[32;1m        PASS[0m [   0.159s] (1193/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1minline_macros_never_panic[0m
+[32;1m        PASS[0m [   0.014s] (1194/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_010_fixtures_tests_author_from_attribute_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1195/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_011_fixtures_tests_bare_role_highlight_adoc[0m
+[32;1m        PASS[0m [   0.155s] (1196/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mnested_list_locations_in_bounds[0m
+[32;1m        PASS[0m [   0.011s] (1197/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_012_fixtures_tests_basic_header_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1198/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_014_fixtures_tests_basic_title_with_double_colon_with_subtitle_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1199/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_013_fixtures_tests_basic_image_block_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1200/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_016_fixtures_tests_bibliography_anchor_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1201/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_015_fixtures_tests_basic_title_with_subtitle_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1202/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_018_fixtures_tests_body_only_output_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1203/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_019_fixtures_tests_book_parts_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1204/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_020_fixtures_tests_boolean_attribute_expansion_adoc[0m
+[32;1m        PASS[0m [   0.024s] (1205/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_017_fixtures_tests_block_monotonic_coverage_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1206/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_023_fixtures_tests_callout_list_auto_numbering_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1207/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_021_fixtures_tests_boolean_attributes_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1208/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_022_fixtures_tests_button_inline_adoc[0m
+[32;1m        PASS[0m [   0.169s] (1209/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mtable_locations_in_bounds[0m
+[32;1m        PASS[0m [   0.017s] (1210/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_024_fixtures_tests_callout_list_basic_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1211/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_026_fixtures_tests_callout_list_mixed_auto_explicit_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1212/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_025_fixtures_tests_callout_list_literal_block_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1213/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_027_fixtures_tests_callout_list_multiple_callouts_same_line_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1214/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_028_fixtures_tests_callout_list_non_sequential_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1215/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_029_fixtures_tests_callout_list_not_after_verbatim_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1216/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_032_fixtures_tests_character_replacement_empty_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1217/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_033_fixtures_tests_combined_formatting_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1218/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_031_fixtures_tests_character_replacement_attributes_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1219/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_037_fixtures_tests_constrained_bold_isolation_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1220/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_030_fixtures_tests_callout_list_with_language_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1221/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_034_fixtures_tests_commas_in_link_text_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1222/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_035_fixtures_tests_constrained_bold_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1223/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_036_fixtures_tests_constrained_bold_html_tags_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1224/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_040_fixtures_tests_constrained_highlight_html_tags_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1225/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_043_fixtures_tests_constrained_italic_html_tags_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1226/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_045_fixtures_tests_constrained_monospace_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1227/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_041_fixtures_tests_constrained_highlight_with_internal_hashes_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1228/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_044_fixtures_tests_constrained_italic_with_internal_underscores_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1229/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_039_fixtures_tests_constrained_highlight_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1230/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_046_fixtures_tests_constrained_monospace_html_tags_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1231/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_038_fixtures_tests_constrained_bold_with_internal_asterisks_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1232/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_042_fixtures_tests_constrained_italic_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1233/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_047_fixtures_tests_constrained_monospace_with_internal_backticks_ado[0m
+[32;1m        PASS[0m [   0.014s] (1234/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_048_fixtures_tests_constrained_nesting_boundary_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1235/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_051_fixtures_tests_cross_reference_basic_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1236/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_052_fixtures_tests_cross_reference_custom_text_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1237/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_049_fixtures_tests_constrained_passthrough_plus_invalid_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1238/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_050_fixtures_tests_constrained_passthrough_plus_valid_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1239/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_055_fixtures_tests_cross_reference_xref_macro_path_fragment_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1240/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_053_fixtures_tests_cross_reference_simple_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1241/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_054_fixtures_tests_cross_reference_xref_macro_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1242/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_059_fixtures_tests_curved_quotes_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1243/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_057_fixtures_tests_curved_apostrophe_inline_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1244/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_056_fixtures_tests_cross_reference_xref_macro_with_fragment_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1245/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_060_fixtures_tests_curved_quotes_combined_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1246/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_058_fixtures_tests_curved_quotation_inline_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1247/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_063_fixtures_tests_delimited_block_with_identical_inner_delimited_sy[0m
+[32;1m        PASS[0m [   0.015s] (1248/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_062_fixtures_tests_delimited_block_with_header_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1249/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_064_fixtures_tests_delimited_block_within_section_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1250/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_061_fixtures_tests_delimited_block_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1251/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_065_fixtures_tests_description_list_anchor_boundary_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1252/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_069_fixtures_tests_description_list_different_delimiters_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1253/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_067_fixtures_tests_description_list_block_attributes_boundary_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1254/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_068_fixtures_tests_description_list_complex_terms_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1255/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_066_fixtures_tests_description_list_basic_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1256/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_070_fixtures_tests_description_list_empty_description_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1257/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_071_fixtures_tests_description_list_explicit_continuation_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1258/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_073_fixtures_tests_description_list_hash_term_in_section_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1259/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_072_fixtures_tests_description_list_followed_by_table_with_attribute[0m
+[32;1m        PASS[0m [   0.017s] (1260/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_074_fixtures_tests_description_list_implicit_continuation_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1261/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_077_fixtures_tests_description_list_multiple_blank_lines_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1262/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_079_fixtures_tests_description_list_no_blank_line_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1263/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_075_fixtures_tests_description_list_in_sidebar_section_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1264/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_076_fixtures_tests_description_list_mixed_content_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1265/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_078_fixtures_tests_description_list_nested_lists_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1266/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_080_fixtures_tests_description_list_no_inline_with_lists_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1267/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_081_fixtures_tests_description_list_separated_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.297s] (1268/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mrich_document_positions_monotonic[0m
+[32;1m        PASS[0m [   0.306s] (1269/1513) [35;1macdc-parser[0m [36mproptests::invariants[0m[36m::[0m[34;1mpositions_are_monotonic[0m
+[32;1m        PASS[0m [   0.011s] (1270/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_082_fixtures_tests_description_list_vs_setext_section_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1271/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_085_fixtures_tests_description_list_with_continuation_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1272/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_083_fixtures_tests_description_list_with_admonition_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1273/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_084_fixtures_tests_description_list_with_auto_attached_list_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1274/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_087_fixtures_tests_description_list_with_surrounding_blocks_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1275/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_088_fixtures_tests_discrete_header_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1276/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_086_fixtures_tests_description_list_with_ordered_list_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1277/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_090_fixtures_tests_discrete_heading_eof_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1278/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_091_fixtures_tests_document_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1279/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_089_fixtures_tests_discrete_heading_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1280/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_092_fixtures_tests_document_attributes_only_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1281/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_093_fixtures_tests_document_comment_start_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1282/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_094_fixtures_tests_document_title_with_attributes_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1283/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_095_fixtures_tests_document_title_with_bold_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1284/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_096_fixtures_tests_document_title_with_inline_markup_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1285/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_097_fixtures_tests_document_title_with_inline_subtitle_adoc[0m
+[32;1m        PASS[0m [   0.755s] (1286/1513) [35;1macdc-lsp::selection_range[0m [34;1mtest_initialize_advertises_selection_range[0m
+[32;1m        PASS[0m [   0.015s] (1287/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_098_fixtures_tests_document_with_admonition_adoc[0m
+[32;1m        PASS[0m [   0.763s] (1288/1513) [35;1macdc-lsp::inlay_hints[0m [34;1mtest_initialize_advertises_inlay_hints[0m
+[32;1m        PASS[0m [   0.014s] (1289/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_099_fixtures_tests_document_with_image_block_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1290/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_102_fixtures_tests_document_with_two_image_blocks_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1291/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_101_fixtures_tests_document_with_toc_block_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1292/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_100_fixtures_tests_document_with_page_breaks_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1293/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_103_fixtures_tests_document_with_two_video_ids_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1294/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_105_fixtures_tests_email_autolinks_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1295/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_104_fixtures_tests_dots_in_link_text_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1296/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_109_fixtures_tests_escaped_formatting_constrained_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1297/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_108_fixtures_tests_escaped_cross_reference_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1298/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_106_fixtures_tests_empty_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1299/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_107_fixtures_tests_escaped_character_replacements_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1300/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_110_fixtures_tests_escaped_formatting_unconstrained_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1301/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_111_fixtures_tests_escaped_macros_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1302/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_113_fixtures_tests_footnotes_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1303/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_112_fixtures_tests_escaped_superscript_subscript_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1304/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_115_fixtures_tests_hard_wrap_attribute_values_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1305/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_116_fixtures_tests_header_attribute_references_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1306/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_114_fixtures_tests_gradual_complexity_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1307/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_117_fixtures_tests_header_partial_attribute_refs_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1308/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_119_fixtures_tests_highlight_constrained_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1309/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_121_fixtures_tests_hr_after_paragraph_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1310/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_118_fixtures_tests_header_with_metadata_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1311/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_120_fixtures_tests_highlight_unconstrained_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1312/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_122_fixtures_tests_image_block_attributes_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1313/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_127_fixtures_tests_inline_image_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1314/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_124_fixtures_tests_inline_anchor_location_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1315/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_123_fixtures_tests_index_terms_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1316/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_126_fixtures_tests_inline_icon_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1317/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_128_fixtures_tests_inline_line_break_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1318/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_132_fixtures_tests_keyboard_comma_only_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1319/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_130_fixtures_tests_inline_raw_text_location_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1320/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_129_fixtures_tests_inline_line_break_indented_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1321/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_134_fixtures_tests_keyboard_plus_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1322/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_133_fixtures_tests_keyboard_inline_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1323/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_135_fixtures_tests_leveloffset_basic_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1324/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_137_fixtures_tests_leveloffset_included_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1325/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_131_fixtures_tests_inline_role_attributes_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1326/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_136_fixtures_tests_leveloffset_include_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1327/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_139_fixtures_tests_link_macro_with_url_fragment_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1328/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_138_fixtures_tests_link_macro_with_fragment_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1329/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_140_fixtures_tests_link_with_bold_text_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1330/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_144_fixtures_tests_link_with_passthrough_text_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1331/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_143_fixtures_tests_link_with_monospace_text_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1332/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_141_fixtures_tests_link_with_italic_text_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1333/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_142_fixtures_tests_link_with_mixed_markup_text_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1334/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_146_fixtures_tests_list_ancestor_continuation_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1335/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_145_fixtures_tests_link_with_whitespace_text_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1336/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_147_fixtures_tests_list_followed_by_paragraph_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1337/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_150_fixtures_tests_list_to_section_transition_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1338/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_149_fixtures_tests_list_separator_comment_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1339/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_148_fixtures_tests_list_multiline_adoc[0m
+[32;1m        PASS[0m [   0.051s] (1340/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_125_fixtures_tests_inline_heavy_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1341/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_151_fixtures_tests_listing_block_with_comments_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1342/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_154_fixtures_tests_literal_without_source_attribute_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1343/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_152_fixtures_tests_literal_block_with_comments_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1344/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_153_fixtures_tests_literal_paragraph_leading_spaces_adoc[0m
+[32;1m        PASS[0m [   0.011s] (1345/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_157_fixtures_tests_markdown_listing_blocks_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1346/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_156_fixtures_tests_markdown_blockquote_adoc[0m
+[32;1m        PASS[0m [   0.012s] (1347/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_161_fixtures_tests_monospace_in_regular_text_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1348/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_155_fixtures_tests_macros_with_quoted_attributes_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1349/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_160_fixtures_tests_monospace_constrained_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1350/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_159_fixtures_tests_mixed_comments_and_blocks_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1351/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_163_fixtures_tests_monospace_with_multiple_plus_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1352/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_158_fixtures_tests_menu_inline_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1353/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_164_fixtures_tests_monospace_with_nested_formatting_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1354/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_162_fixtures_tests_monospace_unconstrained_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1355/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_168_fixtures_tests_nested_delimited_blocks_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1356/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_165_fixtures_tests_monospace_with_quotes_inside_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1357/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_166_fixtures_tests_multiline_description_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1358/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_167_fixtures_tests_multiple_contiguous_and_nested_sections_with_mult[0m
+[32;1m        PASS[0m [   0.017s] (1359/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_169_fixtures_tests_nested_list_with_parent_continuation_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1360/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_173_fixtures_tests_nested_unordered_in_ordered_adoc[0m
+[32;1m        PASS[0m [   0.855s] (1361/1513) [35;1macdc-lsp::selection_range[0m [34;1mtest_selection_range_nested_inline[0m
+[32;1m        PASS[0m [   0.019s] (1362/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_171_fixtures_tests_nested_ordered_list_with_checkmarks_adoc[0m
+[32;1m        PASS[0m [   0.856s] (1363/1513) [35;1macdc-lsp::selection_range[0m [34;1mtest_selection_range_multiple_positions[0m
+[32;1m        PASS[0m [   0.015s] (1364/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_172_fixtures_tests_nested_sections_adoc[0m
+[32;1m        PASS[0m [   0.858s] (1365/1513) [35;1macdc-lsp::selection_range[0m [34;1mtest_selection_range_basic[0m
+[32;1m        PASS[0m [   0.861s] (1366/1513) [35;1macdc-lsp::inlay_hints[0m [34;1mtest_inlay_hint_xref[0m
+[32;1m        PASS[0m [   0.023s] (1367/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_170_fixtures_tests_nested_ordered_in_unordered_adoc[0m
+[32;1m        PASS[0m [   0.863s] (1368/1513) [35;1macdc-lsp::inlay_hints[0m [34;1mtest_inlay_hint_attribute[0m
+[32;1m        PASS[0m [   0.019s] (1369/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_174_fixtures_tests_open_block_with_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1370/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_176_fixtures_tests_ordered_list_with_checkmarks_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1371/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_175_fixtures_tests_ordered_list_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1372/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_178_fixtures_tests_page_break_with_attributes_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1373/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_177_fixtures_tests_ordered_list_with_explicit_continuation_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1374/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_181_fixtures_tests_paragraph_with_literal_attribute_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1375/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_179_fixtures_tests_paragraph_followed_by_listing_block_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1376/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_180_fixtures_tests_paragraph_roles_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1377/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_188_fixtures_tests_passthrough_macro_inline_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1378/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_185_fixtures_tests_passthrough_boundary_conditions_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1379/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_184_fixtures_tests_passthrough_block_with_comments_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1380/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_186_fixtures_tests_passthrough_escaped_asterisks_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1381/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_192_fixtures_tests_passthrough_nested_markup_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1382/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_193_fixtures_tests_passthrough_other_markup_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1383/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_183_fixtures_tests_passthrough_at_line_start_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1384/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_182_fixtures_tests_paragraph_with_title_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1385/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_191_fixtures_tests_passthrough_multiple_passthroughs_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1386/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_195_fixtures_tests_passthrough_unconstrained_bold_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1387/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_199_fixtures_tests_quote_with_attribution_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1388/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_196_fixtures_tests_passthrough_unconstrained_italic_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1389/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_189_fixtures_tests_passthrough_malformed_patterns_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1390/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_197_fixtures_tests_quote_block_with_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1391/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_200_fixtures_tests_quote_with_url_attribution_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1392/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_203_fixtures_tests_role_cols_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1393/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_201_fixtures_tests_quoted_paragraph_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1394/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_206_fixtures_tests_role_horizontal_properties_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1395/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_202_fixtures_tests_regular_paragraph_adoc[0m
+[32;1m        PASS[0m [   0.038s] (1396/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_187_fixtures_tests_passthrough_html_entities_adoc[0m
+[32;1m        PASS[0m [   0.032s] (1397/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_194_fixtures_tests_passthrough_quotes_multiple_markup_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1398/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_205_fixtures_tests_role_formal_with_options_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1399/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_207_fixtures_tests_role_horizontal_properties_with_options_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1400/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_209_fixtures_tests_section_with_invalid_subsection_adoc[0m
+[32;1m        PASS[0m [   0.041s] (1401/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_190_fixtures_tests_passthrough_multiple_bold_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1402/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_212_fixtures_tests_simple_attribute_substitution_adoc[0m
+[32;1m        PASS[0m [   0.022s] (1403/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_208_fixtures_tests_section_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1404/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_211_fixtures_tests_section_with_valid_subsection_interleaved_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1405/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_213_fixtures_tests_simple_patterns_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.030s] (1406/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_204_fixtures_tests_role_formal_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1407/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_218_fixtures_tests_source_block_with_delimiter_in_content_adoc[0m
+[32;1m        PASS[0m [   0.046s] (1408/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_198_fixtures_tests_quote_block_with_url_citation_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1409/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_214_fixtures_tests_single_quoted_attribute_values_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1410/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_216_fixtures_tests_source_block_with_attribute_in_title_adoc[0m
+[32;1m        PASS[0m [   0.029s] (1411/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_210_fixtures_tests_section_with_multiple_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.024s] (1412/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_219_fixtures_tests_stem_blocks_adoc[0m
+[32;1m        PASS[0m [   0.028s] (1413/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_217_fixtures_tests_source_block_with_comments_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1414/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_221_fixtures_tests_style_with_formal_attributes_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1415/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_223_fixtures_tests_subs_append_attributes_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1416/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_224_fixtures_tests_subs_append_quotes_adoc[0m
+[32;1m        PASS[0m [   0.033s] (1417/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_215_fixtures_tests_source_block_complete_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1418/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_225_fixtures_tests_subs_append_replacements_adoc[0m
+[32;1m        PASS[0m [   0.028s] (1419/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_222_fixtures_tests_styled_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1420/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_227_fixtures_tests_subs_callouts_explicit_adoc[0m
+[32;1m        PASS[0m [   0.032s] (1421/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_220_fixtures_tests_strong_constrained_single_char_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1422/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_233_fixtures_tests_subs_paragraph_modifier_add_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1423/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_228_fixtures_tests_subs_combined_modifiers_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1424/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_231_fixtures_tests_subs_macros_disabled_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1425/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_237_fixtures_tests_subs_post_replacements_disabled_adoc[0m
+[32;1m        PASS[0m [   0.024s] (1426/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_230_fixtures_tests_subs_explicit_no_macros_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1427/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_234_fixtures_tests_subs_paragraph_modifier_remove_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1428/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_236_fixtures_tests_subs_pass_macros_disabled_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1429/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_240_fixtures_tests_subs_quotes_disabled_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1430/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_235_fixtures_tests_subs_pass_attributes_macros_disabled_adoc[0m
+[32;1m        PASS[0m [   0.032s] (1431/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_229_fixtures_tests_subs_comma_list_adoc[0m
+[32;1m        PASS[0m [   0.029s] (1432/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_232_fixtures_tests_subs_none_adoc[0m
+[32;1m        PASS[0m [   0.038s] (1433/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_226_fixtures_tests_subs_callouts_disabled_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1434/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_238_fixtures_tests_subs_post_replacements_explicit_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1435/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_241_fixtures_tests_subs_quotes_explicit_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1436/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_243_fixtures_tests_subs_replacements_disabled_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1437/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_244_fixtures_tests_subs_replacements_explicit_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1438/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_245_fixtures_tests_subs_specialchars_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1439/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_242_fixtures_tests_subs_remove_specialchars_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1440/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_249_fixtures_tests_subscript_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1441/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_246_fixtures_tests_subs_specialchars_disabled_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1442/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_253_fixtures_tests_superscript_subscript_combined_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1443/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_247_fixtures_tests_subs_specialchars_explicit_adoc[0m
+[32;1m        PASS[0m [   0.022s] (1444/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_250_fixtures_tests_subscript_inline_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1445/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_248_fixtures_tests_subs_specialchars_no_attributes_adoc[0m
+[32;1m        PASS[0m [   0.037s] (1446/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_239_fixtures_tests_subs_prepend_quotes_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1447/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_255_fixtures_tests_table_cell_alignment_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1448/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_258_fixtures_tests_table_cell_rowspan_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1449/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_251_fixtures_tests_superscript_in_passthrough_adoc[0m
+[32;1m        PASS[0m [   0.022s] (1450/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_254_fixtures_tests_superscript_subscript_isolation_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1451/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_260_fixtures_tests_table_column_alignment_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1452/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_261_fixtures_tests_table_column_alignment_combined_adoc[0m
+[32;1m        PASS[0m [   0.027s] (1453/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_256_fixtures_tests_table_cell_colspan_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1454/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_262_fixtures_tests_table_column_alignment_multiplier_adoc[0m
+[32;1m        PASS[0m [   0.035s] (1455/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_252_fixtures_tests_superscript_inline_adoc[0m
+[32;1m        PASS[0m [   0.027s] (1456/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_257_fixtures_tests_table_cell_duplication_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1457/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_264_fixtures_tests_table_csv_basic_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1458/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_263_fixtures_tests_table_column_alignment_right_middle_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1459/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_268_fixtures_tests_table_dsv_escaped_separator_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1460/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_272_fixtures_tests_table_multi_cell_per_line_adoc[0m
+[32;1m        PASS[0m [   0.024s] (1461/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_265_fixtures_tests_table_csv_multiline_adoc[0m
+[32;1m        PASS[0m [   0.020s] (1462/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_270_fixtures_tests_table_incomplete_row_adoc[0m
+[32;1m        PASS[0m [   0.031s] (1463/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_259_fixtures_tests_table_cell_span_combined_adoc[0m
+[32;1m        PASS[0m [   0.024s] (1464/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_267_fixtures_tests_table_dsv_basic_adoc[0m
+[32;1m        PASS[0m [   0.029s] (1465/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_266_fixtures_tests_table_csv_no_header_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1466/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_274_fixtures_tests_table_nested_multiple_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1467/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_273_fixtures_tests_table_nested_basic_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1468/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_275_fixtures_tests_table_nested_with_content_adoc[0m
+[32;1m        PASS[0m [   0.030s] (1469/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_269_fixtures_tests_table_empty_cells_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1470/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_276_fixtures_tests_table_psv_escaped_separator_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1471/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_279_fixtures_tests_table_with_header_and_footer_adoc[0m
+[32;1m        PASS[0m [   0.022s] (1472/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_277_fixtures_tests_table_rowspan_with_cols_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1473/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_282_fixtures_tests_thematic_break_with_title_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1474/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_286_fixtures_tests_toc_with_literal_levels_adoc[0m
+[32;1m        PASS[0m [   0.036s] (1475/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_271_fixtures_tests_table_incomplete_row_single_line_adoc[0m
+[32;1m        PASS[0m [   0.017s] (1476/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_285_fixtures_tests_toc_with_attribute_substitution_adoc[0m
+[32;1m        PASS[0m [   0.025s] (1477/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_278_fixtures_tests_table_tsv_basic_adoc[0m
+[32;1m        PASS[0m [   0.015s] (1478/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_287_fixtures_tests_two_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.028s] (1479/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_280_fixtures_tests_test_noblanks_adoc[0m
+[32;1m        PASS[0m [   0.014s] (1480/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_290_fixtures_tests_unconstrained_monospace_adoc[0m
+[32;1m        PASS[0m [   0.026s] (1481/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_283_fixtures_tests_titled_list_with_nested_adoc[0m
+[32;1m        PASS[0m [   0.013s] (1482/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_295_fixtures_tests_url_macro_inline_adoc[0m
+[32;1m        PASS[0m [   0.016s] (1483/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_294_fixtures_tests_url_macro_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1484/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_292_fixtures_tests_unordered_list_adoc[0m
+[32;1m        PASS[0m [   0.036s] (1485/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_281_fixtures_tests_test_sep_adoc[0m
+[32;1m        PASS[0m [   0.026s] (1486/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_289_fixtures_tests_unconstrained_highlight_adoc[0m
+[32;1m        PASS[0m [   0.018s] (1487/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_296_fixtures_tests_url_macro_url_display_text_adoc[0m
+[32;1m        PASS[0m [   0.026s] (1488/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_291_fixtures_tests_unconstrained_text_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1489/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_297_fixtures_tests_utf8_box_drawing_adoc[0m
+[32;1m        PASS[0m [   0.032s] (1490/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_288_fixtures_tests_two_regular_paragraphs_adoc[0m
+[32;1m        PASS[0m [   0.021s] (1491/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_299_fixtures_tests_utf8_multibyte_emoji_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1492/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_301_fixtures_tests_video_comprehensive_adoc[0m
+[32;1m        PASS[0m [   0.043s] (1493/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_284_fixtures_tests_toc_empty_brackets_adoc[0m
+[32;1m        PASS[0m [   0.023s] (1494/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_300_fixtures_tests_verse_with_attribution_adoc[0m
+[32;1m        PASS[0m [   0.026s] (1495/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_298_fixtures_tests_utf8_cjk_text_adoc[0m
+[32;1m        PASS[0m [   0.022s] (1496/1513) [35;1macdc-parser[0m [36mtests::warning_deduplication_tests[0m[36m::[0m[34;1mdistinct_warnings_all_emitted[0m
+[32;1m        PASS[0m [   0.024s] (1497/1513) [35;1macdc-parser[0m [36mtests::warning_deduplication_tests[0m[36m::[0m[34;1mcounter_reference_peg_backtracking_does_not_duplicate[0m
+[32;1m        PASS[0m [   0.018s] (1498/1513) [35;1macdc-parser[0m [36mwarning::tests[0m[36m::[0m[34;1mdisplay_without_location[0m
+[32;1m        PASS[0m [   0.021s] (1499/1513) [35;1macdc-parser[0m [36mwarning::tests[0m[36m::[0m[34;1mequality_holds_on_kind_and_location[0m
+[32;1m        PASS[0m [   0.019s] (1500/1513) [35;1macdc-parser[0m [36mwarning::tests[0m[36m::[0m[34;1munterminated_table_display_preserves_longer_tokens[0m
+[32;1m        PASS[0m [   0.022s] (1501/1513) [35;1macdc-parser[0m [36mwarning::tests[0m[36m::[0m[34;1munterminated_table_display_renders_original_token[0m
+[32;1m        PASS[0m [   0.016s] (1502/1513) [35;1macdc-parser::unterminated_tables[0m [34;1mbasic_unterminated_pipe_table[0m
+[32;1m        PASS[0m [   0.028s] (1503/1513) [35;1macdc-parser[0m [36mwarning::tests[0m[36m::[0m[34;1mdisplay_with_location_no_file[0m
+[32;1m        PASS[0m [   0.018s] (1504/1513) [35;1macdc-parser::no_leak[0m [34;1mparse_file_returns_static_document[0m
+[32;1m        PASS[0m [   0.018s] (1505/1513) [35;1macdc-parser::unterminated_tables[0m [34;1mempty_open_delimiter_at_eof[0m
+[32;1m        PASS[0m [   0.014s] (1506/1513) [35;1macdc-parser::unterminated_tables[0m [34;1mnested_inner_unterminated_in_a_cell[0m
+[32;1m        PASS[0m [   0.036s] (1507/1513) [35;1macdc-parser[0m [36mwarning::tests[0m[36m::[0m[34;1mdisplay_with_location_and_file[0m
+[32;1m        PASS[0m [   0.021s] (1508/1513) [35;1macdc-parser::unterminated_tables[0m [34;1mlonger_equals_run_is_preserved[0m
+[32;1m        PASS[0m [   0.052s] (1509/1513) [35;1macdc-parser[0m [36mtests::test_with_fixtures[0m[36m::[0m[34;1mpath_293_fixtures_tests_unordered_list_with_explicit_continuation_adoc[0m
+[32;1m        PASS[0m [   0.019s] (1510/1513) [35;1macdc-parser::unterminated_tables[0m [34;1monly_the_last_separator_variant_is_unterminated[0m
+[32;1m        PASS[0m [   0.021s] (1511/1513) [35;1macdc-parser::unterminated_tables[0m [34;1msecond_delimiter_acts_as_close_no_warning[0m
+[32;1m        PASS[0m [   0.046s] (1512/1513) [35;1macdc-parser::no_leak[0m [34;1mparse_inline_does_not_leak_across_iterations[0m
+[32;1m        PASS[0m [   0.669s] (1513/1513) [35;1macdc-parser::no_leak[0m [34;1mparse_file_does_not_leak_across_iterations[0m
+────────────
+[32;1m     Summary[0m [   2.970s] [1m1513[0m tests run: [1m1513[0m [32;1mpassed[0m, [1m0[0m [33;1mskipped[0m
+----

--- a/converters/html/samples/terminal_replay.adoc
+++ b/converters/html/samples/terminal_replay.adoc
@@ -1,0 +1,27 @@
+= Terminal Replay Sample
+:author: ACDC
+:toc:
+
+This document demonstrates an HTML terminal replay block. The block contains
+recorded terminal bytes; acdc replays those bytes into HTML frames and does not
+execute commands, shells, scripts, or recording files.
+
+== Recorded ANSI Output
+
+Each line below becomes a replay frame. Captured ANSI output can be pasted into
+the same kind of block; acdc treats it as recorded bytes, not as commands to
+run.
+
+[terminal%replay,cols=64,rows=10]
+----
+$ acdc convert guide.adoc --backend html -o guide.html
+Parsing guide.adoc
+Rendering terminal replay frames
+Generated html file: ./guide.html
+Done
+----
+
+== Notes
+
+Replay blocks require fixed terminal dimensions. Use `cols` and `rows` on the
+block, or set `:terminal-cols:` and `:terminal-rows:` document attributes.

--- a/converters/html/src/admonition.rs
+++ b/converters/html/src/admonition.rs
@@ -32,11 +32,14 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return visit_admonition_semantic(self, admon, caption, processor.is_font_icons_mode());
         }
 
-        let mut writer = self.writer_mut();
-        writeln!(writer, "<div class=\"admonitionblock {}\">", admon.variant)?;
-        writeln!(writer, "<table>")?;
-        writeln!(writer, "<tr>")?;
-        writeln!(writer, "<td class=\"icon\">")?;
+        writeln!(
+            self.writer,
+            "<div class=\"admonitionblock {}\">",
+            admon.variant
+        )?;
+        writeln!(self.writer, "<table>")?;
+        writeln!(self.writer, "<tr>")?;
+        writeln!(self.writer, "<td class=\"icon\">")?;
 
         // Output icon based on `:icons:` document attribute
         // - Font mode (`icons=font`): Use Font Awesome <i> element
@@ -50,36 +53,30 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 AdmonitionVariant::Caution => "fa-fire",
             };
             writeln!(
-                writer,
+                self.writer,
                 "<i class=\"fa-solid {fa_icon}\" title=\"{caption}\"></i>",
             )?;
         } else {
-            writeln!(writer, "<div class=\"title\">{caption}</div>")?;
+            writeln!(self.writer, "<div class=\"title\">{caption}</div>")?;
         }
-        writeln!(writer, "</td>")?;
-        writeln!(writer, "<td class=\"content\">")?;
+        writeln!(self.writer, "</td>")?;
+        writeln!(self.writer, "<td class=\"content\">")?;
         if !admon.title.is_empty() {
-            write!(writer, "<div class=\"title\">")?;
-            let _ = writer;
+            write!(self.writer, "<div class=\"title\">")?;
             self.visit_inline_nodes(&admon.title)?;
-            writer = self.writer_mut();
-            writeln!(writer, "</div>")?;
+            writeln!(self.writer, "</div>")?;
         }
-        let _ = writer;
 
         // Handle paragraph rendering based on block count
         // Single paragraph: wrap in <div class="paragraph"><p>...</p></div>
         // Multiple blocks: render each with normal wrapper
         match admon.blocks.as_slice() {
             [acdc_parser::Block::Paragraph(para)] => {
-                let writer = self.writer_mut();
-                writeln!(writer, "<div class=\"paragraph\">")?;
-                write!(writer, "<p>")?;
-                let _ = writer;
+                writeln!(self.writer, "<div class=\"paragraph\">")?;
+                write!(self.writer, "<p>")?;
                 self.visit_inline_nodes(&para.content)?;
-                let writer = self.writer_mut();
-                writeln!(writer, "</p>")?;
-                writeln!(writer, "</div>")?;
+                writeln!(self.writer, "</p>")?;
+                writeln!(self.writer, "</div>")?;
             }
             [block] => {
                 // Single non-paragraph block: use normal rendering
@@ -93,11 +90,10 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             }
         }
 
-        let writer = self.writer_mut();
-        writeln!(writer, "</td>")?;
-        writeln!(writer, "</tr>")?;
-        writeln!(writer, "</table>")?;
-        writeln!(writer, "</div>")?;
+        writeln!(self.writer, "</td>")?;
+        writeln!(self.writer, "</tr>")?;
+        writeln!(self.writer, "</table>")?;
+        writeln!(self.writer, "</div>")?;
         Ok(())
     }
 }

--- a/converters/html/src/audio.rs
+++ b/converters/html/src/audio.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Write as _, io::Write};
 
-use acdc_converters_core::visitor::{Visitor, WritableVisitor};
+use acdc_converters_core::visitor::Visitor;
 use acdc_parser::{AttributeValue, Audio};
 
 use crate::{Error, HtmlVariant, HtmlVisitor};
@@ -11,22 +11,19 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return visit_audio_semantic(audio, self);
         }
 
-        let mut w = self.writer_mut();
-        write!(w, "<div")?;
+        write!(self.writer, "<div")?;
         if let Some(id) = &audio.metadata.id {
-            write!(w, " id=\"{}\"", id.id)?;
+            write!(self.writer, " id=\"{}\"", id.id)?;
         }
-        writeln!(w, " class=\"audioblock\">")?;
+        writeln!(self.writer, " class=\"audioblock\">")?;
 
         if !audio.title.is_empty() {
-            write!(w, "<div class=\"title\">")?;
-            let _ = w;
+            write!(self.writer, "<div class=\"title\">")?;
             self.visit_inline_nodes(&audio.title)?;
-            w = self.writer_mut();
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</div>")?;
         }
 
-        writeln!(w, "<div class=\"content\">")?;
+        writeln!(self.writer, "<div class=\"content\">")?;
 
         // Build the src attribute with optional start and end time
         let mut src = audio.source.to_string();
@@ -43,28 +40,28 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             _ => {}
         }
 
-        write!(w, "<audio src=\"{src}\"")?;
+        write!(self.writer, "<audio src=\"{src}\"")?;
 
         // Add autoplay option if present
         if audio.metadata.options.contains(&"autoplay") {
-            write!(w, " autoplay")?;
+            write!(self.writer, " autoplay")?;
         }
 
         // Add loop option if present
         if audio.metadata.options.contains(&"loop") {
-            write!(w, " loop")?;
+            write!(self.writer, " loop")?;
         }
 
         // Add nocontrols option check - if present, don't add controls
         if !audio.metadata.options.contains(&"nocontrols") {
-            write!(w, " controls")?;
+            write!(self.writer, " controls")?;
         }
 
-        writeln!(w, ">")?;
-        writeln!(w, "Your browser does not support the audio tag.")?;
-        writeln!(w, "</audio>")?;
-        writeln!(w, "</div>")?;
-        writeln!(w, "</div>")?;
+        writeln!(self.writer, ">")?;
+        writeln!(self.writer, "Your browser does not support the audio tag.")?;
+        writeln!(self.writer, "</audio>")?;
+        writeln!(self.writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
 
         Ok(())
     }
@@ -111,26 +108,22 @@ fn visit_audio_semantic<W: Write>(
     visitor: &mut HtmlVisitor<'_, '_, W>,
 ) -> Result<(), Error> {
     let has_title = !audio.title.is_empty();
-    let mut w = visitor.writer_mut();
 
     let tag = if has_title { "figure" } else { "div" };
-    write!(w, "<{tag} class=\"audio-block\"")?;
+    write!(visitor.writer, "<{tag} class=\"audio-block\"")?;
     if let Some(id) = &audio.metadata.id {
-        write!(w, " id=\"{}\"", id.id)?;
+        write!(visitor.writer, " id=\"{}\"", id.id)?;
     }
-    writeln!(w, ">")?;
+    writeln!(visitor.writer, ">")?;
 
-    render_audio_element(audio, w)?;
+    render_audio_element(audio, &mut visitor.writer)?;
 
     if has_title {
-        w = visitor.writer_mut();
-        write!(w, "<figcaption>")?;
-        let _ = w;
+        write!(visitor.writer, "<figcaption>")?;
         visitor.visit_inline_nodes(&audio.title)?;
-        w = visitor.writer_mut();
-        writeln!(w, "</figcaption>")?;
+        writeln!(visitor.writer, "</figcaption>")?;
     }
 
-    writeln!(w, "</{tag}>")?;
+    writeln!(visitor.writer, "</{tag}>")?;
     Ok(())
 }

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -65,9 +65,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return self.write_example_block_collapsible(block, blocks);
         }
 
-        let mut writer = self.writer_mut();
-        write_block_div_open(&mut writer, &block.metadata, "exampleblock")?;
-        let _ = writer;
+        write_block_div_open(&mut self.writer, &block.metadata, "exampleblock")?;
 
         // Render title with caption prefix if title exists
         // Caption can be disabled with :example-caption!:
@@ -81,15 +79,12 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             )?;
         }
 
-        let mut writer = self.writer_mut();
-        writeln!(writer, "<div class=\"content\">")?;
-        let _ = writer;
+        writeln!(self.writer, "<div class=\"content\">")?;
         for nested_block in blocks {
             self.visit_block(nested_block)?;
         }
-        writer = self.writer_mut();
-        writeln!(writer, "</div>")?;
-        writeln!(writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
         Ok(())
     }
 
@@ -100,23 +95,20 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     ) -> Result<(), Error> {
         let is_open = block.metadata.options.contains(&"open");
 
-        let writer = self.writer_mut();
-        write!(writer, "<details")?;
+        write!(self.writer, "<details")?;
         if let Some(id) = &block.metadata.id {
-            write!(writer, " id=\"{}\"", id.id)?;
+            write!(self.writer, " id=\"{}\"", id.id)?;
         } else if let Some(anchor) = block.metadata.anchors.first() {
-            write!(writer, " id=\"{}\"", anchor.id)?;
+            write!(self.writer, " id=\"{}\"", anchor.id)?;
         }
         if is_open {
-            writeln!(writer, " open>")?;
+            writeln!(self.writer, " open>")?;
         } else {
-            writeln!(writer, ">")?;
+            writeln!(self.writer, ">")?;
         }
-        let _ = writer;
 
         if block.title.is_empty() {
-            let writer = self.writer_mut();
-            writeln!(writer, "<summary class=\"title\">Details</summary>")?;
+            writeln!(self.writer, "<summary class=\"title\">Details</summary>")?;
         } else {
             self.render_title_with_wrapper(
                 &block.title,
@@ -125,15 +117,12 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             )?;
         }
 
-        let mut writer = self.writer_mut();
-        writeln!(writer, "<div class=\"content\">")?;
-        let _ = writer;
+        writeln!(self.writer, "<div class=\"content\">")?;
         for nested_block in blocks {
             self.visit_block(nested_block)?;
         }
-        writer = self.writer_mut();
-        writeln!(writer, "</div>")?;
-        writeln!(writer, "</details>")?;
+        writeln!(self.writer, "</div>")?;
+        writeln!(self.writer, "</details>")?;
         Ok(())
     }
 
@@ -146,24 +135,22 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         let is_collapsible = block.metadata.options.contains(&"collapsible");
         let is_open = block.metadata.options.contains(&"open");
 
-        let mut writer = self.writer_mut();
         if is_collapsible {
             // Collapsible: <details> with no class (unless id/roles)
-            write!(writer, "<details")?;
+            write!(self.writer, "<details")?;
             if !block.metadata.roles.is_empty() {
-                write!(writer, " class=\"{}\"", block.metadata.roles.join(" "))?;
+                write!(self.writer, " class=\"{}\"", block.metadata.roles.join(" "))?;
             }
             if let Some(id) = &block.metadata.id {
-                write!(writer, " id=\"{}\"", id.id)?;
+                write!(self.writer, " id=\"{}\"", id.id)?;
             } else if let Some(anchor) = block.metadata.anchors.first() {
-                write!(writer, " id=\"{}\"", anchor.id)?;
+                write!(self.writer, " id=\"{}\"", anchor.id)?;
             }
             if is_open {
-                writeln!(writer, " open>")?;
+                writeln!(self.writer, " open>")?;
             } else {
-                writeln!(writer, ">")?;
+                writeln!(self.writer, ">")?;
             }
-            let _ = writer;
             if !block.title.is_empty() {
                 let prefix = processor.caption_prefix(
                     "example-caption",
@@ -177,19 +164,15 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 )?;
             }
             // Collapsible content wrapper
-            writer = self.writer_mut();
-            writeln!(writer, "<div class=\"content\">")?;
-            let _ = writer;
+            writeln!(self.writer, "<div class=\"content\">")?;
             for nested_block in blocks {
                 self.visit_block(nested_block)?;
             }
-            writer = self.writer_mut();
-            writeln!(writer, "</div>")?;
-            writeln!(writer, "</details>")?;
+            writeln!(self.writer, "</div>")?;
+            writeln!(self.writer, "</details>")?;
         } else if !block.title.is_empty() {
             // Titled: use figure/figcaption with inner div.example
-            write_semantic_tag_open(&mut writer, "figure", &block.metadata, "example-block")?;
-            let _ = writer;
+            write_semantic_tag_open(&mut self.writer, "figure", &block.metadata, "example-block")?;
             let prefix =
                 processor.caption_prefix("example-caption", &processor.example_counter, "Example");
             self.render_title_with_wrapper(
@@ -197,26 +180,21 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 &format!("<figcaption>{prefix}"),
                 "</figcaption>\n",
             )?;
-            writer = self.writer_mut();
-            writeln!(writer, "<div class=\"example\">")?;
-            let _ = writer;
+            writeln!(self.writer, "<div class=\"example\">")?;
             for nested_block in blocks {
                 self.visit_block(nested_block)?;
             }
-            writer = self.writer_mut();
-            writeln!(writer, "</div>")?;
-            writeln!(writer, "</figure>")?;
+            writeln!(self.writer, "</div>")?;
+            writeln!(self.writer, "</figure>")?;
         } else {
             // Untitled: use div with inner div.example
-            write_semantic_tag_open(&mut writer, "div", &block.metadata, "example-block")?;
-            writeln!(writer, "<div class=\"example\">")?;
-            let _ = writer;
+            write_semantic_tag_open(&mut self.writer, "div", &block.metadata, "example-block")?;
+            writeln!(self.writer, "<div class=\"example\">")?;
             for nested_block in blocks {
                 self.visit_block(nested_block)?;
             }
-            writer = self.writer_mut();
-            writeln!(writer, "</div>")?;
-            writeln!(writer, "</div>")?;
+            writeln!(self.writer, "</div>")?;
+            writeln!(self.writer, "</div>")?;
         }
         Ok(())
     }
@@ -231,63 +209,52 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             DelimitedBlockType::DelimitedQuote(blocks) => {
                 if processor.variant() == HtmlVariant::Semantic {
                     let has_title = !block.title.is_empty();
-                    let mut writer = self.writer_mut();
                     if has_title {
                         write_semantic_tag_open(
-                            &mut writer,
+                            &mut self.writer,
                             "section",
                             &block.metadata,
                             "quote-block",
                         )?;
-                        let _ = writer;
                         self.render_title_with_wrapper(
                             &block.title,
                             "<h6 class=\"block-title\">",
                             "</h6>\n",
                         )?;
-                        writer = self.writer_mut();
                     } else {
                         write_semantic_tag_open(
-                            &mut writer,
+                            &mut self.writer,
                             "div",
                             &block.metadata,
                             "quote-block",
                         )?;
                     }
-                    writeln!(writer, "<blockquote>")?;
-                    let _ = writer;
+                    writeln!(self.writer, "<blockquote>")?;
                     for nested_block in blocks {
                         self.visit_block(nested_block)?;
                     }
-                    let _ = self.writer_mut();
                     // Attribution goes inside blockquote as <footer>
                     write_semantic_attribution(self, &block.metadata)?;
-                    let writer = self.writer_mut();
-                    writeln!(writer, "</blockquote>")?;
+                    writeln!(self.writer, "</blockquote>")?;
                     if has_title {
-                        writeln!(writer, "</section>")?;
+                        writeln!(self.writer, "</section>")?;
                     } else {
-                        writeln!(writer, "</div>")?;
+                        writeln!(self.writer, "</div>")?;
                     }
                 } else {
-                    let mut writer = self.writer_mut();
                     let base_class = if let Some(style) = &block.metadata.style {
                         format!("{style}block")
                     } else {
                         "quoteblock".to_string()
                     };
-                    write_block_div_open(&mut writer, &block.metadata, &base_class)?;
-                    writeln!(writer, "<blockquote>")?;
-                    let _ = writer;
+                    write_block_div_open(&mut self.writer, &block.metadata, &base_class)?;
+                    writeln!(self.writer, "<blockquote>")?;
                     for nested_block in blocks {
                         self.visit_block(nested_block)?;
                     }
-                    let writer = self.writer_mut();
-                    writeln!(writer, "</blockquote>")?;
-                    let _ = writer;
+                    writeln!(self.writer, "</blockquote>")?;
                     write_attribution(self, &block.metadata)?;
-                    let writer = self.writer_mut();
-                    writeln!(writer, "</div>")?;
+                    writeln!(self.writer, "</div>")?;
                 }
             }
             DelimitedBlockType::DelimitedOpen(blocks) => {
@@ -296,55 +263,48 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                     if is_abstract {
                         // Abstract style: render as quote-block abstract
                         let has_title = !block.title.is_empty();
-                        let mut writer = self.writer_mut();
                         if has_title {
                             let base = build_class("quote-block abstract", &block.metadata.roles);
-                            write!(writer, "<section class=\"{base}\"")?;
+                            write!(self.writer, "<section class=\"{base}\"")?;
                             if let Some(id) = &block.metadata.id {
-                                write!(writer, " id=\"{}\"", id.id)?;
+                                write!(self.writer, " id=\"{}\"", id.id)?;
                             } else if let Some(anchor) = block.metadata.anchors.first() {
-                                write!(writer, " id=\"{}\"", anchor.id)?;
+                                write!(self.writer, " id=\"{}\"", anchor.id)?;
                             }
-                            writeln!(writer, ">")?;
-                            let _ = writer;
+                            writeln!(self.writer, ">")?;
                             self.render_title_with_wrapper(
                                 &block.title,
                                 "<h6 class=\"block-title\">",
                                 "</h6>\n",
                             )?;
-                            writer = self.writer_mut();
                         } else {
                             write_semantic_tag_open(
-                                &mut writer,
+                                &mut self.writer,
                                 "div",
                                 &block.metadata,
                                 "quote-block abstract",
                             )?;
                         }
-                        writeln!(writer, "<blockquote>")?;
-                        let _ = writer;
+                        writeln!(self.writer, "<blockquote>")?;
                         for nested_block in blocks {
                             self.visit_block(nested_block)?;
                         }
-                        writer = self.writer_mut();
-                        writeln!(writer, "</blockquote>")?;
+                        writeln!(self.writer, "</blockquote>")?;
                         if has_title {
-                            writeln!(writer, "</section>")?;
+                            writeln!(self.writer, "</section>")?;
                         } else {
-                            writeln!(writer, "</div>")?;
+                            writeln!(self.writer, "</div>")?;
                         }
                     } else {
                         // Regular open block in semantic mode
                         let has_title = !block.title.is_empty();
-                        let mut writer = self.writer_mut();
                         if has_title {
                             write_semantic_tag_open(
-                                &mut writer,
+                                &mut self.writer,
                                 "section",
                                 &block.metadata,
                                 "open-block",
                             )?;
-                            let _ = writer;
                             self.render_title_with_wrapper(
                                 &block.title,
                                 "<h6 class=\"block-title\">",
@@ -352,44 +312,36 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                             )?;
                         } else {
                             write_semantic_tag_open(
-                                &mut writer,
+                                &mut self.writer,
                                 "div",
                                 &block.metadata,
                                 "open-block",
                             )?;
                         }
-                        writer = self.writer_mut();
-                        writeln!(writer, "<div class=\"content\">")?;
-                        let _ = writer;
+                        writeln!(self.writer, "<div class=\"content\">")?;
                         for nested_block in blocks {
                             self.visit_block(nested_block)?;
                         }
-                        writer = self.writer_mut();
-                        writeln!(writer, "</div>")?;
+                        writeln!(self.writer, "</div>")?;
                         if has_title {
-                            writeln!(writer, "</section>")?;
+                            writeln!(self.writer, "</section>")?;
                         } else {
-                            writeln!(writer, "</div>")?;
+                            writeln!(self.writer, "</div>")?;
                         }
                     }
                 } else {
-                    let mut writer = self.writer_mut();
-                    write_block_div_open(&mut writer, &block.metadata, "openblock")?;
-                    let _ = writer;
+                    write_block_div_open(&mut self.writer, &block.metadata, "openblock")?;
                     self.render_title_with_wrapper(
                         &block.title,
                         "<div class=\"title\">",
                         "</div>\n",
                     )?;
-                    writer = self.writer_mut();
-                    writeln!(writer, "<div class=\"content\">")?;
-                    let _ = writer;
+                    writeln!(self.writer, "<div class=\"content\">")?;
                     for nested_block in blocks {
                         self.visit_block(nested_block)?;
                     }
-                    writer = self.writer_mut();
-                    writeln!(writer, "</div>")?;
-                    writeln!(writer, "</div>")?;
+                    writeln!(self.writer, "</div>")?;
+                    writeln!(self.writer, "</div>")?;
                 }
             }
             DelimitedBlockType::DelimitedExample(blocks) => {
@@ -401,9 +353,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             }
             DelimitedBlockType::DelimitedSidebar(blocks) => {
                 if processor.variant() == HtmlVariant::Semantic {
-                    let mut writer = self.writer_mut();
-                    write_semantic_tag_open(&mut writer, "aside", &block.metadata, "sidebar")?;
-                    let _ = writer;
+                    write_semantic_tag_open(&mut self.writer, "aside", &block.metadata, "sidebar")?;
                     self.render_title_with_wrapper(
                         &block.title,
                         "<h6 class=\"block-title\">",
@@ -412,26 +362,20 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                     for nested_block in blocks {
                         self.visit_block(nested_block)?;
                     }
-                    let writer = self.writer_mut();
-                    writeln!(writer, "</aside>")?;
+                    writeln!(self.writer, "</aside>")?;
                 } else {
-                    let mut writer = self.writer_mut();
-                    write_block_div_open(&mut writer, &block.metadata, "sidebarblock")?;
-                    writeln!(writer, "<div class=\"content\">")?;
-                    let _ = writer;
+                    write_block_div_open(&mut self.writer, &block.metadata, "sidebarblock")?;
+                    writeln!(self.writer, "<div class=\"content\">")?;
                     self.render_title_with_wrapper(
                         &block.title,
                         "<div class=\"title\">",
                         "</div>\n",
                     )?;
-                    let writer = self.writer_mut();
-                    let _ = writer;
                     for nested_block in blocks {
                         self.visit_block(nested_block)?;
                     }
-                    let writer = self.writer_mut();
-                    writeln!(writer, "</div>")?;
-                    writeln!(writer, "</div>")?;
+                    writeln!(self.writer, "</div>")?;
+                    writeln!(self.writer, "</div>")?;
                 }
             }
             // Handle tables
@@ -565,9 +509,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return self.render_terminal_listing_block(inlines, title, metadata);
         }
 
-        let mut w = self.writer_mut();
-        write_block_div_open(&mut w, metadata, "listingblock")?;
-        let _ = w;
+        write_block_div_open(&mut self.writer, metadata, "listingblock")?;
 
         // Check if listing-caption is set and block has a title
         if !title.is_empty() {
@@ -587,15 +529,10 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             }
         }
 
-        let w = self.writer_mut();
-        writeln!(w, "<div class=\"content\">")?;
-        let _ = w;
-
+        writeln!(self.writer, "<div class=\"content\">")?;
         self.render_listing_code(inlines, metadata)?;
-
-        let w = self.writer_mut();
-        writeln!(w, "</div>")?;
-        writeln!(w, "</div>")?;
+        writeln!(self.writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
         Ok(())
     }
 
@@ -618,22 +555,17 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return self.render_terminal_listing_block_semantic(inlines, title, metadata);
         }
 
-        let mut w = self.writer_mut();
         if title.is_empty() {
             // Untitled: use div
-            write_semantic_tag_open(&mut w, "div", metadata, "listing-block")?;
-            let _ = w;
+            write_semantic_tag_open(&mut self.writer, "div", metadata, "listing-block")?;
             self.render_listing_code(inlines, metadata)?;
-            let w = self.writer_mut();
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</div>")?;
         } else {
             // Titled: use figure/figcaption
-            write_semantic_tag_open(&mut w, "figure", metadata, "listing-block")?;
-            let _ = w;
+            write_semantic_tag_open(&mut self.writer, "figure", metadata, "listing-block")?;
             self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
             self.render_listing_code(inlines, metadata)?;
-            let w = self.writer_mut();
-            writeln!(w, "</figure>")?;
+            writeln!(self.writer, "</figure>")?;
         }
         Ok(())
     }
@@ -730,20 +662,26 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     ) -> Result<(), Error> {
         let attrs = self.processor.document_attributes.clone();
         let options = self.processor.options.clone();
-        let mut w = self.writer_mut();
-        write_block_div_open(&mut w, metadata, "listingblock terminal-preview-block")?;
-        let _ = w;
+        write_block_div_open(
+            &mut self.writer,
+            metadata,
+            "listingblock terminal-preview-block",
+        )?;
 
         if !title.is_empty() {
             self.render_title_with_wrapper(title, "<div class=\"title\">", "</div>\n")?;
         }
 
-        w = self.writer_mut();
-        writeln!(w, "<div class=\"content\">")?;
-        crate::terminal_preview::render_listing(w, inlines, metadata, options, &attrs)?;
-        w = self.writer_mut();
-        writeln!(w, "</div>")?;
-        writeln!(w, "</div>")?;
+        writeln!(self.writer, "<div class=\"content\">")?;
+        crate::terminal_preview::render_listing(
+            &mut self.writer,
+            inlines,
+            metadata,
+            options,
+            &attrs,
+        )?;
+        writeln!(self.writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
         Ok(())
     }
 
@@ -756,30 +694,37 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     ) -> Result<(), Error> {
         let attrs = self.processor.document_attributes.clone();
         let options = self.processor.options.clone();
-        let mut w = self.writer_mut();
         if title.is_empty() {
             write_semantic_tag_open(
-                &mut w,
+                &mut self.writer,
                 "div",
                 metadata,
                 "listing-block terminal-preview-block",
             )?;
-            crate::terminal_preview::render_listing(w, inlines, metadata, options, &attrs)?;
-            w = self.writer_mut();
-            writeln!(w, "</div>")?;
+            crate::terminal_preview::render_listing(
+                &mut self.writer,
+                inlines,
+                metadata,
+                options,
+                &attrs,
+            )?;
+            writeln!(self.writer, "</div>")?;
         } else {
             write_semantic_tag_open(
-                &mut w,
+                &mut self.writer,
                 "figure",
                 metadata,
                 "listing-block terminal-preview-block",
             )?;
-            let _ = w;
             self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
-            w = self.writer_mut();
-            crate::terminal_preview::render_listing(w, inlines, metadata, options, &attrs)?;
-            w = self.writer_mut();
-            writeln!(w, "</figure>")?;
+            crate::terminal_preview::render_listing(
+                &mut self.writer,
+                inlines,
+                metadata,
+                options,
+                &attrs,
+            )?;
+            writeln!(self.writer, "</figure>")?;
         }
         Ok(())
     }
@@ -874,7 +819,6 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 // Check for custom style other than "source" - I've done this because
                 // `asciidoctor` seems to always use "literalblock" for source blocks or
                 // so I think!
-                let mut w = self.writer_mut();
                 let base_class = if let Some(style) = &metadata.style
                     && *style != "source"
                 {
@@ -882,47 +826,33 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 } else {
                     "literalblock".to_string()
                 };
-                write_block_div_open(&mut w, metadata, &base_class)?;
-                let _ = w;
+                write_block_div_open(&mut self.writer, metadata, &base_class)?;
                 self.render_title_with_wrapper(title, "<div class=\"title\">", "</div>\n")?;
-                let mut w = self.writer_mut();
-                writeln!(w, "<div class=\"content\">")?;
-                write!(w, "<pre>")?;
-                let _ = w;
+                writeln!(self.writer, "<div class=\"content\">")?;
+                write!(self.writer, "<pre>")?;
                 self.visit_inline_nodes(inlines)?;
-                w = self.writer_mut();
-                writeln!(w, "</pre>")?;
-                writeln!(w, "</div>")?;
-                writeln!(w, "</div>")?;
+                writeln!(self.writer, "</pre>")?;
+                writeln!(self.writer, "</div>")?;
+                writeln!(self.writer, "</div>")?;
             }
             DelimitedBlockType::DelimitedStem(stem) => {
-                let mut w = self.writer_mut();
-                write_block_div_open(&mut w, metadata, "stemblock")?;
-                let _ = w;
+                write_block_div_open(&mut self.writer, metadata, "stemblock")?;
                 self.render_title_with_wrapper(title, "<div class=\"title\">", "</div>\n")?;
                 let processor = self.processor.clone();
-                let w = self.writer_mut();
-                render_stem_content(stem, w, &processor)?;
-                writeln!(w, "</div>")?;
+                render_stem_content(stem, &mut self.writer, &processor)?;
+                writeln!(self.writer, "</div>")?;
             }
             DelimitedBlockType::DelimitedComment(_) => {
                 // Comment blocks produce no output
             }
             DelimitedBlockType::DelimitedVerse(inlines) => {
-                let mut w = self.writer_mut();
-                write_block_div_open(&mut w, metadata, "verseblock")?;
-                let _ = w;
+                write_block_div_open(&mut self.writer, metadata, "verseblock")?;
                 self.render_title_with_wrapper(title, "<div class=\"title\">", "</div>\n")?;
-                let mut w = self.writer_mut();
-                write!(w, "<pre class=\"content\">")?;
-                let _ = w;
+                write!(self.writer, "<pre class=\"content\">")?;
                 self.visit_inline_nodes(inlines)?;
-                w = self.writer_mut();
-                writeln!(w, "</pre>")?;
-                let _ = w;
+                writeln!(self.writer, "</pre>")?;
                 write_attribution(self, metadata)?;
-                let w = self.writer_mut();
-                writeln!(w, "</div>")?;
+                writeln!(self.writer, "</div>")?;
             }
             DelimitedBlockType::DelimitedQuote(_)
             | DelimitedBlockType::DelimitedOpen(_)
@@ -1010,45 +940,40 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             }
             DelimitedBlockType::DelimitedLiteral(inlines) => {
                 let has_title = !title.is_empty();
-                let mut w = self.writer_mut();
                 if has_title {
-                    write_semantic_tag_open(&mut w, "section", metadata, "literal-block")?;
-                    let _ = w;
+                    write_semantic_tag_open(
+                        &mut self.writer,
+                        "section",
+                        metadata,
+                        "literal-block",
+                    )?;
                     self.render_title_with_wrapper(title, "<h6 class=\"block-title\">", "</h6>\n")?;
-                    w = self.writer_mut();
                 } else {
-                    write_semantic_tag_open(&mut w, "div", metadata, "literal-block")?;
+                    write_semantic_tag_open(&mut self.writer, "div", metadata, "literal-block")?;
                 }
-                write!(w, "<pre>")?;
-                let _ = w;
+                write!(self.writer, "<pre>")?;
                 self.visit_inline_nodes(inlines)?;
-                let w = self.writer_mut();
-                writeln!(w, "</pre>")?;
+                writeln!(self.writer, "</pre>")?;
                 if has_title {
-                    writeln!(w, "</section>")?;
+                    writeln!(self.writer, "</section>")?;
                 } else {
-                    writeln!(w, "</div>")?;
+                    writeln!(self.writer, "</div>")?;
                 }
             }
             DelimitedBlockType::DelimitedStem(stem) => {
                 let has_title = !title.is_empty();
-                let mut w = self.writer_mut();
                 if has_title {
-                    write_semantic_tag_open(&mut w, "figure", metadata, "stem-block")?;
-                    let _ = w;
+                    write_semantic_tag_open(&mut self.writer, "figure", metadata, "stem-block")?;
                     self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
                 } else {
-                    write_semantic_tag_open(&mut w, "div", metadata, "stem-block")?;
-                    let _ = w;
+                    write_semantic_tag_open(&mut self.writer, "div", metadata, "stem-block")?;
                 }
                 let processor = self.processor.clone();
-                let w = self.writer_mut();
-                render_stem_content_semantic(stem, w, &processor)?;
-                let w = self.writer_mut();
+                render_stem_content_semantic(stem, &mut self.writer, &processor)?;
                 if has_title {
-                    writeln!(w, "</figure>")?;
+                    writeln!(self.writer, "</figure>")?;
                 } else {
-                    writeln!(w, "</div>")?;
+                    writeln!(self.writer, "</div>")?;
                 }
             }
             DelimitedBlockType::DelimitedComment(_)
@@ -1080,41 +1005,30 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         let has_attribution = metadata.attribution.as_ref().is_some_and(|a| !a.is_empty())
             || metadata.citetitle.as_ref().is_some_and(|c| !c.is_empty());
 
-        let mut w = self.writer_mut();
         if has_title {
-            write_semantic_tag_open(&mut w, "section", metadata, "verse-block")?;
-            let _ = w;
+            write_semantic_tag_open(&mut self.writer, "section", metadata, "verse-block")?;
             self.render_title_with_wrapper(title, "<h6 class=\"block-title\">", "</h6>\n")?;
-            w = self.writer_mut();
         } else {
-            write_semantic_tag_open(&mut w, "div", metadata, "verse-block")?;
+            write_semantic_tag_open(&mut self.writer, "div", metadata, "verse-block")?;
         }
 
         if has_attribution {
-            writeln!(w, "<blockquote class=\"verse\">")?;
-            write!(w, "<pre class=\"verse\">")?;
-            let _ = w;
+            writeln!(self.writer, "<blockquote class=\"verse\">")?;
+            write!(self.writer, "<pre class=\"verse\">")?;
             self.visit_inline_nodes(inlines)?;
-            let w = self.writer_mut();
-            writeln!(w, "</pre>")?;
-            let _ = w;
+            writeln!(self.writer, "</pre>")?;
             write_semantic_attribution(self, metadata)?;
-            let w = self.writer_mut();
-            writeln!(w, "</blockquote>")?;
+            writeln!(self.writer, "</blockquote>")?;
         } else {
-            write!(w, "<pre class=\"verse\">")?;
-            let _ = w;
+            write!(self.writer, "<pre class=\"verse\">")?;
             self.visit_inline_nodes(inlines)?;
-            let w = self.writer_mut();
-            writeln!(w, "</pre>")?;
-            let _ = w;
+            writeln!(self.writer, "</pre>")?;
         }
 
-        let w = self.writer_mut();
         if has_title {
-            writeln!(w, "</section>")?;
+            writeln!(self.writer, "</section>")?;
         } else {
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</div>")?;
         }
         Ok(())
     }

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -647,20 +647,29 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     ) -> Result<(), Error> {
         let attrs = self.processor.document_attributes.clone();
         let options = self.processor.options.clone();
-        let mut w = self.writer_mut();
-        write_block_div_open(&mut w, metadata, "terminalblock terminal-preview-block")?;
-        let _ = w;
+        write_block_div_open(
+            &mut self.writer,
+            metadata,
+            "terminalblock terminal-preview-block",
+        )?;
 
         if !title.is_empty() {
             self.render_title_with_wrapper(title, "<div class=\"title\">", "</div>\n")?;
         }
 
-        w = self.writer_mut();
-        writeln!(w, "<div class=\"content\">")?;
-        crate::terminal_preview::render_session(w, inlines, metadata, options, &attrs)?;
-        w = self.writer_mut();
-        writeln!(w, "</div>")?;
-        writeln!(w, "</div>")?;
+        writeln!(self.writer, "<div class=\"content\">")?;
+        // Direct field access so the writer and diagnostics borrows stay
+        // disjoint; `writer_mut()` would borrow all of `self`.
+        crate::terminal_preview::render_session(
+            &mut self.writer,
+            inlines,
+            metadata,
+            options,
+            &attrs,
+            &mut self.diagnostics,
+        )?;
+        writeln!(self.writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
         Ok(())
     }
 
@@ -673,30 +682,41 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     ) -> Result<(), Error> {
         let attrs = self.processor.document_attributes.clone();
         let options = self.processor.options.clone();
-        let mut w = self.writer_mut();
+        // Direct field access so the writer and diagnostics borrows stay
+        // disjoint; `writer_mut()` would borrow all of `self`.
         if title.is_empty() {
             write_semantic_tag_open(
-                &mut w,
+                &mut self.writer,
                 "div",
                 metadata,
                 "terminal-block terminal-preview-block",
             )?;
-            crate::terminal_preview::render_session(w, inlines, metadata, options, &attrs)?;
-            w = self.writer_mut();
-            writeln!(w, "</div>")?;
+            crate::terminal_preview::render_session(
+                &mut self.writer,
+                inlines,
+                metadata,
+                options,
+                &attrs,
+                &mut self.diagnostics,
+            )?;
+            writeln!(self.writer, "</div>")?;
         } else {
             write_semantic_tag_open(
-                &mut w,
+                &mut self.writer,
                 "figure",
                 metadata,
                 "terminal-block terminal-preview-block",
             )?;
-            let _ = w;
             self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
-            w = self.writer_mut();
-            crate::terminal_preview::render_session(w, inlines, metadata, options, &attrs)?;
-            w = self.writer_mut();
-            writeln!(w, "</figure>")?;
+            crate::terminal_preview::render_session(
+                &mut self.writer,
+                inlines,
+                metadata,
+                options,
+                &attrs,
+                &mut self.diagnostics,
+            )?;
+            writeln!(self.writer, "</figure>")?;
         }
         Ok(())
     }

--- a/converters/html/src/error.rs
+++ b/converters/html/src/error.rs
@@ -24,6 +24,10 @@ pub enum Error {
     #[error(transparent)]
     TerminalRenderState(#[from] acdc_converters_terminal::cell_grid::Error),
 
+    #[cfg(feature = "terminal")]
+    #[error(transparent)]
+    TerminalReplay(#[from] acdc_converters_terminal::replay::Error),
+
     #[error("input file and output file cannot be the same: {0}")]
     OutputPathSameAsInput(std::path::PathBuf),
 

--- a/converters/html/src/image.rs
+++ b/converters/html/src/image.rs
@@ -16,8 +16,6 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return self.render_image_semantic(img);
         }
 
-        let mut w = self.writer_mut();
-
         // Build class list: imageblock + alignment + float + roles
         let mut classes = vec!["imageblock".to_string()];
 
@@ -36,8 +34,8 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             classes.push(role.to_string());
         }
 
-        write!(w, "<div class=\"{}\">", classes.join(" "))?;
-        write!(w, "<div class=\"content\">")?;
+        write!(self.writer, "<div class=\"{}\">", classes.join(" "))?;
+        write!(self.writer, "<div class=\"content\">")?;
         // Get alt text from attribute or generate from filename
         let alt_text = img.metadata.attributes.get_string("alt").map_or_else(
             || alt_text_from_filename(&img.source),
@@ -48,43 +46,44 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         let link = img.metadata.attributes.get("link");
         if let Some(link) = link {
             write!(
-                w,
+                self.writer,
                 "<a class=\"image\" href=\"{}\">",
                 escape_href(&link.to_string())
             )?;
         }
 
-        write!(w, "<img src=\"{}\" alt=\"{alt_text}\"", img.source)?;
-        write_dimension_attributes(w, &img.metadata)?;
-        write!(w, ">")?;
+        write!(
+            self.writer,
+            "<img src=\"{}\" alt=\"{alt_text}\"",
+            img.source
+        )?;
+        write_dimension_attributes(&mut self.writer, &img.metadata)?;
+        write!(self.writer, ">")?;
 
         if link.is_some() {
-            write!(w, "</a>")?;
+            write!(self.writer, "</a>")?;
         }
-        write!(w, "</div>")?; // close content
+        write!(self.writer, "</div>")?; // close content
 
         // Render title with figure caption if title exists
         // Caption can be disabled with :figure-caption!:
         if !img.title.is_empty() {
             let prefix =
                 processor.caption_prefix("figure-caption", &processor.figure_counter, "Figure");
-            let _ = w;
             self.render_title_with_wrapper(
                 &img.title,
                 &format!("<div class=\"title\">{prefix}"),
                 "</div>",
             )?;
-            w = self.writer_mut();
         }
 
-        write!(w, "</div>")?; // close imageblock
+        write!(self.writer, "</div>")?; // close imageblock
         Ok(())
     }
 
     fn render_image_semantic(&mut self, img: &Image) -> Result<(), Error> {
         let processor = self.processor.clone();
         let has_title = !img.title.is_empty();
-        let mut w = self.writer_mut();
 
         // Build class and style for wrapper
         let mut classes = vec!["image-block".to_string()];
@@ -102,16 +101,16 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
 
         // Wrapper: figure for titled, div for untitled
         let tag = if has_title { "figure" } else { "div" };
-        write!(w, "<{tag} class=\"{}\"", classes.join(" "))?;
+        write!(self.writer, "<{tag} class=\"{}\"", classes.join(" "))?;
         if let Some(id) = &img.metadata.id {
-            write!(w, " id=\"{}\"", id.id)?;
+            write!(self.writer, " id=\"{}\"", id.id)?;
         } else if let Some(anchor) = img.metadata.anchors.first() {
-            write!(w, " id=\"{}\"", anchor.id)?;
+            write!(self.writer, " id=\"{}\"", anchor.id)?;
         }
         if !styles.is_empty() {
-            write!(w, " style=\"{}\"", styles.join("; "))?;
+            write!(self.writer, " style=\"{}\"", styles.join("; "))?;
         }
-        writeln!(w, ">")?;
+        writeln!(self.writer, ">")?;
 
         let alt_text = img.metadata.attributes.get_string("alt").map_or_else(
             || alt_text_from_filename(&img.source),
@@ -148,7 +147,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                     ToString::to_string,
                 );
             write!(
-                w,
+                self.writer,
                 "<a class=\"image bare\" href=\"{}\" title=\"{label}\" aria-label=\"{label}\">",
                 img.source
             )?;
@@ -156,39 +155,45 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             && !is_link_self
             && let Some(ref link_str) = link_str
         {
-            write!(w, "<a class=\"image\" href=\"{}\">", escape_href(link_str))?;
+            write!(
+                self.writer,
+                "<a class=\"image\" href=\"{}\">",
+                escape_href(link_str)
+            )?;
         }
 
-        write!(w, "<img src=\"{}\" alt=\"{alt_text}\"", img.source)?;
-        write_dimension_attributes(w, &img.metadata)?;
+        write!(
+            self.writer,
+            "<img src=\"{}\" alt=\"{alt_text}\"",
+            img.source
+        )?;
+        write_dimension_attributes(&mut self.writer, &img.metadata)?;
 
         // Add loading attribute if present
         if let Some(loading) = img.metadata.attributes.get_string("loading") {
-            write!(w, " loading=\"{loading}\"")?;
+            write!(self.writer, " loading=\"{loading}\"")?;
         }
 
-        write!(w, ">")?;
+        write!(self.writer, ">")?;
 
         // Close link tag if we opened one
         let has_link = (use_self_link && !suppress_default_self)
             || (!is_link_none && !is_link_self && link_str.is_some());
         if has_link {
-            write!(w, "</a>")?;
+            write!(self.writer, "</a>")?;
         }
 
         if has_title {
             let prefix =
                 processor.caption_prefix("figure-caption", &processor.figure_counter, "Figure");
-            let _ = w;
             self.render_title_with_wrapper(
                 &img.title,
                 &format!("<figcaption>{prefix}"),
                 "</figcaption>\n",
             )?;
-            w = self.writer_mut();
         }
 
-        writeln!(w, "</{tag}>")?;
+        writeln!(self.writer, "</{tag}>")?;
         Ok(())
     }
 }

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -831,7 +831,7 @@ pub(crate) fn render_pre_code<W: std::io::Write>(
     visitor: &mut HtmlVisitor<'_, '_, W>,
     subs: &[Substitution],
 ) -> Result<(), Error> {
-    use acdc_converters_core::visitor::{Visitor, WritableVisitor};
+    use acdc_converters_core::visitor::Visitor;
     #[cfg(feature = "highlighting")]
     let highlighting_enabled = visitor
         .processor
@@ -839,16 +839,13 @@ pub(crate) fn render_pre_code<W: std::io::Write>(
         .get("source-highlighter")
         .is_some_and(|v| !matches!(v, AttributeValue::Bool(false)));
 
-    let mut w = visitor.writer_mut();
-
     #[cfg(feature = "highlighting")]
     if let Some(lang) = language {
         if highlighting_enabled {
             write!(
-                w,
+                visitor.writer,
                 "<pre class=\"highlight\"><code class=\"language-{lang}\" data-lang=\"{lang}\">"
             )?;
-            let _ = w;
             let processor = visitor.processor.clone();
             let (theme_name, mode) = resolve_highlight_settings(&processor.document_attributes);
             let effective_inlines = apply_attribute_subs(inlines, subs, &processor);
@@ -863,24 +860,19 @@ pub(crate) fn render_pre_code<W: std::io::Write>(
                 mode,
                 Some(&mut visitor.diagnostics),
             )?;
-            w = visitor.writer_mut();
-            writeln!(w, "</code></pre>")?;
+            writeln!(visitor.writer, "</code></pre>")?;
         } else {
             write!(
-                w,
+                visitor.writer,
                 "<pre class=\"highlight\"><code class=\"language-{lang}\" data-lang=\"{lang}\">"
             )?;
-            let _ = w;
             visitor.visit_inline_nodes(inlines)?;
-            w = visitor.writer_mut();
-            writeln!(w, "</code></pre>")?;
+            writeln!(visitor.writer, "</code></pre>")?;
         }
     } else {
-        write!(w, "<pre>")?;
-        let _ = w;
+        write!(visitor.writer, "<pre>")?;
         visitor.visit_inline_nodes(inlines)?;
-        w = visitor.writer_mut();
-        writeln!(w, "</pre>")?;
+        writeln!(visitor.writer, "</pre>")?;
     }
 
     #[cfg(not(feature = "highlighting"))]
@@ -888,19 +880,15 @@ pub(crate) fn render_pre_code<W: std::io::Write>(
         let _ = subs;
         if let Some(lang) = language {
             write!(
-                w,
+                visitor.writer,
                 "<pre class=\"highlight\"><code class=\"language-{lang}\" data-lang=\"{lang}\">"
             )?;
-            let _ = w;
             visitor.visit_inline_nodes(inlines)?;
-            w = visitor.writer_mut();
-            writeln!(w, "</code></pre>")?;
+            writeln!(visitor.writer, "</code></pre>")?;
         } else {
-            write!(w, "<pre>")?;
-            let _ = w;
+            write!(visitor.writer, "<pre>")?;
             visitor.visit_inline_nodes(inlines)?;
-            w = visitor.writer_mut();
-            writeln!(w, "</pre>")?;
+            writeln!(visitor.writer, "</pre>")?;
         }
     }
 

--- a/converters/html/src/list.rs
+++ b/converters/html/src/list.rs
@@ -42,57 +42,52 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         let semantic = self.processor.variant() == HtmlVariant::Semantic;
         let has_title = !list.title.is_empty();
 
-        let writer = self.writer_mut();
         // Semantic mode: use <section> for titled, <div> otherwise
         let wrapper_tag = if semantic && has_title {
             "section"
         } else {
             "div"
         };
-        write!(writer, "<{wrapper_tag}")?;
+        write!(self.writer, "<{wrapper_tag}")?;
         if let Some(id) = &list.metadata.id {
-            write!(writer, " id=\"{}\"", id.id)?;
+            write!(self.writer, " id=\"{}\"", id.id)?;
         } else if let Some(anchor) = list.metadata.anchors.first() {
-            write!(writer, " id=\"{}\"", anchor.id)?;
+            write!(self.writer, " id=\"{}\"", anchor.id)?;
         }
         if semantic {
             // Semantic mode: no "checklist" on wrapper div
             if is_bibliography {
                 let class = build_class("ulist bibliography", &list.metadata.roles);
-                writeln!(writer, " class=\"{class}\">")?;
+                writeln!(self.writer, " class=\"{class}\">")?;
             } else {
                 let class = build_class("ulist", &list.metadata.roles);
-                writeln!(writer, " class=\"{class}\">")?;
+                writeln!(self.writer, " class=\"{class}\">")?;
             }
         } else if is_checklist {
-            writeln!(writer, " class=\"ulist checklist\">")?;
+            writeln!(self.writer, " class=\"ulist checklist\">")?;
         } else if is_bibliography {
-            writeln!(writer, " class=\"ulist bibliography\">")?;
+            writeln!(self.writer, " class=\"ulist bibliography\">")?;
         } else {
-            writeln!(writer, " class=\"ulist\">")?;
+            writeln!(self.writer, " class=\"ulist\">")?;
         }
-        let _ = writer;
         if semantic && has_title {
             self.render_title_with_wrapper(&list.title, "<h6 class=\"block-title\">", "</h6>\n")?;
         } else {
             self.render_title_with_wrapper(&list.title, "<div class=\"title\">", "</div>\n")?;
         }
 
-        let mut writer = self.writer_mut();
         if is_checklist && semantic {
-            writeln!(writer, "<ul class=\"task-list\">")?;
+            writeln!(self.writer, "<ul class=\"task-list\">")?;
         } else if is_checklist {
-            writeln!(writer, "<ul class=\"checklist\">")?;
+            writeln!(self.writer, "<ul class=\"checklist\">")?;
         } else if is_bibliography {
-            writeln!(writer, "<ul class=\"bibliography\">")?;
+            writeln!(self.writer, "<ul class=\"bibliography\">")?;
         } else {
-            writeln!(writer, "<ul>")?;
+            writeln!(self.writer, "<ul>")?;
         }
-        let _ = writer;
         render_nested_list_items(&list.items, self, 1, false, 1, !semantic, semantic)?;
-        writer = self.writer_mut();
-        writeln!(writer, "</ul>")?;
-        writeln!(writer, "</{wrapper_tag}>")?;
+        writeln!(self.writer, "</ul>")?;
+        writeln!(self.writer, "</{wrapper_tag}>")?;
         Ok(())
     }
 
@@ -109,39 +104,34 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         let semantic = self.processor.variant() == HtmlVariant::Semantic;
         let has_title = !list.title.is_empty();
 
-        let writer = self.writer_mut();
         // Semantic mode: use <section> for titled, <div> otherwise
         let wrapper_tag = if semantic && has_title {
             "section"
         } else {
             "div"
         };
-        write!(writer, "<{wrapper_tag}")?;
+        write!(self.writer, "<{wrapper_tag}")?;
         if let Some(id) = &list.metadata.id {
-            write!(writer, " id=\"{}\"", id.id)?;
+            write!(self.writer, " id=\"{}\"", id.id)?;
         } else if let Some(anchor) = list.metadata.anchors.first() {
-            write!(writer, " id=\"{}\"", anchor.id)?;
+            write!(self.writer, " id=\"{}\"", anchor.id)?;
         }
         let class = build_class(&format!("olist {style}"), &list.metadata.roles);
-        writeln!(writer, " class=\"{class}\">")?;
-        let _ = writer;
+        writeln!(self.writer, " class=\"{class}\">")?;
         if semantic && has_title {
             self.render_title_with_wrapper(&list.title, "<h6 class=\"block-title\">", "</h6>\n")?;
         } else {
             self.render_title_with_wrapper(&list.title, "<div class=\"title\">", "</div>\n")?;
         }
 
-        let mut writer = self.writer_mut();
         if let Some(t) = type_attr {
-            writeln!(writer, "<ol class=\"{style}\" type=\"{t}\">")?;
+            writeln!(self.writer, "<ol class=\"{style}\" type=\"{t}\">")?;
         } else {
-            writeln!(writer, "<ol class=\"{style}\">")?;
+            writeln!(self.writer, "<ol class=\"{style}\">")?;
         }
-        let _ = writer;
         render_nested_list_items(&list.items, self, 1, true, 1, !semantic, semantic)?;
-        writer = self.writer_mut();
-        writeln!(writer, "</ol>")?;
-        writeln!(writer, "</{wrapper_tag}>")?;
+        writeln!(self.writer, "</ol>")?;
+        writeln!(self.writer, "</{wrapper_tag}>")?;
         Ok(())
     }
 
@@ -150,64 +140,47 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return visit_callout_list_semantic(list, self);
         }
 
-        let writer = self.writer_mut();
-        writeln!(writer, "<div class=\"colist arabic\">")?;
-        let _ = writer;
+        writeln!(self.writer, "<div class=\"colist arabic\">")?;
         self.render_title_with_wrapper(&list.title, "<div class=\"title\">", "</div>\n")?;
 
         if self.processor.is_font_icons_mode() {
-            let writer = self.writer_mut();
-            writeln!(writer, "<table>")?;
-            let _ = writer;
+            writeln!(self.writer, "<table>")?;
 
             for item in &list.items {
                 let num = item.callout.number;
-                let writer = self.writer_mut();
-                writeln!(writer, "<tr>")?;
+                writeln!(self.writer, "<tr>")?;
                 writeln!(
-                    writer,
+                    self.writer,
                     "<td><i class=\"conum\" data-value=\"{num}\"></i><b>{num}</b></td>"
                 )?;
-                write!(writer, "<td>")?;
-                let _ = writer;
+                write!(self.writer, "<td>")?;
                 self.visit_inline_nodes(&item.principal)?;
                 for block in &item.blocks {
                     self.visit_block(block)?;
                 }
-                let writer = self.writer_mut();
-                writeln!(writer, "</td>")?;
-                writeln!(writer, "</tr>")?;
+                writeln!(self.writer, "</td>")?;
+                writeln!(self.writer, "</tr>")?;
             }
 
-            let writer = self.writer_mut();
-            writeln!(writer, "</table>")?;
+            writeln!(self.writer, "</table>")?;
         } else {
-            let writer = self.writer_mut();
-            writeln!(writer, "<ol>")?;
-            let _ = writer;
+            writeln!(self.writer, "<ol>")?;
 
             for item in &list.items {
-                let writer = self.writer_mut();
-                write!(writer, "<li>")?;
-                write!(writer, "<p>")?;
-                let _ = writer;
+                write!(self.writer, "<li>")?;
+                write!(self.writer, "<p>")?;
                 self.visit_inline_nodes(&item.principal)?;
-                let writer = self.writer_mut();
-                write!(writer, "</p>")?;
-                let _ = writer;
+                write!(self.writer, "</p>")?;
                 for block in &item.blocks {
                     self.visit_block(block)?;
                 }
-                let writer = self.writer_mut();
-                writeln!(writer, "</li>")?;
+                writeln!(self.writer, "</li>")?;
             }
 
-            let writer = self.writer_mut();
-            writeln!(writer, "</ol>")?;
+            writeln!(self.writer, "</ol>")?;
         }
 
-        let writer = self.writer_mut();
-        writeln!(writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
         Ok(())
     }
 }
@@ -414,13 +387,12 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         }
 
         // Start the description list outer div
-        let writer = self.writer_mut();
-        write!(writer, "<div")?;
+        write!(self.writer, "<div")?;
         // Use metadata.id if present, otherwise use first anchor
         if let Some(id) = &list.metadata.id {
-            write!(writer, " id=\"{}\"", id.id)?;
+            write!(self.writer, " id=\"{}\"", id.id)?;
         } else if let Some(anchor) = list.metadata.anchors.first() {
-            write!(writer, " id=\"{}\"", anchor.id)?;
+            write!(self.writer, " id=\"{}\"", anchor.id)?;
         }
 
         // Description list
@@ -431,9 +403,8 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             visit_standard_description_list(list, self)?;
         }
 
-        let writer = self.writer_mut();
         // Close the description list
-        writeln!(writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
         Ok(())
     }
 }
@@ -581,16 +552,13 @@ fn render_bare_ulist_semantic<W: Write>(
     let is_checklist = has_checklist_items(&list.items);
     let semantic = visitor.processor.variant() == HtmlVariant::Semantic;
 
-    let mut writer = visitor.writer_mut();
     if is_checklist {
-        writeln!(writer, "<ul class=\"task-list\">")?;
+        writeln!(visitor.writer, "<ul class=\"task-list\">")?;
     } else {
-        writeln!(writer, "<ul>")?;
+        writeln!(visitor.writer, "<ul>")?;
     }
-    let _ = writer;
     render_nested_list_items(&list.items, visitor, 1, false, 1, false, semantic)?;
-    writer = visitor.writer_mut();
-    writeln!(writer, "</ul>")?;
+    writeln!(visitor.writer, "</ul>")?;
     Ok(())
 }
 
@@ -604,16 +572,13 @@ fn render_bare_olist_semantic<W: Write>(
     let (style, type_attr) = ordered_list_style(depth);
     let semantic = visitor.processor.variant() == HtmlVariant::Semantic;
 
-    let mut writer = visitor.writer_mut();
     if let Some(t) = type_attr {
-        writeln!(writer, "<ol class=\"{style}\" type=\"{t}\">")?;
+        writeln!(visitor.writer, "<ol class=\"{style}\" type=\"{t}\">")?;
     } else {
-        writeln!(writer, "<ol class=\"{style}\">")?;
+        writeln!(visitor.writer, "<ol class=\"{style}\">")?;
     }
-    let _ = writer;
     render_nested_list_items(&list.items, visitor, 1, true, 1, false, semantic)?;
-    writer = visitor.writer_mut();
-    writeln!(writer, "</ol>")?;
+    writeln!(visitor.writer, "</ol>")?;
     Ok(())
 }
 
@@ -622,44 +587,32 @@ fn render_bare_dlist_semantic<W: Write>(
     list: &DescriptionList,
     visitor: &mut HtmlVisitor<'_, '_, W>,
 ) -> Result<(), Error> {
-    let mut writer = visitor.writer_mut();
-    writeln!(writer, "<dl>")?;
-    let _ = writer;
+    writeln!(visitor.writer, "<dl>")?;
 
     for item in &list.items {
-        writer = visitor.writer_mut();
-        writeln!(writer, "<dt>")?;
-        let _ = writer;
+        writeln!(visitor.writer, "<dt>")?;
         visitor.visit_inline_nodes(&item.term)?;
-        writer = visitor.writer_mut();
-        writeln!(writer, "</dt>")?;
+        writeln!(visitor.writer, "</dt>")?;
 
         if !item.principal_text.is_empty() || !item.description.is_empty() {
-            writeln!(writer, "<dd>")?;
+            writeln!(visitor.writer, "<dd>")?;
             if !item.principal_text.is_empty() {
                 if item.description.is_empty() {
-                    let _ = writer;
                     visitor.visit_inline_nodes(&item.principal_text)?;
-                    writer = visitor.writer_mut();
                 } else {
-                    write!(writer, "<p>")?;
-                    let _ = writer;
+                    write!(visitor.writer, "<p>")?;
                     visitor.visit_inline_nodes(&item.principal_text)?;
-                    writer = visitor.writer_mut();
-                    writeln!(writer, "</p>")?;
+                    writeln!(visitor.writer, "</p>")?;
                 }
             }
-            let _ = writer;
             for block in &item.description {
                 render_block_in_semantic_list_context(block, visitor)?;
             }
-            writer = visitor.writer_mut();
-            writeln!(writer, "</dd>")?;
+            writeln!(visitor.writer, "</dd>")?;
         }
     }
 
-    writer = visitor.writer_mut();
-    writeln!(writer, "</dl>")?;
+    writeln!(visitor.writer, "</dl>")?;
     Ok(())
 }
 
@@ -688,72 +641,58 @@ fn visit_description_list_semantic<W: Write>(
     let class = build_class(&base_class, &list.metadata.roles);
 
     let wrapper_tag = if has_title { "section" } else { "div" };
-    let writer = visitor.writer_mut();
-    write!(writer, "<{wrapper_tag}")?;
+    write!(visitor.writer, "<{wrapper_tag}")?;
     if let Some(id) = &list.metadata.id {
-        write!(writer, " id=\"{}\"", id.id)?;
+        write!(visitor.writer, " id=\"{}\"", id.id)?;
     } else if let Some(anchor) = list.metadata.anchors.first() {
-        write!(writer, " id=\"{}\"", anchor.id)?;
+        write!(visitor.writer, " id=\"{}\"", anchor.id)?;
     }
-    write!(writer, " class=\"{class}\"")?;
+    write!(visitor.writer, " class=\"{class}\"")?;
     if is_qanda {
-        write!(writer, " role=\"doc-qna\"")?;
+        write!(visitor.writer, " role=\"doc-qna\"")?;
     }
-    writeln!(writer, ">")?;
-    let _ = writer;
+    writeln!(visitor.writer, ">")?;
 
     if has_title {
         visitor.render_title_with_wrapper(&list.title, "<h6 class=\"block-title\">", "</h6>\n")?;
     }
 
-    let writer = visitor.writer_mut();
     // Inner <dl> with optional class
     if is_qanda {
-        writeln!(writer, "<dl class=\"qanda\">")?;
+        writeln!(visitor.writer, "<dl class=\"qanda\">")?;
     } else if is_horizontal {
-        writeln!(writer, "<dl class=\"horizontal\">")?;
+        writeln!(visitor.writer, "<dl class=\"horizontal\">")?;
     } else {
-        writeln!(writer, "<dl>")?;
+        writeln!(visitor.writer, "<dl>")?;
     }
-    let _ = writer;
 
     for item in &list.items {
-        let mut writer = visitor.writer_mut();
-        writeln!(writer, "<dt>")?;
-        let _ = writer;
+        writeln!(visitor.writer, "<dt>")?;
         visitor.visit_inline_nodes(&item.term)?;
-        writer = visitor.writer_mut();
-        writeln!(writer, "</dt>")?;
+        writeln!(visitor.writer, "</dt>")?;
 
         // Only render <dd> if there's content
         if !item.principal_text.is_empty() || !item.description.is_empty() {
-            writeln!(writer, "<dd>")?;
+            writeln!(visitor.writer, "<dd>")?;
             if !item.principal_text.is_empty() {
                 // Wrap in <p> only when there are also blocks
                 if item.description.is_empty() {
-                    let _ = writer;
                     visitor.visit_inline_nodes(&item.principal_text)?;
-                    writer = visitor.writer_mut();
                 } else {
-                    write!(writer, "<p>")?;
-                    let _ = writer;
+                    write!(visitor.writer, "<p>")?;
                     visitor.visit_inline_nodes(&item.principal_text)?;
-                    writer = visitor.writer_mut();
-                    writeln!(writer, "</p>")?;
+                    writeln!(visitor.writer, "</p>")?;
                 }
             }
-            let _ = writer;
             for block in &item.description {
                 render_block_in_semantic_list_context(block, visitor)?;
             }
-            writer = visitor.writer_mut();
-            writeln!(writer, "</dd>")?;
+            writeln!(visitor.writer, "</dd>")?;
         }
     }
 
-    let writer = visitor.writer_mut();
-    writeln!(writer, "</dl>")?;
-    writeln!(writer, "</{wrapper_tag}>")?;
+    writeln!(visitor.writer, "</dl>")?;
+    writeln!(visitor.writer, "</{wrapper_tag}>")?;
     Ok(())
 }
 

--- a/converters/html/src/paragraph.rs
+++ b/converters/html/src/paragraph.rs
@@ -20,20 +20,15 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         if let Some(style) = para.metadata.style
             && style == "literal"
         {
-            let mut w = self.writer_mut();
             let class = build_class("literalblock", &para.metadata.roles);
-            writeln!(w, "<div class=\"{class}\">")?;
-            let _ = w;
+            writeln!(self.writer, "<div class=\"{class}\">")?;
             self.render_title_with_wrapper(&para.title, "<div class=\"title\">", "</div>\n")?;
-            w = self.writer_mut();
-            writeln!(w, "<div class=\"content\">")?;
-            write!(w, "<pre>")?;
-            let _ = w;
+            writeln!(self.writer, "<div class=\"content\">")?;
+            write!(self.writer, "<pre>")?;
             self.visit_inline_nodes(&para.content)?;
-            w = self.writer_mut();
-            writeln!(w, "</pre>")?;
-            writeln!(w, "</div>")?;
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</pre>")?;
+            writeln!(self.writer, "</div>")?;
+            writeln!(self.writer, "</div>")?;
             return Ok(());
         }
 
@@ -41,18 +36,15 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         if para.metadata.style == Some("example") && para.metadata.options.contains(&"collapsible")
         {
             let is_open = para.metadata.options.contains(&"open");
-            let w = self.writer_mut();
-            write!(w, "<details")?;
-            write_id(w, &para.metadata)?;
+            write!(self.writer, "<details")?;
+            write_id(&mut self.writer, &para.metadata)?;
             if is_open {
-                writeln!(w, " open>")?;
+                writeln!(self.writer, " open>")?;
             } else {
-                writeln!(w, ">")?;
+                writeln!(self.writer, ">")?;
             }
-            let _ = w;
             if para.title.is_empty() {
-                let w = self.writer_mut();
-                writeln!(w, "<summary class=\"title\">Details</summary>")?;
+                writeln!(self.writer, "<summary class=\"title\">Details</summary>")?;
             } else {
                 self.render_title_with_wrapper(
                     &para.title,
@@ -60,54 +52,38 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                     "</summary>\n",
                 )?;
             }
-            let mut w = self.writer_mut();
-            writeln!(w, "<div class=\"content\">")?;
-            let _ = w;
+            writeln!(self.writer, "<div class=\"content\">")?;
             self.visit_inline_nodes(&para.content)?;
-            w = self.writer_mut();
-            writeln!(w)?;
-            writeln!(w, "</div>")?;
-            writeln!(w, "</details>")?;
+            writeln!(self.writer)?;
+            writeln!(self.writer, "</div>")?;
+            writeln!(self.writer, "</details>")?;
             return Ok(());
         }
 
         if let Some(style) = para.metadata.style {
             // Check if this paragraph should be rendered as a quote block
             if style == "quote" {
-                let mut w = self.writer_mut();
                 let class = build_class("quoteblock", &para.metadata.roles);
-                writeln!(w, "<div class=\"{class}\">")?;
-                let _ = w;
+                writeln!(self.writer, "<div class=\"{class}\">")?;
                 self.render_title_with_wrapper(&para.title, "<div class=\"title\">", "</div>\n")?;
-                w = self.writer_mut();
-                writeln!(w, "<blockquote>")?;
-                let _ = w;
+                writeln!(self.writer, "<blockquote>")?;
                 self.visit_inline_nodes(&para.content)?;
-                w = self.writer_mut();
-                writeln!(w)?;
-                writeln!(w, "</blockquote>")?;
-                let _ = w;
+                writeln!(self.writer)?;
+                writeln!(self.writer, "</blockquote>")?;
                 write_attribution(self, &para.metadata)?;
-                let w = self.writer_mut();
-                writeln!(w, "</div>")?;
+                writeln!(self.writer, "</div>")?;
                 return Ok(());
             }
 
             // Check if this paragraph should be rendered as a verse block
             if style == "verse" {
-                let mut w = self.writer_mut();
                 let class = build_class("verseblock", &para.metadata.roles);
-                writeln!(w, "<div class=\"{class}\">")?;
-                let _ = w;
+                writeln!(self.writer, "<div class=\"{class}\">")?;
                 self.render_title_with_wrapper(&para.title, "<div class=\"title\">", "</div>\n")?;
-                w = self.writer_mut();
-                write!(w, "<pre class=\"content\">")?;
-                let _ = w;
+                write!(self.writer, "<pre class=\"content\">")?;
                 self.visit_inline_nodes(&para.content)?;
-                let _ = self.writer_mut();
                 write_attribution(self, &para.metadata)?;
-                let w = self.writer_mut();
-                writeln!(w, "</div>")?;
+                writeln!(self.writer, "</div>")?;
                 return Ok(());
             }
 
@@ -125,59 +101,43 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
 
             if has_title {
                 // Titled paragraphs get a section wrapper
-                let mut w = self.writer_mut();
                 let class = build_class("paragraph", &para.metadata.roles);
-                write!(w, "<section")?;
-                write_id(w, &para.metadata)?;
-                writeln!(w, " class=\"{class}\">")?;
-                let _ = w;
+                write!(self.writer, "<section")?;
+                write_id(&mut self.writer, &para.metadata)?;
+                writeln!(self.writer, " class=\"{class}\">")?;
                 self.render_title_with_wrapper(
                     &para.title,
                     "<h6 class=\"block-title\">",
                     "</h6>\n",
                 )?;
-                w = self.writer_mut();
-                write!(w, "<p>")?;
-                let _ = w;
+                write!(self.writer, "<p>")?;
                 self.visit_inline_nodes(&para.content)?;
-                w = self.writer_mut();
-                writeln!(w, "</p>")?;
-                writeln!(w, "</section>")?;
+                writeln!(self.writer, "</p>")?;
+                writeln!(self.writer, "</section>")?;
             } else if has_id || has_roles {
                 // Id/roles without title: put attributes directly on <p>
-                let mut w = self.writer_mut();
-                write!(w, "<p")?;
+                write!(self.writer, "<p")?;
                 if has_roles {
-                    write!(w, " class=\"{}\"", para.metadata.roles.join(" "))?;
+                    write!(self.writer, " class=\"{}\"", para.metadata.roles.join(" "))?;
                 }
-                write_id(w, &para.metadata)?;
-                write!(w, ">")?;
-                let _ = w;
+                write_id(&mut self.writer, &para.metadata)?;
+                write!(self.writer, ">")?;
                 self.visit_inline_nodes(&para.content)?;
-                w = self.writer_mut();
-                writeln!(w, "</p>")?;
+                writeln!(self.writer, "</p>")?;
             } else {
                 // Bare paragraph — no wrapper
-                let mut w = self.writer_mut();
-                write!(w, "<p>")?;
-                let _ = w;
+                write!(self.writer, "<p>")?;
                 self.visit_inline_nodes(&para.content)?;
-                w = self.writer_mut();
-                writeln!(w, "</p>")?;
+                writeln!(self.writer, "</p>")?;
             }
         } else {
-            let mut w = self.writer_mut();
             let class = build_class("paragraph", &para.metadata.roles);
-            writeln!(w, "<div class=\"{class}\">")?;
-            let _ = w;
+            writeln!(self.writer, "<div class=\"{class}\">")?;
             self.render_title_with_wrapper(&para.title, "<div class=\"title\">", "</div>\n")?;
-            w = self.writer_mut();
-            write!(w, "<p>")?;
-            let _ = w;
+            write!(self.writer, "<p>")?;
             self.visit_inline_nodes(&para.content)?;
-            w = self.writer_mut();
-            writeln!(w, "</p>")?;
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</p>")?;
+            writeln!(self.writer, "</div>")?;
         }
         Ok(())
     }
@@ -191,34 +151,27 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         let subs = baseline_subs(true);
 
         if self.processor.variant() == HtmlVariant::Semantic {
-            let w = self.writer_mut();
             if para.title.is_empty() {
-                write!(w, "<div")?;
-                write_id(w, &para.metadata)?;
+                write!(self.writer, "<div")?;
+                write_id(&mut self.writer, &para.metadata)?;
                 let class = build_class("listing-block", &para.metadata.roles);
-                writeln!(w, " class=\"{class}\">")?;
-                let _ = w;
+                writeln!(self.writer, " class=\"{class}\">")?;
                 crate::render_pre_code(&para.content, language, self, &subs)?;
-                let w = self.writer_mut();
-                writeln!(w, "</div>")?;
+                writeln!(self.writer, "</div>")?;
             } else {
-                write!(w, "<figure")?;
-                write_id(w, &para.metadata)?;
+                write!(self.writer, "<figure")?;
+                write_id(&mut self.writer, &para.metadata)?;
                 let class = build_class("listing-block", &para.metadata.roles);
-                writeln!(w, " class=\"{class}\">")?;
-                let _ = w;
+                writeln!(self.writer, " class=\"{class}\">")?;
                 self.render_title_with_wrapper(&para.title, "<figcaption>", "</figcaption>\n")?;
                 crate::render_pre_code(&para.content, language, self, &subs)?;
-                let w = self.writer_mut();
-                writeln!(w, "</figure>")?;
+                writeln!(self.writer, "</figure>")?;
             }
         } else {
-            let w = self.writer_mut();
-            write!(w, "<div")?;
-            write_id(w, &para.metadata)?;
+            write!(self.writer, "<div")?;
+            write_id(&mut self.writer, &para.metadata)?;
             let class = build_class("listingblock", &para.metadata.roles);
-            writeln!(w, " class=\"{class}\">")?;
-            let _ = w;
+            writeln!(self.writer, " class=\"{class}\">")?;
 
             // Title with optional listing-caption numbering
             if !para.title.is_empty() {
@@ -241,13 +194,10 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 }
             }
 
-            let mut w = self.writer_mut();
-            writeln!(w, "<div class=\"content\">")?;
-            let _ = w;
+            writeln!(self.writer, "<div class=\"content\">")?;
             crate::render_pre_code(&para.content, language, self, &subs)?;
-            w = self.writer_mut();
-            writeln!(w, "</div>")?;
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</div>")?;
+            writeln!(self.writer, "</div>")?;
         }
 
         Ok(())

--- a/converters/html/src/section.rs
+++ b/converters/html/src/section.rs
@@ -70,30 +70,34 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         };
         let heading_level = effective_level + 1; // Level 1 = h2
 
-        let mut w = self.writer_mut();
-
         if section.level == 0 && !is_appendix {
             // Parts (level 0) in book doctype: standalone h1 with class="sect0", no wrapper div
-            write!(w, "<h{heading_level} id=\"{id}\" class=\"sect0\">")?;
+            write!(
+                self.writer,
+                "<h{heading_level} id=\"{id}\" class=\"sect0\">"
+            )?;
 
             // Prepend part number if :partnums: is enabled
             if !skip_numbering
                 && let Some(part_label) = processor.part_number_tracker().enter_part()
             {
-                write!(w, "{part_label}")?;
+                write!(self.writer, "{part_label}")?;
             }
         } else {
             if processor.variant() == HtmlVariant::Semantic {
-                writeln!(w, "<section class=\"doc-section level-{effective_level}\">")?;
+                writeln!(
+                    self.writer,
+                    "<section class=\"doc-section level-{effective_level}\">"
+                )?;
             } else {
-                writeln!(w, "<div class=\"sect{effective_level}\">")?;
+                writeln!(self.writer, "<div class=\"sect{effective_level}\">")?;
             }
-            write!(w, "<h{heading_level} id=\"{id}\">")?;
+            write!(self.writer, "<h{heading_level} id=\"{id}\">")?;
 
             // Prepend appendix label for appendix sections (any level)
             if is_appendix {
                 if let Some(appendix_label) = processor.appendix_tracker().enter_appendix() {
-                    write!(w, "{appendix_label}")?;
+                    write!(self.writer, "{appendix_label}")?;
                 }
             } else if !skip_numbering
                 && let Some(number) = processor
@@ -101,18 +105,16 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                     .enter_section(effective_level)
             {
                 // Prepend section number if sectnums is enabled and this isn't a special section
-                write!(w, "{number}")?;
+                write!(self.writer, "{number}")?;
             }
         }
 
-        let _ = w;
         self.visit_inline_nodes(&section.title)?;
-        w = self.writer_mut();
-        writeln!(w, "</h{heading_level}>")?;
+        writeln!(self.writer, "</h{heading_level}>")?;
 
         // sect1 (or appendix demoted to sect1) gets a sectionbody wrapper in standard mode
         if processor.variant() == HtmlVariant::Standard && effective_level == 1 {
-            writeln!(w, "<div class=\"sectionbody\">")?;
+            writeln!(self.writer, "<div class=\"sectionbody\">")?;
         }
         Ok(())
     }
@@ -139,16 +141,14 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return Ok(());
         }
 
-        let w = self.writer_mut();
-
         if processor.variant() == HtmlVariant::Semantic {
-            writeln!(w, "</section>")?;
+            writeln!(self.writer, "</section>")?;
         } else {
             // sect1 (or appendix demoted to sect1) has a sectionbody wrapper to close
             if effective_level == 1 {
-                writeln!(w, "</div>")?; // Close sectionbody
+                writeln!(self.writer, "</div>")?; // Close sectionbody
             }
-            writeln!(w, "</div>")?; // Close sectN
+            writeln!(self.writer, "</div>")?; // Close sectN
         }
         Ok(())
     }

--- a/converters/html/src/terminal_preview.rs
+++ b/converters/html/src/terminal_preview.rs
@@ -260,14 +260,12 @@ fn render_replay<W: Write>(
     // which stays fast because such recordings are short.
     let frames = if is_append_only(&ansi) {
         // The capture terminal must be tall enough to hold the whole recording
-        // without scrolling. `scrollback_size` already covers content that ends
-        // mid-line; a trailing newline leaves the cursor one row lower, so
-        // reserve one more row in that case.
-        let trailing_newline = usize::from(ansi.last() == Some(&b'\n'));
-        let tall = TerminalSize::new(
-            size.cols,
-            scrollback_rows(&ansi, size.rows) + trailing_newline,
-        );
+        // without scrolling. `estimate_rows` accounts for lines that wrap at
+        // `cols` into several grid rows (a raw newline count would undercount
+        // them and let the "tall" terminal scroll, corrupting windowed frames);
+        // counting bytes over-estimates display width, so it never
+        // under-allocates.
+        let tall = TerminalSize::new(size.cols, estimate_rows(&ansi, size.cols).max(size.rows));
         let replay_options = ReplayOptions::new(tall).with_default_frame_duration(frame_duration);
         replay::capture_windowed(events, replay_options, size.rows)?.into_frames()
     } else {
@@ -340,15 +338,6 @@ fn positive_attr(
         ));
     }
     parsed
-}
-
-fn scrollback_rows(ansi: &[u8], min_rows: usize) -> usize {
-    let trailing_line = usize::from(!ansi.is_empty() && !ansi.ends_with(b"\n"));
-    let lines = ansi
-        .split_inclusive(|byte| *byte == b'\n')
-        .count()
-        .saturating_add(trailing_line);
-    lines.max(min_rows)
 }
 
 /// Byte offsets where each replay chunk ends. Chunks are split on line feeds
@@ -544,6 +533,7 @@ fn render_replay_filmstrip<W: Write>(
         .max(1);
     let cols = first.grid.cols();
     let rows = first.grid.rows();
+    let animation_name = replay_animation_name(frames, rows, total_duration);
 
     write!(
         writer,
@@ -556,7 +546,14 @@ fn render_replay_filmstrip<W: Write>(
         frames.len(),
         total_ms
     )?;
-    render_replay_scroll_keyframes(writer, frames, rows, first_at, total_duration)?;
+    render_replay_scroll_keyframes(
+        writer,
+        &animation_name,
+        frames,
+        rows,
+        first_at,
+        total_duration,
+    )?;
     // The viewport keeps the terminal padding and any horizontal scrolling; the
     // clip is exactly `rows` tall (font-size pins `em` to the screen's line box)
     // and hides everything but the current frame as the filmstrip scrolls.
@@ -571,7 +568,7 @@ fn render_replay_filmstrip<W: Write>(
     )?;
     writeln!(
         writer,
-        "<pre class=\"terminal-preview__screen terminal-replay__scroll\" aria-label=\"Terminal replay\" style=\"margin:0;padding:0;animation:terminal-replay-scroll {total_ms}ms step-end both\">"
+        "<pre class=\"terminal-preview__screen terminal-replay__scroll\" aria-label=\"Terminal replay\" style=\"margin:0;padding:0;animation:{animation_name} {total_ms}ms step-end both\">"
     )?;
     let mut first_row = true;
     for frame in frames {
@@ -590,15 +587,38 @@ fn render_replay_filmstrip<W: Write>(
     Ok(())
 }
 
+/// A deterministic, per-block CSS animation name. Every replay block emits its
+/// own `@keyframes`, so a single shared global name would let a later block's
+/// keyframes override an earlier block's, animating the earlier block with the
+/// wrong offsets. The name hashes the inputs that define the keyframes (frame
+/// timings and row geometry); blocks that animate identically share a name,
+/// which is harmless.
+fn replay_animation_name(
+    frames: &[replay::Frame],
+    rows: usize,
+    total_duration: std::time::Duration,
+) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    rows.hash(&mut hasher);
+    total_duration.hash(&mut hasher);
+    frames.len().hash(&mut hasher);
+    for frame in frames {
+        frame.at.hash(&mut hasher);
+    }
+    format!("terminal-replay-scroll-{:016x}", hasher.finish())
+}
+
 fn render_replay_scroll_keyframes<W: Write>(
     writer: &mut W,
+    name: &str,
     frames: &[replay::Frame],
     rows: usize,
     first_at: std::time::Duration,
     total_duration: std::time::Duration,
 ) -> Result<(), Error> {
     writeln!(writer, "<style>")?;
-    write!(writer, "@keyframes terminal-replay-scroll{{")?;
+    write!(writer, "@keyframes {name}{{")?;
     for (index, frame) in frames.iter().enumerate() {
         let percent = replay_frame_percent(frame.at.saturating_sub(first_at), total_duration);
         let offset = row_em(index.saturating_mul(rows));
@@ -1068,6 +1088,42 @@ mod tests {
         assert!(!html.contains("@keyframes terminal-replay-frame-"));
         assert!(html.contains("first"));
         assert!(html.contains("second</span>"));
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_replay_blocks_use_distinct_animation_names() -> TestResult {
+        // Two replay blocks in one document must not share a global
+        // `@keyframes` name, or the later block's keyframes would override the
+        // earlier block's and animate it with the wrong offsets.
+        let html = render(
+            "= Example\n\n[terminal%replay,cols=20,rows=4]\n----\nfirst\nsecond\n----\n\n[terminal%replay,cols=20,rows=4]\n----\nalpha\nbeta\ngamma\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        let names: Vec<&str> = html
+            .split("@keyframes ")
+            .skip(1)
+            .filter_map(|rest| rest.split('{').next())
+            .filter(|name| name.starts_with("terminal-replay-scroll-"))
+            .collect();
+
+        assert_eq!(
+            names.len(),
+            2,
+            "each replay block defines its own keyframes"
+        );
+        assert_ne!(
+            names.first(),
+            names.get(1),
+            "animation names must be unique per block"
+        );
+        for name in &names {
+            assert!(
+                html.contains(&format!("animation:{name} ")),
+                "each block animates with its own keyframes name"
+            );
+        }
         Ok(())
     }
 

--- a/converters/html/src/terminal_preview.rs
+++ b/converters/html/src/terminal_preview.rs
@@ -222,11 +222,12 @@ fn render_replay<W: Write>(
     let Some(size) = replay_size(attrs, metadata, diagnostics) else {
         return render_with_options(writer, inlines, metadata, options, attrs, preview_options);
     };
-    let playback_duration = positive_duration_attr(
+    let playback_duration = positive_attr(
         REPLAY_DURATION_MS_ATTR,
         metadata.attributes.get(REPLAY_DURATION_MS_ATTR),
         diagnostics,
-    );
+    )
+    .map(|ms| std::time::Duration::from_millis(ms as u64));
 
     let ansi = normalize_terminal_newlines(&acdc_converters_terminal::render_listing_to_ansi(
         options,
@@ -265,7 +266,7 @@ fn render_replay<W: Write>(
         let trailing_newline = usize::from(ansi.last() == Some(&b'\n'));
         let tall = TerminalSize::new(
             size.cols,
-            scrollback_size(size, &ansi).rows + trailing_newline,
+            scrollback_rows(&ansi, size.rows) + trailing_newline,
         );
         let replay_options = ReplayOptions::new(tall).with_default_frame_duration(frame_duration);
         replay::capture_windowed(events, replay_options, size.rows)?.into_frames()
@@ -332,43 +333,22 @@ fn positive_attr(
     diagnostics: &mut Diagnostics<'_>,
 ) -> Option<usize> {
     let value = value?;
-    let raw = value.to_string();
-    match raw.parse::<usize>() {
-        Ok(parsed) if parsed > 0 => Some(parsed),
-        Ok(_) | Err(_) => {
-            diagnostics.warn(format!(
-                "terminal replay attribute `{name}` must be a positive integer, got `{raw}`"
-            ));
-            None
-        }
+    let parsed = attr_usize(Some(value));
+    if parsed.is_none() {
+        diagnostics.warn(format!(
+            "terminal replay attribute `{name}` must be a positive integer, got `{value}`"
+        ));
     }
+    parsed
 }
 
-fn positive_duration_attr(
-    name: &'static str,
-    value: Option<&AttributeValue<'_>>,
-    diagnostics: &mut Diagnostics<'_>,
-) -> Option<std::time::Duration> {
-    let value = value?;
-    let raw = value.to_string();
-    match raw.parse::<u64>() {
-        Ok(parsed) if parsed > 0 => Some(std::time::Duration::from_millis(parsed)),
-        Ok(_) | Err(_) => {
-            diagnostics.warn(format!(
-                "terminal replay attribute `{name}` must be a positive integer number of milliseconds, got `{raw}`"
-            ));
-            None
-        }
-    }
-}
-
-fn scrollback_size(size: TerminalSize, ansi: &[u8]) -> TerminalSize {
+fn scrollback_rows(ansi: &[u8], min_rows: usize) -> usize {
     let trailing_line = usize::from(!ansi.is_empty() && !ansi.ends_with(b"\n"));
     let lines = ansi
         .split_inclusive(|byte| *byte == b'\n')
         .count()
         .saturating_add(trailing_line);
-    TerminalSize::new(size.cols, lines.max(size.rows))
+    lines.max(min_rows)
 }
 
 /// Byte offsets where each replay chunk ends. Chunks are split on line feeds
@@ -584,12 +564,10 @@ fn render_replay_filmstrip<W: Write>(
         writer,
         "<div class=\"terminal-replay__viewport\" style=\"overflow:auto;max-width:100%;padding:18px;font-size:14px\">"
     )?;
-    let height = row_em(rows);
     writeln!(
         writer,
-        "<div class=\"terminal-replay__clip\" style=\"position:relative;overflow:hidden;width:max-content;height:{}.{:02}em\">",
-        height / 100,
-        height % 100
+        "<div class=\"terminal-replay__clip\" style=\"position:relative;overflow:hidden;width:max-content;height:{}\">",
+        row_em(rows)
     )?;
     writeln!(
         writer,
@@ -624,29 +602,30 @@ fn render_replay_scroll_keyframes<W: Write>(
     for (index, frame) in frames.iter().enumerate() {
         let percent = replay_frame_percent(frame.at.saturating_sub(first_at), total_duration);
         let offset = row_em(index.saturating_mul(rows));
-        write!(
-            writer,
-            "{percent:.4}%{{transform:translateY(-{}.{:02}em)}}",
-            offset / 100,
-            offset % 100
-        )?;
+        write!(writer, "{percent:.4}%{{transform:translateY(-{offset})}}")?;
     }
     // Hold the final frame to the end of the timeline.
     let last_offset = row_em(frames.len().saturating_sub(1).saturating_mul(rows));
-    writeln!(
-        writer,
-        "100%{{transform:translateY(-{}.{:02}em)}}}}",
-        last_offset / 100,
-        last_offset % 100
-    )?;
+    writeln!(writer, "100%{{transform:translateY(-{last_offset})}}}}")?;
     writeln!(writer, "</style>")?;
     Ok(())
 }
 
-/// Height of `rows` terminal rows in hundredths of an `em`, matching the
-/// screen's `font: 14px/1.45` line box (1.45em per row).
-fn row_em(rows: usize) -> usize {
-    rows.saturating_mul(145)
+/// A length in hundredths of an `em`, formatted as a CSS `em` value
+/// (e.g. `145` -> `1.45em`).
+#[derive(Clone, Copy)]
+struct Em(usize);
+
+impl std::fmt::Display for Em {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{:02}em", self.0 / 100, self.0 % 100)
+    }
+}
+
+/// Height of `rows` terminal rows, matching the screen's `font: 14px/1.45`
+/// line box (1.45em per row).
+fn row_em(rows: usize) -> Em {
+    Em(rows.saturating_mul(145))
 }
 
 fn replay_frame_percent(elapsed: std::time::Duration, total_duration: std::time::Duration) -> f64 {

--- a/converters/html/src/terminal_preview.rs
+++ b/converters/html/src/terminal_preview.rs
@@ -1,11 +1,11 @@
 //! Selectable HTML rendering for terminal cell-grid previews.
 
-use std::io::Write;
+use std::{borrow::Cow, io::Write};
 
-use acdc_converters_core::Options;
-use acdc_converters_core::code::detect_language;
-use acdc_converters_terminal::cell_grid::{
-    Cell, CellDecorations, CellGrid, Rgb, TerminalSize, capture_ansi,
+use acdc_converters_core::{Diagnostics, Options, code::detect_language};
+use acdc_converters_terminal::{
+    cell_grid::{Cell, CellDecorations, CellGrid, Rgb, TerminalSize, capture_ansi},
+    replay::{self, Options as ReplayOptions},
 };
 use acdc_parser::{AttributeValue, BlockMetadata, DocumentAttributes, InlineNode};
 
@@ -14,6 +14,11 @@ use crate::Error;
 const DEFAULT_COLS: usize = 80;
 const AUTO_ROW_PADDING: usize = 1;
 const MAX_AUTO_ROWS: usize = 200;
+const REPLAY_OPTION: &str = "replay";
+const REPLAY_FRAME_DURATION_MS: u64 = 500;
+const REPLAY_DURATION_MS_ATTR: &str = "replay-duration-ms";
+const REPLAY_RENDER_FPS: u128 = 30;
+const MAX_REPLAY_RENDER_FRAMES: usize = 120;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Theme {
@@ -144,6 +149,10 @@ pub(crate) fn is_terminal_session(metadata: &BlockMetadata<'_>) -> bool {
     metadata.style == Some("terminal")
 }
 
+fn is_terminal_replay(metadata: &BlockMetadata<'_>) -> bool {
+    metadata.options.contains(&REPLAY_OPTION) || metadata.attributes.contains_key(REPLAY_OPTION)
+}
+
 pub(crate) fn render_listing<W: Write>(
     writer: W,
     inlines: &[InlineNode<'_>],
@@ -161,8 +170,20 @@ pub(crate) fn render_session<W: Write>(
     metadata: &BlockMetadata<'_>,
     options: Options,
     attrs: &DocumentAttributes<'_>,
+    diagnostics: &mut Diagnostics<'_>,
 ) -> Result<(), Error> {
     let preview_options = PreviewOptions::resolve(attrs, Some(metadata));
+    if is_terminal_replay(metadata) {
+        return render_replay(
+            writer,
+            inlines,
+            metadata,
+            options,
+            attrs,
+            preview_options,
+            diagnostics,
+        );
+    }
     render_with_options(writer, inlines, metadata, options, attrs, preview_options)
 }
 
@@ -187,6 +208,279 @@ fn render_with_options<W: Write>(
 
     render_grid(&mut writer, &grid, preview_options.theme)?;
     Ok(())
+}
+
+fn render_replay<W: Write>(
+    mut writer: W,
+    inlines: &[InlineNode<'_>],
+    metadata: &BlockMetadata<'_>,
+    options: Options,
+    attrs: &DocumentAttributes<'_>,
+    preview_options: PreviewOptions,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Result<(), Error> {
+    let Some(size) = replay_size(attrs, metadata, diagnostics) else {
+        return render_with_options(writer, inlines, metadata, options, attrs, preview_options);
+    };
+    let playback_duration = positive_duration_attr(
+        REPLAY_DURATION_MS_ATTR,
+        metadata.attributes.get(REPLAY_DURATION_MS_ATTR),
+        diagnostics,
+    );
+
+    let ansi = normalize_terminal_newlines(&acdc_converters_terminal::render_listing_to_ansi(
+        options,
+        attrs.clone(),
+        inlines,
+        metadata,
+        size.cols,
+        preview_options.theme == Theme::Dark,
+    )?);
+    let boundaries = chunk_boundaries(&ansi);
+    let frame_duration = std::time::Duration::from_millis(REPLAY_FRAME_DURATION_MS);
+    let estimated_playback_ms = frame_duration
+        .as_millis()
+        .saturating_mul(boundaries.len() as u128)
+        .max(1);
+    let playback_ms = playback_duration.map_or(estimated_playback_ms, |duration| {
+        duration.as_millis().max(1)
+    });
+    let events = sampled_events(
+        &ansi,
+        &boundaries,
+        replay_frame_budget(playback_ms),
+        frame_duration,
+    );
+
+    // Append-only recordings (logs, build/test output) can be captured into a
+    // tall, non-scrolling terminal and windowed per frame, which avoids
+    // libghostty's costly viewport scroll. Recordings that redraw earlier rows
+    // (progress bars, full-screen TUIs) fall back to the scrolling emulator,
+    // which stays fast because such recordings are short.
+    let frames = if is_append_only(&ansi) {
+        // The capture terminal must be tall enough to hold the whole recording
+        // without scrolling. `scrollback_size` already covers content that ends
+        // mid-line; a trailing newline leaves the cursor one row lower, so
+        // reserve one more row in that case.
+        let trailing_newline = usize::from(ansi.last() == Some(&b'\n'));
+        let tall = TerminalSize::new(
+            size.cols,
+            scrollback_size(size, &ansi).rows + trailing_newline,
+        );
+        let replay_options = ReplayOptions::new(tall).with_default_frame_duration(frame_duration);
+        replay::capture_windowed(events, replay_options, size.rows)?.into_frames()
+    } else {
+        let replay_options = ReplayOptions::new(size).with_default_frame_duration(frame_duration);
+        replay::capture(events, replay_options)?.into_frames()
+    };
+
+    if frames.is_empty() {
+        diagnostics.warn(
+            "terminal replay produced no visible frames; rendering a static terminal preview instead",
+        );
+        let grid = capture_ansi(&ansi, size)?;
+        return render_grid(&mut writer, &grid, preview_options.theme);
+    }
+
+    render_replay_filmstrip(
+        &mut writer,
+        &frames,
+        preview_options.theme,
+        playback_duration,
+    )?;
+    Ok(())
+}
+
+fn replay_size(
+    attrs: &DocumentAttributes<'_>,
+    metadata: &BlockMetadata<'_>,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Option<TerminalSize> {
+    let cols = positive_attr("cols", metadata.attributes.get("cols"), diagnostics)
+        .or_else(|| {
+            positive_attr(
+                "terminal-cols",
+                metadata.attributes.get("terminal-cols"),
+                diagnostics,
+            )
+        })
+        .or_else(|| positive_attr("terminal-cols", attrs.get("terminal-cols"), diagnostics));
+    let rows = positive_attr("rows", metadata.attributes.get("rows"), diagnostics)
+        .or_else(|| {
+            positive_attr(
+                "terminal-rows",
+                metadata.attributes.get("terminal-rows"),
+                diagnostics,
+            )
+        })
+        .or_else(|| positive_attr("terminal-rows", attrs.get("terminal-rows"), diagnostics));
+
+    if let (Some(cols), Some(rows)) = (cols, rows) {
+        Some(TerminalSize::new(cols, rows))
+    } else {
+        diagnostics.warn_with_advice(
+            "terminal replay requires positive `cols` and `rows` block attributes or `terminal-cols` and `terminal-rows` document attributes; rendering a static terminal preview instead",
+            "Use a replay block such as `[terminal%replay,cols=80,rows=24]`.",
+        );
+        None
+    }
+}
+
+fn positive_attr(
+    name: &'static str,
+    value: Option<&AttributeValue<'_>>,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Option<usize> {
+    let value = value?;
+    let raw = value.to_string();
+    match raw.parse::<usize>() {
+        Ok(parsed) if parsed > 0 => Some(parsed),
+        Ok(_) | Err(_) => {
+            diagnostics.warn(format!(
+                "terminal replay attribute `{name}` must be a positive integer, got `{raw}`"
+            ));
+            None
+        }
+    }
+}
+
+fn positive_duration_attr(
+    name: &'static str,
+    value: Option<&AttributeValue<'_>>,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Option<std::time::Duration> {
+    let value = value?;
+    let raw = value.to_string();
+    match raw.parse::<u64>() {
+        Ok(parsed) if parsed > 0 => Some(std::time::Duration::from_millis(parsed)),
+        Ok(_) | Err(_) => {
+            diagnostics.warn(format!(
+                "terminal replay attribute `{name}` must be a positive integer number of milliseconds, got `{raw}`"
+            ));
+            None
+        }
+    }
+}
+
+fn scrollback_size(size: TerminalSize, ansi: &[u8]) -> TerminalSize {
+    let trailing_line = usize::from(!ansi.is_empty() && !ansi.ends_with(b"\n"));
+    let lines = ansi
+        .split_inclusive(|byte| *byte == b'\n')
+        .count()
+        .saturating_add(trailing_line);
+    TerminalSize::new(size.cols, lines.max(size.rows))
+}
+
+/// Byte offsets where each replay chunk ends. Chunks are split on line feeds
+/// (kept with the line) and on bare carriage returns (which begin an in-place
+/// refresh), matching how a terminal advances between visible updates.
+fn chunk_boundaries(ansi: &[u8]) -> Vec<usize> {
+    let mut boundaries = Vec::new();
+    let mut start = 0;
+
+    for (index, byte) in ansi.iter().copied().enumerate() {
+        match byte {
+            b'\n' => {
+                boundaries.push(index + 1);
+                start = index + 1;
+            }
+            b'\r' if ansi.get(index + 1) != Some(&b'\n') => {
+                if start < index {
+                    boundaries.push(index);
+                }
+                start = index;
+            }
+            _ => {}
+        }
+    }
+
+    if start < ansi.len() {
+        boundaries.push(ansi.len());
+    }
+
+    boundaries
+}
+
+/// Build at most `frame_budget` replay events by sampling chunk boundaries and
+/// referencing the contiguous bytes between sampled boundaries directly (no
+/// copies). Timestamps reflect each sampled chunk's position in the recording.
+fn sampled_events<'a>(
+    ansi: &'a [u8],
+    boundaries: &[usize],
+    frame_budget: usize,
+    frame_duration: std::time::Duration,
+) -> Vec<replay::Event<'a>> {
+    let sampled = sampled_indexes(boundaries.len(), frame_budget);
+    let mut events = Vec::with_capacity(sampled.len());
+    let mut start = 0;
+
+    for index in sampled {
+        let Some(&end) = boundaries.get(index) else {
+            continue;
+        };
+        if start < end
+            && let Some(bytes) = ansi.get(start..end)
+        {
+            events.push(replay::Event::write_at(
+                Cow::Borrowed(bytes),
+                replay_chunk_timestamp(index, frame_duration),
+            ));
+        }
+        start = end;
+    }
+
+    events
+}
+
+fn replay_chunk_timestamp(
+    chunk_index: usize,
+    frame_duration: std::time::Duration,
+) -> std::time::Duration {
+    frame_duration.saturating_mul(u32::try_from(chunk_index + 1).unwrap_or(u32::MAX))
+}
+
+/// Whether the recorded output only ever appends below the cursor, so it can be
+/// captured with the fast tall-terminal windowing path. Output is append-only
+/// when it contains no bare carriage returns (in-place line refreshes) and no
+/// escape sequences other than SGR styling (`ESC [ ... m`) and OSC sequences
+/// (hyperlinks/titles), which never move the cursor up or erase the screen.
+fn is_append_only(ansi: &[u8]) -> bool {
+    let mut index = 0;
+    while let Some(&byte) = ansi.get(index) {
+        match byte {
+            b'\r' if ansi.get(index + 1) != Some(&b'\n') => return false,
+            0x1b => match ansi.get(index + 1) {
+                Some(b'[') => {
+                    let mut end = index + 2;
+                    while ansi.get(end).is_some_and(|b| !(0x40..=0x7e).contains(b)) {
+                        end += 1;
+                    }
+                    if ansi.get(end) != Some(&b'm') {
+                        return false;
+                    }
+                    index = end + 1;
+                }
+                Some(b']') => index = skip_osc(ansi, index + 2),
+                _ => return false,
+            },
+            _ => index += 1,
+        }
+    }
+    true
+}
+
+/// Advance past an OSC sequence body starting at `start`, stopping after a BEL
+/// or ST (`ESC \`) terminator. Returns the index just past the terminator.
+fn skip_osc(ansi: &[u8], start: usize) -> usize {
+    let mut index = start;
+    while let Some(&byte) = ansi.get(index) {
+        match byte {
+            0x07 => return index + 1,
+            0x1b if ansi.get(index + 1) == Some(&b'\\') => return index + 2,
+            _ => index += 1,
+        }
+    }
+    index
 }
 
 fn is_terminal_language(language: &str) -> bool {
@@ -242,6 +536,167 @@ fn render_grid<W: Write>(writer: &mut W, grid: &CellGrid, theme: Theme) -> Resul
     writeln!(writer, "</pre>")?;
     writeln!(writer, "</div>")?;
     Ok(())
+}
+
+/// Render the replay as a single "filmstrip": every sampled frame stacked into
+/// one `<pre>`, with a clipped viewport showing one frame at a time and a single
+/// stepped `translateY` animation advancing through them. This keeps the DOM to
+/// one grid and one animation regardless of recording length, instead of N
+/// stacked frame layers. Playback ends on the final frame (no scroll-back).
+fn render_replay_filmstrip<W: Write>(
+    writer: &mut W,
+    frames: &[replay::Frame],
+    theme: Theme,
+    playback_duration: Option<std::time::Duration>,
+) -> Result<(), Error> {
+    let Some(first) = frames.first() else {
+        return Ok(());
+    };
+    let (bg, fg) = theme.colors();
+    let frame_duration = std::time::Duration::from_millis(REPLAY_FRAME_DURATION_MS);
+    let first_at = first.at;
+    let total_duration = frames.last().map_or(frame_duration, |frame| {
+        frame.at.saturating_sub(first_at) + frame_duration
+    });
+    let total_ms = playback_duration
+        .unwrap_or(total_duration)
+        .as_millis()
+        .max(1);
+    let cols = first.grid.cols();
+    let rows = first.grid.rows();
+
+    write!(
+        writer,
+        "<div class=\"terminal-preview terminal-replay terminal-preview--{}\" style=\"background-color:{};color:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\">",
+        theme.as_str(),
+        rgb_css(bg),
+        rgb_css(fg),
+        cols,
+        rows,
+        frames.len(),
+        total_ms
+    )?;
+    render_replay_scroll_keyframes(writer, frames, rows, first_at, total_duration)?;
+    // The viewport keeps the terminal padding and any horizontal scrolling; the
+    // clip is exactly `rows` tall (font-size pins `em` to the screen's line box)
+    // and hides everything but the current frame as the filmstrip scrolls.
+    writeln!(
+        writer,
+        "<div class=\"terminal-replay__viewport\" style=\"overflow:auto;max-width:100%;padding:18px;font-size:14px\">"
+    )?;
+    let height = row_em(rows);
+    writeln!(
+        writer,
+        "<div class=\"terminal-replay__clip\" style=\"position:relative;overflow:hidden;width:max-content;height:{}.{:02}em\">",
+        height / 100,
+        height % 100
+    )?;
+    writeln!(
+        writer,
+        "<pre class=\"terminal-preview__screen terminal-replay__scroll\" aria-label=\"Terminal replay\" style=\"margin:0;padding:0;animation:terminal-replay-scroll {total_ms}ms step-end both\">"
+    )?;
+    let mut first_row = true;
+    for frame in frames {
+        for row in frame.grid.rows_iter() {
+            if !first_row {
+                writeln!(writer)?;
+            }
+            first_row = false;
+            render_row(writer, row)?;
+        }
+    }
+    writeln!(writer, "</pre>")?;
+    writeln!(writer, "</div>")?;
+    writeln!(writer, "</div>")?;
+    writeln!(writer, "</div>")?;
+    Ok(())
+}
+
+fn render_replay_scroll_keyframes<W: Write>(
+    writer: &mut W,
+    frames: &[replay::Frame],
+    rows: usize,
+    first_at: std::time::Duration,
+    total_duration: std::time::Duration,
+) -> Result<(), Error> {
+    writeln!(writer, "<style>")?;
+    write!(writer, "@keyframes terminal-replay-scroll{{")?;
+    for (index, frame) in frames.iter().enumerate() {
+        let percent = replay_frame_percent(frame.at.saturating_sub(first_at), total_duration);
+        let offset = row_em(index.saturating_mul(rows));
+        write!(
+            writer,
+            "{percent:.4}%{{transform:translateY(-{}.{:02}em)}}",
+            offset / 100,
+            offset % 100
+        )?;
+    }
+    // Hold the final frame to the end of the timeline.
+    let last_offset = row_em(frames.len().saturating_sub(1).saturating_mul(rows));
+    writeln!(
+        writer,
+        "100%{{transform:translateY(-{}.{:02}em)}}}}",
+        last_offset / 100,
+        last_offset % 100
+    )?;
+    writeln!(writer, "</style>")?;
+    Ok(())
+}
+
+/// Height of `rows` terminal rows in hundredths of an `em`, matching the
+/// screen's `font: 14px/1.45` line box (1.45em per row).
+fn row_em(rows: usize) -> usize {
+    rows.saturating_mul(145)
+}
+
+fn replay_frame_percent(elapsed: std::time::Duration, total_duration: std::time::Duration) -> f64 {
+    let total = total_duration.as_secs_f64();
+    if total == 0.0 {
+        return 0.0;
+    }
+    (elapsed.as_secs_f64() / total * 100.0).clamp(0.0, 100.0)
+}
+
+fn replay_frame_budget(playback_ms: u128) -> usize {
+    let budget = playback_ms
+        .saturating_mul(REPLAY_RENDER_FPS)
+        .div_ceil(1000)
+        .saturating_add(1)
+        .try_into()
+        .unwrap_or(MAX_REPLAY_RENDER_FRAMES);
+    budget.clamp(2, MAX_REPLAY_RENDER_FRAMES)
+}
+
+fn sampled_indexes(item_count: usize, budget: usize) -> Vec<usize> {
+    if item_count == 0 {
+        return Vec::new();
+    }
+    let budget = budget.min(item_count);
+    if item_count <= budget {
+        return (0..item_count).collect();
+    }
+    if budget <= 1 {
+        return vec![item_count - 1];
+    }
+
+    let last_index = item_count - 1;
+    let last_slot = budget - 1;
+    let mut indexes = Vec::with_capacity(budget);
+    let mut previous_index = None;
+
+    for slot in 0..budget {
+        let index = if slot == last_slot {
+            last_index
+        } else {
+            slot.saturating_mul(last_index) / last_slot
+        };
+        if previous_index != Some(index) {
+            indexes.push(index);
+            previous_index = Some(index);
+        }
+    }
+
+    indexes
 }
 
 fn render_row<W: Write>(writer: &mut W, row: &[Cell]) -> Result<(), Error> {
@@ -428,7 +883,7 @@ fn escape_html(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use acdc_converters_core::{
-        Diagnostics, GeneratorMetadata, Options as ConverterOptions, WarningSource,
+        Diagnostics, GeneratorMetadata, Options as ConverterOptions, Warning, WarningSource,
     };
     use acdc_parser::Options as ParserOptions;
 
@@ -440,6 +895,14 @@ mod tests {
         input: &str,
         variant: crate::HtmlVariant,
     ) -> Result<String, Box<dyn std::error::Error>> {
+        let (html, _) = render_with_warnings(input, variant)?;
+        Ok(html)
+    }
+
+    fn render_with_warnings(
+        input: &str,
+        variant: crate::HtmlVariant,
+    ) -> Result<(String, Vec<Warning>), Box<dyn std::error::Error>> {
         let parser_options =
             ParserOptions::with_attributes(acdc_converters_core::default_rendering_attributes());
         let parsed = acdc_parser::parse(input, &parser_options)?;
@@ -458,7 +921,7 @@ mod tests {
             &RenderOptions::default(),
             &mut diagnostics,
         )?;
-        Ok(String::from_utf8(output)?)
+        Ok((String::from_utf8(output)?, warnings))
     }
 
     #[test]
@@ -594,6 +1057,133 @@ mod tests {
         assert!(html.contains("<div class=\"terminalblock terminal-preview-block\">"));
         assert!(html.contains("data-cols=\"20\""));
         assert!(html.contains("$ echo literal"));
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_replay_block_renders_multiple_frames() -> TestResult {
+        let html = render(
+            "= Example\n\n[terminal%replay,cols=20,rows=4]\n----\nfirst\n\x1b[31msecond\x1b[0m\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(
+            html.contains(
+                "<div class=\"terminal-preview terminal-replay terminal-preview--light\""
+            )
+        );
+        assert!(html.contains("data-cols=\"20\""));
+        assert!(html.contains("data-rows=\"4\""));
+        assert!(html.contains("data-frames=\"2\""));
+        assert!(html.contains("data-duration-ms=\"1000\""));
+        // Single filmstrip grid + one stepped scroll animation, no per-frame
+        // layers or visibility toggling.
+        assert!(html.contains("@keyframes terminal-replay-scroll"));
+        assert!(html.contains("terminal-replay__scroll"));
+        assert!(html.contains("transform:translateY("));
+        assert!(html.contains("1000ms step-end both"));
+        assert!(!html.contains("<script>"));
+        assert!(!html.contains("terminal-replay__frame"));
+        assert!(!html.contains("terminal-replay__stage"));
+        assert!(!html.contains("terminal-replay__scrollback"));
+        assert!(!html.contains("@keyframes terminal-replay-frame-"));
+        assert!(html.contains("first"));
+        assert!(html.contains("second</span>"));
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_replay_accepts_playback_duration_override() -> TestResult {
+        let html = render(
+            "= Example\n\n[terminal%replay,cols=20,rows=4,replay-duration-ms=250]\n----\nfirst\nsecond\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("data-duration-ms=\"250\""));
+        assert!(html.contains("250ms step-end both"));
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_replay_samples_dense_frames_for_short_playback() -> TestResult {
+        let lines = (0..200)
+            .map(|index| format!("line {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let html = render(
+            &format!(
+                "= Example\n\n[terminal%replay,cols=20,rows=4,replay-duration-ms=100]\n----\n{lines}\n----\n"
+            ),
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("data-frames=\"4\""));
+        assert!(html.contains("line 0"));
+        assert!(html.contains("line 199"));
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_replay_keeps_carriage_return_refreshes_atomic() {
+        // A bare carriage return ends a chunk so an in-place refresh
+        // ("working" -> "done") is replayed as its own visible update.
+        let ansi = b"working\r\x1b[Kdone\n";
+        let boundaries = super::chunk_boundaries(ansi);
+
+        assert_eq!(boundaries, vec![7, ansi.len()]);
+        assert_eq!(&ansi[..7], b"working");
+        assert_eq!(&ansi[7..], b"\r\x1b[Kdone\n");
+        assert!(!super::is_append_only(ansi));
+    }
+
+    #[test]
+    fn terminal_replay_keeps_crlf_lines_in_one_chunk() {
+        let ansi = b"first\r\nsecond\r\n";
+        let boundaries = super::chunk_boundaries(ansi);
+
+        assert_eq!(boundaries, vec![7, ansi.len()]);
+        assert_eq!(&ansi[..7], b"first\r\n");
+        assert_eq!(&ansi[7..], b"second\r\n");
+        assert!(super::is_append_only(ansi));
+    }
+
+    #[test]
+    fn terminal_replay_animates_in_place_refreshes_via_emulator_fallback() -> TestResult {
+        // A bare carriage return rewrites the same line in place; the emulator
+        // fallback replays each intermediate state rather than jumping to the
+        // final value.
+        let html = render(
+            "= Example\n\n[terminal%replay,cols=20,rows=4]\n----\nWorking 0%\rWorking 50%\rWorking 100%\nDone\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("terminal-replay__scroll"));
+        assert!(html.contains("Working 0%"));
+        assert!(html.contains("Working 50%"));
+        assert!(html.contains("Working 100%"));
+        assert!(html.contains("Done"));
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_replay_requires_explicit_dimensions() -> TestResult {
+        let (html, warnings) = render_with_warnings(
+            "= Example\n\n[terminal%replay,cols=0]\n----\nfirst\nsecond\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(!html.contains("terminal-replay"));
+        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(warnings.iter().any(|warning| {
+            warning
+                .message
+                .contains("terminal replay attribute `cols` must be a positive integer")
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning
+                .message
+                .contains("terminal replay requires positive `cols` and `rows`")
+        }));
         Ok(())
     }
 

--- a/converters/html/src/video.rs
+++ b/converters/html/src/video.rs
@@ -1,9 +1,6 @@
 use std::io::Write;
 
-use acdc_converters_core::{
-    video::TryUrl,
-    visitor::{Visitor, WritableVisitor},
-};
+use acdc_converters_core::{video::TryUrl, visitor::Visitor};
 use acdc_parser::{AttributeValue, Video};
 
 use crate::{Error, HtmlVariant, HtmlVisitor};
@@ -14,27 +11,24 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             return visit_video_semantic(video, self);
         }
 
-        let mut w = self.writer_mut();
-        write!(w, "<div")?;
+        write!(self.writer, "<div")?;
         if let Some(id) = &video.metadata.id {
-            write!(w, " id=\"{}\"", id.id)?;
+            write!(self.writer, " id=\"{}\"", id.id)?;
         }
-        writeln!(w, " class=\"videoblock\">")?;
+        writeln!(self.writer, " class=\"videoblock\">")?;
 
         if !video.title.is_empty() {
-            write!(w, "<div class=\"title\">")?;
-            let _ = w;
+            write!(self.writer, "<div class=\"title\">")?;
             self.visit_inline_nodes(&video.title)?;
-            w = self.writer_mut();
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</div>")?;
         }
 
-        writeln!(w, "<div class=\"content\">")?;
+        writeln!(self.writer, "<div class=\"content\">")?;
 
         // Video blocks can have multiple sources
         if video.sources.is_empty() {
-            writeln!(w, "</div>")?;
-            writeln!(w, "</div>")?;
+            writeln!(self.writer, "</div>")?;
+            writeln!(self.writer, "</div>")?;
             return Ok(());
         }
 
@@ -50,13 +44,13 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         );
 
         if is_youtube || is_vimeo {
-            render_iframe_video(video, w)?;
+            render_iframe_video(video, &mut self.writer)?;
         } else {
-            render_local_video(video, w)?;
+            render_local_video(video, &mut self.writer)?;
         }
 
-        writeln!(w, "</div>")?;
-        writeln!(w, "</div>")?;
+        writeln!(self.writer, "</div>")?;
+        writeln!(self.writer, "</div>")?;
 
         Ok(())
     }
@@ -139,17 +133,16 @@ fn visit_video_semantic<W: Write>(
     visitor: &mut HtmlVisitor<'_, '_, W>,
 ) -> Result<(), Error> {
     let has_title = !video.title.is_empty();
-    let mut w = visitor.writer_mut();
 
     let tag = if has_title { "figure" } else { "div" };
-    write!(w, "<{tag} class=\"video-block\"")?;
+    write!(visitor.writer, "<{tag} class=\"video-block\"")?;
     if let Some(id) = &video.metadata.id {
-        write!(w, " id=\"{}\"", id.id)?;
+        write!(visitor.writer, " id=\"{}\"", id.id)?;
     }
-    writeln!(w, ">")?;
+    writeln!(visitor.writer, ">")?;
 
     if video.sources.is_empty() {
-        writeln!(w, "</{tag}>")?;
+        writeln!(visitor.writer, "</{tag}>")?;
         return Ok(());
     }
 
@@ -163,20 +156,17 @@ fn visit_video_semantic<W: Write>(
     );
 
     if is_youtube || is_vimeo {
-        render_iframe_video(video, w)?;
+        render_iframe_video(video, &mut visitor.writer)?;
     } else {
-        render_local_video(video, w)?;
+        render_local_video(video, &mut visitor.writer)?;
     }
 
     if has_title {
-        w = visitor.writer_mut();
-        write!(w, "<figcaption>")?;
-        let _ = w;
+        write!(visitor.writer, "<figcaption>")?;
         visitor.visit_inline_nodes(&video.title)?;
-        w = visitor.writer_mut();
-        writeln!(w, "</figcaption>")?;
+        writeln!(visitor.writer, "</figcaption>")?;
     }
 
-    writeln!(w, "</{tag}>")?;
+    writeln!(visitor.writer, "</{tag}>")?;
     Ok(())
 }

--- a/converters/terminal/CHANGELOG.md
+++ b/converters/terminal/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Internal terminal replay frame capture can now build ordered, deduplicated
-  `CellGrid` frames from ANSI chunks for animated replay renderers.
+- Terminal replay frame capture (`replay::capture` / `capture_windowed`) builds
+  ordered, deduplicated `CellGrid` frames from recorded ANSI for animated replay
+  renderers; `capture_windowed` is a fast path for append-only recordings.
 - `[subs="-replacements"]` on a paragraph now keeps typography source (`--`,
   `(C)`, `->`, `...`) literal instead of converting to Unicode.
 - User-facing converter warnings are now collected in `ConversionResult` for

--- a/converters/terminal/src/document.rs
+++ b/converters/terminal/src/document.rs
@@ -21,9 +21,7 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
             temp_visitor.visit_inline_node(node)?;
         }
         if let Some(subtitle) = &header.subtitle {
-            let w = temp_visitor.writer_mut();
-            write!(w, ": ")?;
-            let _ = w;
+            write!(temp_visitor.writer, ": ")?;
             for node in subtitle {
                 temp_visitor.visit_inline_node(node)?;
             }

--- a/converters/terminal/src/list.rs
+++ b/converters/terminal/src/list.rs
@@ -102,26 +102,22 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
         item_number: usize,
         unicode: bool,
     ) -> Result<(), Error> {
-        let w = self.writer_mut();
-        write_indent(w, indent)?;
+        write_indent(&mut self.writer, indent)?;
 
         if is_ordered {
-            write!(w, "{item_number}.")?;
+            write!(self.writer, "{item_number}.")?;
         } else {
-            write!(w, "*")?;
+            write!(self.writer, "*")?;
         }
 
-        render_checked_status(item.checked.as_ref(), w, unicode)?;
-        write!(w, " ")?;
-        let _ = w;
+        render_checked_status(item.checked.as_ref(), &mut self.writer, unicode)?;
+        write!(self.writer, " ")?;
 
         for node in &item.principal {
             self.visit_inline_node(node)?;
         }
 
-        let w = self.writer_mut();
-        writeln!(w)?;
-        let _ = w;
+        writeln!(self.writer)?;
 
         // Render attached blocks with increased indentation.
         // Set list_indent so nested lists rendered via the visitor pick up the right depth.
@@ -188,30 +184,24 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
     pub(crate) fn render_callout_list(&mut self, list: &CalloutList) -> Result<(), Error> {
         self.render_styled_title(&list.title)?;
         if !list.title.is_empty() {
-            let w = self.writer_mut();
-            writeln!(w)?;
+            writeln!(self.writer)?;
         }
 
         for (idx, item) in list.items.iter().enumerate() {
             let item_number = idx + 1;
-            let mut w = self.writer_mut();
-            write!(w, "<{item_number}>")?;
-            write!(w, " ")?;
-            let _ = w;
+            write!(self.writer, "<{item_number}>")?;
+            write!(self.writer, " ")?;
 
             // Render principal text inline
             for node in &item.principal {
                 self.visit_inline_node(node)?;
             }
 
-            w = self.writer_mut();
-            writeln!(w)?;
+            writeln!(self.writer)?;
 
             // Render attached blocks with indentation
             for block in &item.blocks {
-                let w = self.writer_mut();
-                write!(w, "  ")?;
-                let _ = w;
+                write!(self.writer, "  ")?;
                 self.visit_block(block)?;
             }
         }
@@ -226,9 +216,7 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
     /// - **qanda**: Terms prefixed with "Q: ", definitions with "A: "
     pub(crate) fn render_description_list(&mut self, list: &DescriptionList) -> Result<(), Error> {
         self.render_styled_title(&list.title)?;
-        let w = self.writer_mut();
-        writeln!(w)?;
-        let _ = w;
+        writeln!(self.writer)?;
 
         let style = list.metadata.style;
 
@@ -266,23 +254,19 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
             .into_inner()
             .map_err(io::IntoInnerError::into_error)?;
 
-        let mut w = self.writer_mut();
-        w.queue(PrintStyledContent(
+        self.writer.queue(PrintStyledContent(
             String::from_utf8_lossy(&buffer).to_string().bold(),
         ))?;
-        writeln!(w)?;
+        writeln!(self.writer)?;
 
         // Render principal text with indentation if present
         if !item.principal_text.is_empty() {
-            write!(w, "  ")?;
-            let _ = w;
+            write!(self.writer, "  ")?;
             for node in &item.principal_text {
                 self.visit_inline_node(node)?;
             }
-            w = self.writer_mut();
-            writeln!(w)?;
+            writeln!(self.writer)?;
         }
-        let _ = w;
 
         // Render description blocks (without indentation as block.render handles formatting)
         for block in &item.description {
@@ -312,28 +296,22 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
             .into_inner()
             .map_err(io::IntoInnerError::into_error)?;
 
-        let mut w = self.writer_mut();
-        w.queue(PrintStyledContent(
+        self.writer.queue(PrintStyledContent(
             String::from_utf8_lossy(&buffer).to_string().bold(),
         ))?;
 
         // Same line: term :: definition
         if !item.principal_text.is_empty() {
-            write!(w, " :: ")?;
-            let _ = w;
+            write!(self.writer, " :: ")?;
             for node in &item.principal_text {
                 self.visit_inline_node(node)?;
             }
-            w = self.writer_mut();
         }
-        writeln!(w)?;
-        let _ = w;
+        writeln!(self.writer)?;
 
         // Render description blocks indented
         for block in &item.description {
-            let w = self.writer_mut();
-            write!(w, "  ")?;
-            let _ = w;
+            write!(self.writer, "  ")?;
             self.visit_block(block)?;
         }
 
@@ -360,30 +338,24 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
             .into_inner()
             .map_err(io::IntoInnerError::into_error)?;
 
-        let mut w = self.writer_mut();
-        w.queue(PrintStyledContent("Q: ".bold()))?;
-        w.queue(PrintStyledContent(
+        self.writer.queue(PrintStyledContent("Q: ".bold()))?;
+        self.writer.queue(PrintStyledContent(
             String::from_utf8_lossy(&buffer).to_string().bold(),
         ))?;
-        writeln!(w)?;
+        writeln!(self.writer)?;
 
         // Render "A: " prefix + principal text
         if !item.principal_text.is_empty() {
-            w.queue(PrintStyledContent("A: ".dim()))?;
-            let _ = w;
+            self.writer.queue(PrintStyledContent("A: ".dim()))?;
             for node in &item.principal_text {
                 self.visit_inline_node(node)?;
             }
-            w = self.writer_mut();
-            writeln!(w)?;
+            writeln!(self.writer)?;
         }
-        let _ = w;
 
         // Render description blocks indented
         for block in &item.description {
-            let w = self.writer_mut();
-            write!(w, "   ")?;
-            let _ = w;
+            write!(self.writer, "   ")?;
             self.visit_block(block)?;
         }
 

--- a/converters/terminal/src/replay.rs
+++ b/converters/terminal/src/replay.rs
@@ -50,7 +50,7 @@
 
 use std::{borrow::Cow, time::Duration};
 
-use crate::cell_grid::{self, CellGrid, GridCapture, TerminalSize, new_terminal};
+use crate::cell_grid::{self, Cell, CellGrid, GridCapture, TerminalSize, new_terminal};
 
 const DEFAULT_FRAME_DURATION: Duration = Duration::from_millis(100);
 const DEFAULT_CELL_WIDTH_PX: u32 = 1;
@@ -335,6 +335,112 @@ where
     Ok(Timeline { frames })
 }
 
+/// Capture replay frames from append-only recorded output without paying
+/// libghostty's expensive viewport scroll.
+///
+/// Scrolling a short viewport shifts every visible row, so feeding thousands of
+/// lines through a small terminal is pathologically slow. This avoids it:
+/// `options.size` must be tall enough to hold the whole recording without
+/// scrolling (one grid row per output line, plus a little headroom), so writes
+/// never scroll. Each frame is then a `viewport_rows`-tall window of the final
+/// screen that follows the cursor, reproducing what a scrolling viewport of
+/// that height would have shown.
+///
+/// This is only faithful for output that never rewrites rows the cursor has
+/// already passed (no upward cursor motion, absolute positioning, scroll
+/// regions, alternate screen, or erase-in-display). Use [`capture`] for
+/// recordings that redraw earlier rows.
+///
+/// Returns the windowed [`Timeline`], matching what [`capture`] would produce
+/// for append-only output.
+///
+/// # Errors
+///
+/// Returns an error when terminal dimensions are invalid, render-state capture
+/// fails, or explicit event timestamps move backwards.
+pub fn capture_windowed<'a, I>(
+    events: I,
+    options: Options,
+    viewport_rows: usize,
+) -> Result<Timeline, Error>
+where
+    I: IntoIterator<Item = Event<'a>>,
+{
+    let size = options.size;
+    let viewport_rows = viewport_rows.max(1);
+
+    let mut terminal = new_terminal(size)?;
+    let mut capture = GridCapture::new()?;
+
+    // Record where the cursor lands after each write instead of snapshotting the
+    // (potentially huge) screen every time. For append-only output the rows
+    // below the cursor are still blank, so a single final capture reproduces
+    // every intermediate frame once it is windowed to the recorded cursor row.
+    let mut current_time = Duration::ZERO;
+    let mut markers = Vec::new();
+    for event in events {
+        current_time = next_timestamp(&event, current_time, options.default_frame_duration)?;
+        let Event::Write { bytes, .. } = event else {
+            // Resizes and timing boundaries do not occur in append-only ANSI
+            // capture; ignore them rather than complicate the fast path.
+            continue;
+        };
+        terminal.vt_write(bytes.as_ref());
+        let cursor_x = terminal.cursor_x().map_err(cell_grid::Error::from)?;
+        let cursor_y = usize::from(terminal.cursor_y().map_err(cell_grid::Error::from)?);
+        // The viewport's bottom row tracks the cursor, exactly as a scrolling
+        // terminal would. After a line break the cursor sits on a fresh blank
+        // row, so the last row that actually holds content is the one above it;
+        // mid-line, the cursor row itself holds content.
+        let content_bottom = cursor_y.saturating_sub(usize::from(cursor_x == 0 && cursor_y > 0));
+        markers.push((current_time, cursor_y, content_bottom));
+    }
+
+    let screen = capture.capture(&terminal, size)?;
+
+    // Seed deduplication with a blank viewport so a leading all-blank frame is
+    // dropped, matching `capture`.
+    let mut last_window = CellGrid::new(
+        vec![Cell::default(); size.cols.saturating_mul(viewport_rows)],
+        TerminalSize::new(size.cols, viewport_rows),
+    );
+    let mut frames = Vec::new();
+    for (at, viewport_bottom, content_bottom) in markers {
+        let window = window_frame(&screen, viewport_bottom, content_bottom, viewport_rows);
+        if window != last_window {
+            frames.push(Frame {
+                at,
+                grid: window.clone(),
+            });
+            last_window = window;
+        }
+    }
+
+    Ok(Timeline { frames })
+}
+
+/// Extract a `viewport_rows`-tall window of `screen` whose bottom row aligns
+/// with `viewport_bottom` (the cursor row, so the window scrolls with output).
+/// Rows above `content_bottom` are real screen rows; rows below it have not yet
+/// been written at this point in the replay, so they are blanked.
+fn window_frame(
+    screen: &CellGrid,
+    viewport_bottom: usize,
+    content_bottom: usize,
+    viewport_rows: usize,
+) -> CellGrid {
+    let first_visible = (viewport_bottom + 1).saturating_sub(viewport_rows);
+    let mut cells = Vec::with_capacity(screen.cols().saturating_mul(viewport_rows));
+    for offset in 0..viewport_rows {
+        let row = first_visible + offset;
+        match screen.row(row) {
+            Some(row_cells) if row <= content_bottom => cells.extend_from_slice(row_cells),
+            _ => cells.extend(std::iter::repeat_with(Cell::default).take(screen.cols())),
+        }
+    }
+    CellGrid::new(cells, TerminalSize::new(screen.cols(), viewport_rows))
+}
+
 fn next_timestamp(
     event: &Event<'_>,
     current_time: Duration,
@@ -403,6 +509,66 @@ mod tests {
 
     fn options() -> Options {
         Options::new(TerminalSize::new(8, 3)).with_default_frame_duration(Duration::from_millis(50))
+    }
+
+    #[test]
+    fn windowed_capture_matches_scrolling_for_append_only() -> TestResult {
+        // Drive both paths with identical per-line write events and assert the
+        // tall-terminal windowing reproduces the scrolling viewport exactly.
+        let events: Vec<Event<'static>> = (0..50)
+            .map(|i| {
+                let line = format!("\x1b[3{}mline {i}\x1b[0m\r\n", 1 + i % 7);
+                Event::write_at(
+                    Cow::Owned(line.into_bytes()),
+                    Duration::from_millis(10 * (i + 1)),
+                )
+            })
+            .collect();
+
+        let frame_duration = Duration::from_millis(10);
+        let scrolling = capture(
+            events.clone(),
+            Options::new(TerminalSize::new(20, 6)).with_default_frame_duration(frame_duration),
+        )?;
+        let windowed = capture_windowed(
+            events,
+            Options::new(TerminalSize::new(20, 60)).with_default_frame_duration(frame_duration),
+            6,
+        )?;
+
+        assert_eq!(scrolling.frames(), windowed.frames());
+        let Some(last) = windowed.frames().last() else {
+            return Err(std::io::Error::other("expected replay frames").into());
+        };
+        // The final newline leaves the cursor on a blank bottom row, so the
+        // last content line sits one row above it.
+        assert_eq!(last.grid.row_text(4), "line 49");
+        assert_eq!(last.grid.row_text(5), "");
+        Ok(())
+    }
+
+    #[test]
+    fn windowed_capture_handles_unterminated_final_line() -> TestResult {
+        let events = vec![
+            Event::write_at(b"first\r\n".as_slice(), Duration::from_millis(10)),
+            Event::write_at(b"second".as_slice(), Duration::from_millis(20)),
+        ];
+
+        let windowed = capture_windowed(
+            events,
+            Options::new(TerminalSize::new(20, 8))
+                .with_default_frame_duration(Duration::from_millis(10)),
+            4,
+        )?;
+        let [first, second] = windowed.frames() else {
+            return Err(std::io::Error::other("expected two replay frames").into());
+        };
+
+        assert_eq!(first.grid.row_text(0), "first");
+        assert_eq!(first.grid.row_text(1), "");
+        assert_eq!(second.grid.row_text(0), "first");
+        assert_eq!(second.grid.row_text(1), "second");
+        Ok(())
     }
 
     #[test]

--- a/converters/terminal/src/replay.rs
+++ b/converters/terminal/src/replay.rs
@@ -17,7 +17,18 @@
 //! - [`Frame`]: one visible screen at one absolute replay timestamp.
 //! - [`Timeline`]: ordered frames ready for a renderer/player.
 //!
-//! Call order:
+//! Two capture strategies are available:
+//!
+//! - [`capture`] (and the [`capture_ansi`] convenience wrapper) snapshots the
+//!   visible grid after every event. It handles arbitrary output, including
+//!   resizes and redraws of earlier rows.
+//! - [`capture_windowed`] is a fast path for append-only output: it writes into
+//!   an over-tall terminal that never scrolls, snapshots once at the end, and
+//!   derives each frame as a [`window_frame`] of that final screen. It avoids
+//!   libghostty's expensive viewport scroll but is only faithful when the
+//!   recording never rewrites rows the cursor has already passed.
+//!
+//! The call order below describes the general [`capture`] path:
 //!
 //! ```text
 //! capture_ansi(chunks, options)
@@ -421,8 +432,8 @@ where
 
 /// Extract a `viewport_rows`-tall window of `screen` whose bottom row aligns
 /// with `viewport_bottom` (the cursor row, so the window scrolls with output).
-/// Rows above `content_bottom` are real screen rows; rows below it have not yet
-/// been written at this point in the replay, so they are blanked.
+/// Rows at or above `content_bottom` are real screen rows; rows below it have
+/// not yet been written at this point in the replay, so they are blanked.
 fn window_frame(
     screen: &CellGrid,
     viewport_bottom: usize,
@@ -485,9 +496,11 @@ fn record_frame<'alloc>(
     let changed = grid != *last_grid;
 
     // TimingBoundary is the explicit exception to normal deduplication: it lets
-    // a replay preserve a pause even when the screen contents do not change.
-    // It only applies after at least one visible frame exists; a leading timing
-    // boundary should not emit the initial blank baseline grid.
+    // a replay preserve a pause even when the screen contents do not change. It
+    // only applies once at least one visible frame exists (a leading timing
+    // boundary must not emit the initial blank baseline grid) and only when the
+    // timestamp advances past that frame (so it never adds a duplicate frame at
+    // an identical time).
     let preserves_timing = timing_boundary && frames.last().is_some_and(|frame| frame.at != at);
 
     if changed || preserves_timing {

--- a/converters/terminal/src/terminal_visitor.rs
+++ b/converters/terminal/src/terminal_visitor.rs
@@ -20,7 +20,7 @@ use crate::Processor;
 
 /// Terminal visitor that generates terminal output from `AsciiDoc` AST
 pub struct TerminalVisitor<'a, 'd, W: Write> {
-    writer: W,
+    pub(crate) writer: W,
     pub(crate) processor: Processor<'a>,
     /// Per-conversion diagnostics handle.
     pub(crate) diagnostics: Diagnostics<'d>,

--- a/converters/terminal/src/toc.rs
+++ b/converters/terminal/src/toc.rs
@@ -28,14 +28,16 @@ impl<W: Write> TerminalVisitor<'_, '_, W> {
         }
 
         for (i, (entry_index, entry)) in current_level_entries.iter().enumerate() {
-            let mut w = self.writer_mut();
-            write!(w, "{:indent$}", "", indent = current_level as usize - 1)?;
-            let _ = w;
+            write!(
+                self.writer,
+                "{:indent$}",
+                "",
+                indent = current_level as usize - 1
+            )?;
             for inline in &entry.title {
                 self.visit_inline_node(inline)?;
             }
-            w = self.writer_mut();
-            writeln!(w)?;
+            writeln!(self.writer)?;
 
             // Find children: entries that come after this one and have level = current_level + 1
             // but before the next entry at current_level or lower


### PR DESCRIPTION
Render recorded ANSI output as an animated HTML replay.


One day, I will add an extensions system to `acdc` and if I do so, I'll move `terminal` to become an extension but for now this will do.