### PR TITLE
feat: add asciicast support for terminal blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /profile.json.gz
 # Claude Code runtime locks (ScheduleWakeup, etc.)
 .claude/*.lock
+# vibe-check per-checkout theme record (personal, not shared)
+# this is a skill provided by incident-io/claude-skills
+.claude/vibe-check-themes.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 | `network` | off | parser | Remote `include::https://...[]` (pulls in `ureq`) |
 | `highlighting` | off | html, terminal | syntect source highlighting |
 | `terminal` | off | html | Renders terminal previews into HTML; the cli exposes it as `html-terminal` |
-| `render-state` | off | terminal | libghostty-vt grid rendering |
+| `emulator` | off | terminal | Runs terminal output through a libghostty-vt terminal emulator and captures the rendered screen grid (static previews + session replays); the cli exposes it as `terminal-emulator` |
 | `images` | off | terminal | Inline terminal image rendering (viuer) |
 
 New code that gates parsing or rendering on a specific substitution belongs behind `pre-spec-subs`, not an ad-hoc cfg.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,11 +98,14 @@ dependencies = [
  "acdc-converters-core",
  "acdc-converters-dev",
  "acdc-parser",
+ "asciicast-rs",
  "bumpalo",
  "comfy-table",
  "crossterm",
  "libghostty-vt",
  "pretty_assertions",
+ "serde",
+ "serde_json",
  "syntect",
  "thiserror",
  "tracing",
@@ -348,6 +351,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "asciicast-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d16c9eed1f826287ee9824510e46061f6ac831e27c15d1917469283e3446e6c"
+dependencies = [
+ "rgb",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,11 @@ dependencies = [
  "acdc-converters-dev",
  "acdc-converters-terminal",
  "acdc-parser",
+ "base64",
  "chrono",
  "pretty_assertions",
  "rstest",
+ "sha2",
  "syntect",
  "tempfile",
  "thiserror",
@@ -491,6 +493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +708,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -795,6 +821,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +897,17 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -1216,6 +1262,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -2563,6 +2618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3122,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,11 +355,12 @@ dependencies = [
 
 [[package]]
 name = "asciicast-rs"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d16c9eed1f826287ee9824510e46061f6ac831e27c15d1917469283e3446e6c"
+checksum = "fc0ba000776cf478263576bca61217ca5557749c55a8a2d2daf973047188be03"
 dependencies = [
  "rgb",
+ "ruzstd",
  "serde",
  "serde_json",
  "thiserror",
@@ -2478,6 +2479,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 
 [[package]]
 name = "ryu"

--- a/acdc-cli/CHANGELOG.md
+++ b/acdc-cli/CHANGELOG.md
@@ -33,13 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   toolchain to build the bundled library, which is statically linked so the
   binary stays self-contained.
 - The `html-terminal` feature forwards terminal-styled HTML rendering to the
-  HTML converter. The `:terminal-preview:` document attribute opts terminal-like
+  HTML converter. The `:acdc-terminal:` document attribute opts terminal-like
   source blocks into selectable preview rendering; Asciidoctor does not provide
   this attribute or an equivalent built-in feature.
 - Explicit `[terminal]` blocks now render in HTML output when the
   `html-terminal` feature is enabled. `[terminal]` is the terminal-session
   path: it renders transcripts through `libghostty-vt` as selectable styled
-  HTML and does not require the `:terminal-preview:` source-block opt-in. It
+  HTML and does not require the `:acdc-terminal:` source-block opt-in. It
   supports per-block `cols=` and `rows=` attributes and follows the document
   `:dark-mode:` setting. `[terminal]` is an acdc-only block style: Asciidoctor
   renders it as a plain listing or literal block with the raw text (ANSI

--- a/acdc-cli/CHANGELOG.md
+++ b/acdc-cli/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The `terminal-render-state` build feature renders `[terminal]` session blocks
+- The `terminal-emulator` build feature renders `[terminal]` session blocks
   through `libghostty-vt` on the `--backend terminal` path. Requires a Zig
   toolchain to build the bundled library, which is statically linked so the
   binary stays self-contained.

--- a/acdc-cli/Cargo.toml
+++ b/acdc-cli/Cargo.toml
@@ -61,9 +61,9 @@ html-terminal = ["html", "acdc-converters-html/terminal"]
 # Render `[terminal]` session blocks through libghostty-vt for the terminal
 # backend. Requires a Zig toolchain to build the bundled libghostty-vt, which is
 # statically linked into the binary.
-terminal-render-state = [
+terminal-emulator = [
     "terminal",
-    "acdc-converters-terminal/render-state",
+    "acdc-converters-terminal/emulator",
 ]
 
 # Development tools

--- a/acdc-cli/README.adoc
+++ b/acdc-cli/README.adoc
@@ -92,10 +92,10 @@ cargo build --all-features
 
 * `highlighting` - Enable syntax highlighting for source blocks in HTML output (uses syntect)
 * `html-terminal` - Enable acdc-only terminal-styled HTML rendering. This
-  includes `[terminal]` blocks and `:terminal-preview:` source-block previews.
+  includes `[terminal]` blocks and `:acdc-terminal:` source-block previews.
   It enables the html converter's `terminal` feature; see the converters/html
   README for what it renders. Asciidoctor does not provide a
-  `:terminal-preview:` attribute, `[terminal]` block style, or equivalent
+  `:acdc-terminal:` attribute, `[terminal]` block style, or equivalent
   built-in terminal preview support.
 
 === Development Tools
@@ -186,18 +186,18 @@ Render acdc-only terminal previews in HTML:
 [source,console]
 ....
 cargo build --features html-terminal
-acdc convert --backend html -a terminal-preview document.adoc
+acdc convert --backend html -a acdc-terminal document.adoc
 ....
 
 The `html-terminal` Cargo feature enables two terminal-looking HTML render
 paths.
 
-* `:terminal-preview:` is a document attribute that opts terminal-like
+* `:acdc-terminal:` is a document attribute that opts terminal-like
   source blocks such as `[source,console]`, `[source,terminal]`, and
   `[source,bash]` into selectable terminal preview rendering.
 * `[terminal]` is an explicit block style for terminal session content. It
   always renders as terminal output when `html-terminal` is enabled and does
-  not require `:terminal-preview:`.
+  not require `:acdc-terminal:`.
 
 Use `[terminal]` for terminal session transcripts or captured terminal output:
 
@@ -210,7 +210,7 @@ acdc 0.2.0
 ----
 ....
 
-Both `:terminal-preview:` and `[terminal]` are acdc extensions and are
+Both `:acdc-terminal:` and `[terminal]` are acdc extensions and are
 intentionally not Asciidoctor-compatible syntax. Asciidoctor renders
 `[terminal]` as a plain listing or literal block with the raw text (ANSI
 escapes included) left as-is.
@@ -221,13 +221,13 @@ Terminal preview attributes:
 |===
 | Attribute | Effect
 
-| `:terminal-preview:`
+| `:acdc-terminal:`
 | Enables terminal preview rendering for terminal-like source blocks only.
 
-| `:terminal-cols: N`
+| `:acdc-terminal-cols: N`
 | Sets the terminal grid width used to render source-block previews and `[terminal]` blocks. Defaults to `80`.
 
-| `:terminal-rows: N`
+| `:acdc-terminal-rows: N`
 | Sets a fixed terminal grid height for source-block previews and `[terminal]` blocks. When unset, acdc derives the height from the rendered terminal text plus a small padding row.
 
 | `:dark-mode:`

--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -59,12 +59,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `replay-duration-ms` sets total playback time. Readers without JavaScript, or
   who prefer reduced motion, see the final frame. Recorded commands are never
   run. acdc-only; asciidoctor renders the raw text.
+- Terminal rendering (previews, `[terminal]`, and `[terminal%replay]`) runs the
+  bundled terminal emulator only below `SafeMode::Server`. At `server`/`secure`
+  the block degrades to a plain listing and a warning is emitted, since the
+  emulator processes document-controlled input.
 - Set `:csp:` to emit a self-contained `<meta http-equiv="Content-Security-Policy">`
   for standalone output: scripts are locked to acdc's inline scripts by hash (no
   `'unsafe-inline'`) plus the MathJax CDN when `:stem:` is set, while images,
   media, and embeds stay permissive so content keeps loading. For assembling your
-  own head/policy (e.g. embedded mode), the inline scripts, their hashes, the
-  MathJax loader URL, and a `content_security_policy` builder are public API.
+  own head/policy (e.g. embedded mode), the inline scripts, their hashes, and the
+  MathJax loader URL are public API.
 - User-facing converter warnings are now collected in `ConversionResult` for
   recoverable HTML conversion issues such as deprecated roles, docinfo option
   fallbacks, and stylesheet read/write failures.

--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -41,42 +41,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pinning asciidoctor-parity behaviour (raw `<`, `>`, `&` preserved when
   specialchars are disabled; literal `--`, `(C)`, `->` preserved when
   replacements are disabled). The underlying gating was already in place.
-- Feature-gated `terminal` support lets both standard and semantic HTML
-  conversions include selectable terminal-styled previews via `libghostty-vt`.
-  The `:terminal-preview:` document attribute opts terminal-like source blocks
-  into preview rendering. Previews follow
-  `:dark-mode:`, preserve terminal-converter ANSI colors for source/listing
-  blocks, and auto-size to the rendered terminal text unless rows are explicitly
-  configured with `:terminal-rows:`. Preview width can be configured with
-  `:terminal-cols:`. The terminal preview base styles live in the built-in HTML
-  stylesheets, so they follow the same embedded, linked, and copied stylesheet
-  modes as the rest of the converter output. This is an acdc-only HTML
-  extension; Asciidoctor does not provide a `:terminal-preview:` attribute or
-  equivalent built-in terminal preview feature.
-- Feature-gated `[terminal]` listing and literal blocks provide the explicit
-  terminal-session path. They render as selectable terminal-styled HTML through
-  the same `libghostty-vt` CellGrid renderer and do not require the
-  `:terminal-preview:` source-block opt-in. Block attributes `cols=` and
-  `rows=` configure the terminal dimensions for each session, and terminal
-  colors follow the document `:dark-mode:` setting. This is an acdc-only block
-  style: Asciidoctor treats `[terminal]` as a plain listing or literal block
-  and emits the raw text (including any ANSI escape sequences) unrendered.
-- Feature-gated `[terminal%replay]` blocks render pre-recorded terminal output
-  as an animated HTML replay in one of two formats:
-  - default: raw ANSI as a pure-CSS filmstrip; needs `cols`/`rows`.
-  - `format=asciicast`: an asciicast v2/v3 recording (size and timing from its
-    header) played by a small self-contained inline script. It shows every
-    distinct screen, including in-place rewrites like progress bars and
-    full-screen TUIs, in the recording's own colours, with a window title bar
-    showing the recorded command.
-
-  Idle gaps are compressed (the header's `idle_time_limit`, the
-  `replay-idle-limit-ms` attribute, or a default) and `replay-duration-ms`
-  overrides total playback speed. The final frame is rendered server-side, so
-  readers without scripting (or with `prefers-reduced-motion`) still see the
-  finished screen; the inline script's hash is exposed as
-  `REPLAY_PLAYER_SCRIPT_CSP_HASH` for hosts on a strict `script-src`. Commands
-  are never executed, and Asciidoctor renders the block as raw text.
+- Terminal previews (feature-gated `terminal`). Set `:terminal-preview:` to
+  render terminal-like source blocks (`console`, `bash`, and similar) as
+  selectable, terminal-styled HTML with their ANSI colors intact. Previews
+  follow `:dark-mode:`, auto-size to their content, and take `:terminal-cols:` /
+  `:terminal-rows:`. acdc-only; asciidoctor has no equivalent.
+- `[terminal]` blocks (feature-gated `terminal`) render a listing or literal
+  block as a terminal-styled preview without the `:terminal-preview:` opt-in,
+  with `cols=`/`rows=` for size and colors following `:dark-mode:`. acdc-only;
+  asciidoctor renders the raw text, escape sequences included.
+- `[terminal%replay]` blocks (feature-gated `terminal`) animate pre-recorded
+  terminal output as HTML. Replay raw ANSI (the default; needs `cols`/`rows`) or
+  an `asciicast` v2/v3 recording with `format=asciicast`, which plays back in the
+  recording's own colors and reproduces in-place redraws such as progress bars
+  and full-screen TUIs. `rows` is a scrolling window that rests on the last lines
+  of output; idle gaps are compressed (tune with `replay-idle-limit-ms`) and
+  `replay-duration-ms` sets total playback time. Readers without JavaScript, or
+  who prefer reduced motion, see the final frame. Recorded commands are never
+  run. acdc-only; asciidoctor renders the raw text.
 - User-facing converter warnings are now collected in `ConversionResult` for
   recoverable HTML conversion issues such as deprecated roles, docinfo option
   fallbacks, and stylesheet read/write failures.

--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `replay-duration-ms` sets total playback time. Readers without JavaScript, or
   who prefer reduced motion, see the final frame. Recorded commands are never
   run. acdc-only; asciidoctor renders the raw text.
+- Set `:csp:` to emit a self-contained `<meta http-equiv="Content-Security-Policy">`
+  for standalone output: scripts are locked to acdc's inline scripts by hash (no
+  `'unsafe-inline'`) plus the MathJax CDN when `:stem:` is set, while images,
+  media, and embeds stay permissive so content keeps loading. For assembling your
+  own head/policy (e.g. embedded mode), the inline scripts, their hashes, the
+  MathJax loader URL, and a `content_security_policy` builder are public API.
 - User-facing converter warnings are now collected in `ConversionResult` for
   recoverable HTML conversion issues such as deprecated roles, docinfo option
   fallbacks, and stylesheet read/write failures.

--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -41,13 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pinning asciidoctor-parity behaviour (raw `<`, `>`, `&` preserved when
   specialchars are disabled; literal `--`, `(C)`, `->` preserved when
   replacements are disabled). The underlying gating was already in place.
-- Terminal previews (feature-gated `terminal`). Set `:terminal-preview:` to
+- Terminal previews (feature-gated `terminal`). Set `:acdc-terminal:` to
   render terminal-like source blocks (`console`, `bash`, and similar) as
   selectable, terminal-styled HTML with their ANSI colors intact. Previews
-  follow `:dark-mode:`, auto-size to their content, and take `:terminal-cols:` /
-  `:terminal-rows:`. acdc-only; asciidoctor has no equivalent.
+  follow `:dark-mode:`, auto-size to their content, and take `:acdc-terminal-cols:` /
+  `:acdc-terminal-rows:`. acdc-only; asciidoctor has no equivalent.
 - `[terminal]` blocks (feature-gated `terminal`) render a listing or literal
-  block as a terminal-styled preview without the `:terminal-preview:` opt-in,
+  block as a terminal-styled preview without the `:acdc-terminal:` opt-in,
   with `cols=`/`rows=` for size and colors following `:dark-mode:`. acdc-only;
   asciidoctor renders the raw text, escape sequences included.
 - `[terminal%replay]` blocks (feature-gated `terminal`) animate pre-recorded

--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -61,13 +61,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   colors follow the document `:dark-mode:` setting. This is an acdc-only block
   style: Asciidoctor treats `[terminal]` as a plain listing or literal block
   and emits the raw text (including any ANSI escape sequences) unrendered.
-- Feature-gated `[terminal%replay]` blocks render pre-recorded ANSI output as
-  an animated HTML replay. Replay blocks require explicit `cols`/`rows`
-  dimensions, support a `replay-duration-ms` playback override, never execute
-  commands, and fall back to a static terminal preview (with a warning) when
-  dimensions are missing or invalid. Playback scales to long recordings with
-  compact output and ends on the final frame. Like `[terminal]`, this is an
-  acdc-only block style that Asciidoctor renders as raw text.
+- Feature-gated `[terminal%replay]` blocks render pre-recorded terminal output
+  as an animated HTML replay in one of two formats:
+  - default: raw ANSI as a pure-CSS filmstrip; needs `cols`/`rows`.
+  - `format=asciicast`: an asciicast v2/v3 recording (size and timing from its
+    header) played by a small self-contained inline script. It shows every
+    distinct screen, including in-place rewrites like progress bars and
+    full-screen TUIs, in the recording's own colours, with a window title bar
+    showing the recorded command.
+
+  Idle gaps are compressed (the header's `idle_time_limit`, the
+  `replay-idle-limit-ms` attribute, or a default) and `replay-duration-ms`
+  overrides total playback speed. The final frame is rendered server-side, so
+  readers without scripting (or with `prefers-reduced-motion`) still see the
+  finished screen; the inline script's hash is exposed as
+  `REPLAY_PLAYER_SCRIPT_CSP_HASH` for hosts on a strict `script-src`. Commands
+  are never executed, and Asciidoctor renders the block as raw text.
 - User-facing converter warnings are now collected in `ConversionResult` for
   recoverable HTML conversion issues such as deprecated roles, docinfo option
   fallbacks, and stylesheet read/write failures.

--- a/converters/html/Cargo.toml
+++ b/converters/html/Cargo.toml
@@ -24,10 +24,17 @@ syntect = { version = "5.3", optional = true, default-features = false, features
 thiserror.workspace = true
 tracing.workspace = true
 
+[build-dependencies]
+# Compute CSP script-src hashes for embedded inline scripts at build time.
+base64 = "0.22"
+sha2 = "0.11"
+
 [dev-dependencies]
 acdc-converters-dev.workspace = true
+base64 = "0.22"
 pretty_assertions.workspace = true
 rstest.workspace = true
+sha2 = "0.11"
 tempfile = "3.25.0"
 tracing-test.workspace = true
 

--- a/converters/html/Cargo.toml
+++ b/converters/html/Cargo.toml
@@ -13,7 +13,7 @@ pre-spec-subs = ["acdc-parser/pre-spec-subs", "acdc-converters-core/pre-spec-sub
 # Enable syntax highlighting for source blocks using syntect
 highlighting = ["dep:syntect"]
 # Render terminal-converter output into selectable HTML via libghostty-vt.
-terminal = ["dep:acdc-converters-terminal", "acdc-converters-terminal/render-state", "acdc-converters-terminal/highlighting"]
+terminal = ["dep:acdc-converters-terminal", "acdc-converters-terminal/emulator", "acdc-converters-terminal/highlighting"]
 
 [dependencies]
 acdc-converters-core.workspace = true

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -418,20 +418,42 @@ For full details, see the https://docs.asciidoctor.org/asciidoc/latest/docinfo/[
 
 The output is class-based, so you can restyle it without forking the converter. Use whichever seam fits:
 
-* **Override specific rules.** Load your own stylesheet after acdc's and target its classes. Body content uses the standard Asciidoctor classes (`.listingblock`, `.admonitionblock`, `.tableblock`, and so on). The terminal replay emits no chrome of its own, but exposes a stable class/attribute contract you can build on:
+* **Override specific rules.** Load your own stylesheet after acdc's and target its classes. Body content uses the standard Asciidoctor classes (`.listingblock`, `.admonitionblock`, `.tableblock`, and so on). The terminal preview and replay expose a stable class/attribute contract:
 +
 [cols="1,3"]
 |===
-| Classes | `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__viewport`, `.terminal-replay__screen`, `.terminal-replay__row`
-| Attributes | `data-title` (the recorded title, asciicast only, present only when the recording carried one) for building your own title bar, e.g. `.terminal-replay::before{content:attr(data-title)}`
-| Custom properties | `--acdc-term-bg`, `--acdc-term-fg` (the recorded terminal theme), plus `--acdc-term-font-family`, `--acdc-term-font-size`, `--acdc-term-line-height`, `--acdc-term-radius`, `--acdc-term-padding`
+| Classes | Both share the base `.terminal-view` and a theme class (`.terminal-view--light` / `.terminal-view--dark`), and the block wrapper carries `.terminal-block`. Static preview adds `.terminal-view__screen` (the `<pre>`). Replay adds the `.terminal-view--replay` marker and `.terminal-view__viewport` > `.terminal-view__stream` > `.terminal-view__row`.
+| Attributes | `data-title` (the recorded title, asciicast only, present only when the recording carried one) for building your own title bar, e.g. `.terminal-view--replay::before{content:attr(data-title)}`
 |===
 
 * **Replace the whole stylesheet.** Use `:stylesheet: my.css` (see <<Custom stylesheet (`:stylesheet:`)>>), embedded or linked with `:linkcss:`. `:copycss:` copies the built-in CSS out as a starting point.
 * **Augment the `<head>`.** Inject extra `<style>`/`<link>` with <<Docinfo files>> (`:docinfo: shared-head`).
 * **Embedded mode.** There is no `<head>`, so the embedding page owns the stylesheet. Override acdc's classes from your page's own CSS.
 
-NOTE: A few elements still carry inline `style` attributes that beat an external stylesheet unless you use `!important`: terminal cell colours (resolved from the recording's own palette), table column and table widths, and image `align`/`float`. Override those with `!important`, or replace the stylesheet with `:stylesheet:`.
+==== Inline styles that need `!important`
+
+Most output is class-based and fully overridable by the seams above. A few elements carry an inline `style=` attribute, which beats *any* stylesheet rule (embedded, linked, replaced, or injected via docinfo) unless your rule uses `!important`:
+
+[cols="2,3"]
+|===
+| Inline-styled | How to override
+
+| Syntax-highlighted code colours | Inline is the default; set `:syntect-css: class` to emit overridable `syntax-*` classes (plus a `<style>` block) instead.
+| A recording's own colours | The cell palette, plus a replay container's background/foreground when the cast recorded a theme; use `!important`.
+| Table column and table widths | Per-table values (matches Asciidoctor); use `!important`.
+| Page break; image `align`/`float` (semantic backend) | Match Asciidoctor's output; use `!important`.
+|===
+
+The static preview container's colours are *not* inline: they come from `.terminal-view--light` / `.terminal-view--dark`, so override those classes directly. A replay with no recorded theme (raw ANSI, or a theme-less cast) uses those same classes; only a cast that carried its own theme paints the container colours inline.
+
+For example, to recolour terminal cells:
+
+[source,css]
+....
+.terminal-view__screen span { color: #eaeaea !important; }
+....
+
+NOTE: With `:!stylesheet:` (all CSS suppressed) the static preview shows no colours, consistent with opting out of styling entirely.
 
 === Content Security Policy
 

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -435,9 +435,24 @@ NOTE: A few elements still carry inline `style` attributes that beat an external
 
 === Content Security Policy
 
-acdc emits self-contained HTML and does not set a CSP. The policy is up to whatever serves the file: your web server, CDN, or the page you embed into. https://antora.org[Antora] works the same way. The output runs under a normal policy you set yourself.
+By default acdc sets no CSP; the policy is up to whatever serves the file (your web server, CDN, or the page you embed into), exactly like https://antora.org[Antora].
 
-A baseline that covers everything acdc emits:
+==== Opt in with `:csp:`
+
+Set `:csp:` to have acdc emit a self-contained `<meta http-equiv="Content-Security-Policy">` that hardens standalone output with no server configuration:
+
+[source,console]
+....
+acdc convert -a csp document.adoc
+....
+
+The emitted policy locks scripts to acdc's own inline scripts by hash (no `'unsafe-inline'` for `script-src`), plus the MathJax CDN when `:stem:` is set; keeps `style-src 'unsafe-inline'` (acdc emits inline styles, including recording-coloured terminal cells, that cannot be hashed); and stays permissive on images, media, and video embeds so document content keeps loading.
+
+Keep in mind a CSP only *restricts* — it does not enable. A page with no CSP already runs anywhere, and a `<meta>` CSP cannot loosen a policy your host sends as a response header (the browser enforces the intersection). So `:csp:` is for shipping a hardened, self-contained page, not for "making it work" somewhere. Two consequences: `frame-ancestors` is omitted (it is ignored in a `<meta>` CSP — set it as a header), and an inline `<script>` you inject via <<Docinfo files>> will not run under `:csp:` unless you add its own hash. Embedded output has no `<head>`, so `:csp:` is standalone-only.
+
+==== Setting the policy yourself
+
+To set the CSP via a server header instead (or in embedded mode), a baseline that covers everything acdc emits:
 
 [source]
 ....
@@ -450,7 +465,7 @@ connect-src 'self';
 frame-ancestors 'none'
 ....
 
-`'unsafe-eval'` is never needed (the terminal-replay player is plain JS). Add the entries below only when you use the matching feature:
+`'unsafe-eval'` is never needed. Add the entries below only when you use the matching feature:
 
 [cols="1,2"]
 |===
@@ -464,9 +479,7 @@ frame-ancestors 'none'
 
 For a fully self-contained policy with no external origins, disable webfonts (`:!webfonts:`) and skip `:stem:` and `icons=font`. The baseline above then needs nothing extra.
 
-To keep `script-src` off `'unsafe-inline'`: the replay player is the only inline `<script>`, its code is constant, and its hash is exposed as `acdc_converters_html::REPLAY_PLAYER_SCRIPT_CSP_HASH`. Allowlist it as `script-src 'self' '<that hash>'`. Inline styles still need `style-src 'unsafe-inline'`. If the script is blocked, the replay still shows its final frame and only the animation is lost.
-
-NOTE: Embedded mode has no `<head>`, so the file cannot carry its own `<meta http-equiv="Content-Security-Policy">`. The embedding page or server sets the policy.
+To keep `script-src` off `'unsafe-inline'`, allowlist acdc's two constant inline scripts by hash instead: the terminal-replay player (`acdc_converters_html::REPLAY_PLAYER_SCRIPT_CSP_HASH`) and, with `:stem:`, the MathJax config (`MATHJAX_CONFIG_CSP_HASH`). For assembling your own head (embedded mode), the converter also exposes the script strings and the MathJax loader URL (`REPLAY_PLAYER_SCRIPT`, `MATHJAX_CONFIG_SCRIPT`, `MATHJAX_LOADER_URL`), and a `content_security_policy(&CspFeatures { .. })` builder that produces the same policy `:csp:` emits for the features a document uses. If the player script is blocked, the replay still shows its final frame and only the animation is lost.
 
 === Table Enhancements
 

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -200,20 +200,20 @@ Two separate switches are involved:
 * The `terminal` Cargo feature is a build-time feature flag. It compiles the
   HTML terminal renderer. From the CLI this is the `html-terminal` feature,
   which just enables this crate's `terminal` feature.
-* The `:terminal-preview:` document attribute is only a source-block opt-in.
+* The `:acdc-terminal:` document attribute is only a source-block opt-in.
   It makes terminal-like source blocks render through that terminal renderer.
 
 When the Cargo feature is enabled, acdc supports two terminal-looking HTML
 render paths:
 
 * Source blocks such as `[source,console]` render as terminal previews only
-  when the document sets `:terminal-preview:`.
+  when the document sets `:acdc-terminal:`.
 * `[terminal]` is an explicit block style for terminal session content. It
   renders as terminal output whenever the `terminal` Cargo feature is enabled; the
-  `:terminal-preview:` document attribute is not required.
+  `:acdc-terminal:` document attribute is not required.
 
 This is an acdc-only extension; Asciidoctor does not provide a
-`:terminal-preview:` attribute, the `[terminal]` or `[terminal%replay]` block
+`:acdc-terminal:` attribute, the `[terminal]` or `[terminal%replay]` block
 styles, or any equivalent built-in terminal preview or replay feature.
 
 NOTE: Terminal rendering is built directly into the HTML converter, the
@@ -222,14 +222,14 @@ NOTE: Terminal rendering is built directly into the HTML converter, the
 acdc grows a first-class extension mechanism, this functionality may migrate to
 an extension instead of being compiled into the converter.
 
-Use `:terminal-preview:` when existing source blocks should look like terminal
+Use `:acdc-terminal:` when existing source blocks should look like terminal
 examples:
 
 [source,asciidoc]
 ....
 = Demo
-:terminal-preview:
-:terminal-cols: 88
+:acdc-terminal:
+:acdc-terminal-cols: 88
 
 [source,console]
 ----
@@ -275,7 +275,7 @@ should be animated in HTML:
 Terminal replay is replay-only. acdc treats the block as recorded terminal
 data and does not execute commands, shells, scripts, VHS tapes, or other
 recording formats. Replay blocks require explicit terminal dimensions via
-`cols`/`rows` block attributes or `:terminal-cols:`/`:terminal-rows:`
+`cols`/`rows` block attributes or `:acdc-terminal-cols:`/`:acdc-terminal-rows:`
 document attributes; invalid or missing dimensions fall back to a static
 terminal preview with a structured warning.
 
@@ -305,13 +305,13 @@ under asciidoctor.
 |===
 | Attribute | Effect
 
-| `:terminal-preview:`
+| `:acdc-terminal:`
 | Enables terminal preview rendering for terminal-like source blocks only.
 
-| `:terminal-cols: N`
+| `:acdc-terminal-cols: N`
 | Sets the terminal grid width used to render source-block previews and `[terminal]` blocks. Defaults to `80`.
 
-| `:terminal-rows: N`
+| `:acdc-terminal-rows: N`
 | Sets a fixed terminal grid height for source-block previews and `[terminal]` blocks. When unset, acdc derives the height from the rendered terminal text plus a small padding row.
 
 | `:dark-mode:`

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -277,11 +277,24 @@ data and does not execute commands, shells, scripts, VHS tapes, or other
 recording formats. Replay blocks require explicit terminal dimensions via
 `cols`/`rows` block attributes or `:terminal-cols:`/`:terminal-rows:`
 document attributes; invalid or missing dimensions fall back to a static
-terminal preview with a structured warning. The default raw-ANSI replay samples
-dense recordings so the generated HTML stays small even for long output.
-`format=asciicast` keeps every recorded frame instead and stays compact by
-emitting each repeated line once and referencing it per frame. Both end playback
-on the final frame.
+terminal preview with a structured warning.
+
+Both formats render as an animated HTML replay driven by a small,
+self-contained inline player. The final frame is rendered into the page
+server-side, so readers without JavaScript (or who prefer reduced motion) still
+see the finished screen; only the animation is lost. The raw-ANSI replay samples
+dense recordings so the generated HTML stays small even for long output;
+`format=asciicast` keeps every recorded frame and stays compact by emitting each
+repeated line once and referencing it per frame. acdc draws no window chrome;
+the recorded title (asciicast only) is exposed as a `data-title` attribute so
+you can add your own.
+
+For `format=asciicast`, the recording is replayed at its own recorded size so
+its cursor movements render faithfully, then `rows` is the height of a window
+that follows the output like a scrolling terminal: when the recording is taller
+than `rows`, the replay shows the most recent `rows` lines and rests on the
+last lines of output (it does not freeze on a region the recording cleared at
+the end, such as a progress bar's live area).
 
 `[terminal]` and `[terminal%replay]` are acdc-only block styles. Asciidoctor
 renders them as a plain listing or literal block with the raw text (ANSI escapes
@@ -405,11 +418,12 @@ For full details, see the https://docs.asciidoctor.org/asciidoc/latest/docinfo/[
 
 The output is class-based, so you can restyle it without forking the converter. Use whichever seam fits:
 
-* **Override specific rules.** Load your own stylesheet after acdc's and target its classes. Body content uses the standard Asciidoctor classes (`.listingblock`, `.admonitionblock`, `.tableblock`, and so on). The terminal replay's window chrome uses this contract:
+* **Override specific rules.** Load your own stylesheet after acdc's and target its classes. Body content uses the standard Asciidoctor classes (`.listingblock`, `.admonitionblock`, `.tableblock`, and so on). The terminal replay emits no chrome of its own, but exposes a stable class/attribute contract you can build on:
 +
 [cols="1,3"]
 |===
-| Classes | `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__titlebar`, `.terminal-replay__dots`, `.terminal-replay__title`, `.terminal-replay__viewport`, `.terminal-replay__screen`, `.terminal-replay__row`
+| Classes | `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__viewport`, `.terminal-replay__screen`, `.terminal-replay__row`
+| Attributes | `data-title` (the recorded title, asciicast only, present only when the recording carried one) for building your own title bar, e.g. `.terminal-replay::before{content:attr(data-title)}`
 | Custom properties | `--acdc-term-bg`, `--acdc-term-fg` (the recorded terminal theme), plus `--acdc-term-font-family`, `--acdc-term-font-size`, `--acdc-term-line-height`, `--acdc-term-radius`, `--acdc-term-padding`
 |===
 

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -1,4 +1,8 @@
 = `acdc-converters-html`
+:icons: font
+:toc: right
+
+toc::[]
 
 HTML converter for `AsciiDoc` documents. This is the default backend for `acdc`.
 
@@ -300,6 +304,17 @@ the end, such as a progress bar's live area).
 renders them as a plain listing or literal block with the raw text (ANSI escapes
 included) left as-is, so documents that rely on them will not render the same
 under asciidoctor.
+
+[NOTE]
+====
+Terminal rendering runs the bundled terminal emulator only below the `server`
+safe mode. At `--safe-mode server` or `secure`, source-block previews,
+`[terminal]`, and `[terminal%replay]` degrade to a plain listing block and acdc
+emits a warning, because the emulator feeds document-controlled input through a
+native library (`libghostty-vt`). The default safe mode renders terminal blocks
+normally; raise the safe mode when converting untrusted documents, e.g.
+server-side, to keep that input away from the emulator.
+====
 
 [cols="1,2", options="header"]
 |===

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -53,7 +53,7 @@ Supports all major AsciiDoc constructs:
 - **Tables**: Full table support with headers, footers, cell formatting, cell spanning, and nested tables
 - **Cross-references**: Internal links and anchors
 - **Attributes**: Document-level attribute substitution
-- **Index terms**: Visible `((term))` and concealed `(((term,secondary,tertiary)))` with catalog generation
+- **Index terms**: Visible `((term))` and concealed `\(((term,secondary,tertiary)))` with catalog generation
 
 === Section Numbering
 

--- a/converters/html/README.adoc
+++ b/converters/html/README.adoc
@@ -1,8 +1,8 @@
-# `acdc-converters-html`
+= `acdc-converters-html`
 
 HTML converter for `AsciiDoc` documents. This is the default backend for `acdc`.
 
-## Usage
+== Usage
 
 [source,console]
 ....
@@ -25,13 +25,13 @@ Or convert from stdin to stdout:
 cat document.adoc | acdc convert --stdin
 ....
 
-## Features
+== Features
 
-### Standalone HTML Output
+=== Standalone HTML Output
 
 Generates complete, standalone HTML documents with embedded CSS. No external dependencies needed - the output file contains everything required for display.
 
-### Asciidoctor-Compatible Styling
+=== Asciidoctor-Compatible Styling
 
 Uses the same CSS as Asciidoctor for familiar, professional-looking output. The embedded stylesheet provides:
 
@@ -40,7 +40,7 @@ Uses the same CSS as Asciidoctor for familiar, professional-looking output. The 
 - Syntax highlighting support
 - Print-optimized styles
 
-### Full AsciiDoc Support
+=== Full AsciiDoc Support
 
 Supports all major AsciiDoc constructs:
 
@@ -55,7 +55,7 @@ Supports all major AsciiDoc constructs:
 - **Attributes**: Document-level attribute substitution
 - **Index terms**: Visible `((term))` and concealed `(((term,secondary,tertiary)))` with catalog generation
 
-### Section Numbering
+=== Section Numbering
 
 Documents with `:sectnums:` render numbered section headings (e.g., "1. Introduction", "1.1. Overview"). Control numbering depth with `:sectnumlevels:` (default 3, max 5).
 
@@ -66,7 +66,7 @@ acdc convert -a sectnums -a sectnumlevels=2 document.adoc
 
 Table of contents entries are also numbered when `:sectnums:` is set.
 
-### Syntax Highlighting
+=== Syntax Highlighting
 
 Source blocks with a language specified render with syntax highlighting (requires the `highlighting` feature flag). Uses syntect with inline CSS styles.
 
@@ -78,13 +78,13 @@ acdc convert document.adoc
 
 Falls back to plain text when the language isn't recognized.
 
-### Stylesheets
+=== Stylesheets
 
-The HTML converter handles CSS output through document attributes, matching https://docs.asciidoctor.org/asciidoctor/latest/html-backend/stylesheet-modes/[Asciidoctor's stylesheet modes]. By default, CSS is embedded directly in the HTML `<style>` tag — no external files needed.
+The HTML converter handles CSS output through document attributes, matching https://docs.asciidoctor.org/asciidoctor/latest/html-backend/stylesheet-modes/[Asciidoctor's stylesheet modes]. By default, CSS is embedded directly in the HTML `<style>` tag, no external files needed.
 
 NOTE: Stylesheet handling only applies to standalone HTML output. In embedded mode (`acdc convert --embedded`), the `<head>` element is not generated, so stylesheet attributes have no effect on the output. `copycss` is also skipped.
 
-#### Default (embedded CSS)
+==== Default (embedded CSS)
 
 Out of the box, acdc embeds the full stylesheet and links Google Fonts:
 
@@ -93,9 +93,9 @@ Out of the box, acdc embeds the full stylesheet and links Google Fonts:
 acdc convert document.adoc
 ....
 
-The output is self-contained — one HTML file with everything included.
+The output is self-contained, one HTML file with everything included.
 
-#### External stylesheet (`:linkcss:`)
+==== External stylesheet (`:linkcss:`)
 
 Set `:linkcss:` to reference CSS via a `<link>` tag instead of embedding it. The built-in stylesheet is automatically written to disk next to the HTML output (see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/stylesheet-modes/#link-mode[link mode]):
 
@@ -114,7 +114,7 @@ Or in the document header:
 
 This produces a `<link rel="stylesheet" href="./asciidoctor-light-mode.css">` in the HTML and copies the CSS file alongside the output.
 
-#### Custom stylesheet (`:stylesheet:`)
+==== Custom stylesheet (`:stylesheet:`)
 
 Point to your own CSS file with `:stylesheet:`. When combined with `:linkcss:`, it links to the file. Without `:linkcss:`, the file is read from disk and embedded (see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/stylesheet-modes/#custom[custom stylesheet]):
 
@@ -129,7 +129,7 @@ acdc convert -a linkcss -a stylesheet=custom.css document.adoc
 
 The converter looks for the file relative to `:stylesdir:` (default: `.`) and the source document directory. If the file can't be read, it falls back to the built-in stylesheet.
 
-#### No stylesheet (`:!stylesheet:`)
+==== No stylesheet (`:!stylesheet:`)
 
 Suppress all CSS and webfont output entirely (see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/stylesheet-modes/#disable[disable mode]):
 
@@ -146,9 +146,9 @@ Or in the document:
 :!stylesheet:
 ....
 
-No `<style>` block, no `<link>` tags for CSS or fonts — just raw HTML.
+No `<style>` block, no `<link>` tags for CSS or fonts, just raw HTML.
 
-#### Styles directory (`:stylesdir:`)
+==== Styles directory (`:stylesdir:`)
 
 Controls where stylesheet references point and where copies are written (see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/manage-images/#stylesdir[stylesdir]):
 
@@ -159,9 +159,9 @@ acdc convert -a linkcss -a stylesdir=css document.adoc
 
 Produces `<link rel="stylesheet" href="css/asciidoctor-light-mode.css">` and writes the CSS to `css/`.
 
-#### Copy CSS (`:copycss:`)
+==== Copy CSS (`:copycss:`)
 
-When `:linkcss:` is set, `:copycss:` controls whether the stylesheet is written to the output directory. It's enabled by default. A non-empty value overrides the source path — useful when the CSS lives somewhere other than `:stylesdir:` (see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/manage-images/#copycss[copycss]):
+When `:linkcss:` is set, `:copycss:` controls whether the stylesheet is written to the output directory. It's enabled by default. A non-empty value overrides the source path, useful when the CSS lives somewhere other than `:stylesdir:` (see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/manage-images/#copycss[copycss]):
 
 [source,console]
 ....
@@ -169,7 +169,7 @@ When `:linkcss:` is set, `:copycss:` controls whether the stylesheet is written 
 acdc convert -a linkcss -a copycss=/path/to/source.css document.adoc
 ....
 
-#### Webfonts (`:webfonts:`)
+==== Webfonts (`:webfonts:`)
 
 By default, the converter links Google Fonts (Open Sans, Noto Serif, Droid Sans Mono). You can customize or disable this (see https://docs.asciidoctor.org/asciidoctor/latest/html-backend/default-stylesheet/#webfonts[webfonts]):
 
@@ -184,7 +184,7 @@ acdc convert -a "webfonts=Roboto:400,700|Fira+Code:400" document.adoc
 
 Webfonts are suppressed automatically when `:!stylesheet:` is set.
 
-#### Dark mode
+==== Dark mode
 
 Set `:dark-mode:` to use the dark variant of the built-in stylesheet. This adds a `<meta name="color-scheme" content="dark">` tag and uses `asciidoctor-dark-mode.css` (or `html5s-dark-mode.css` for the semantic backend):
 
@@ -193,7 +193,7 @@ Set `:dark-mode:` to use the dark variant of the built-in stylesheet. This adds 
 acdc convert -a dark-mode document.adoc
 ....
 
-#### Terminal previews
+==== Terminal previews
 
 Two separate switches are involved:
 
@@ -216,9 +216,9 @@ This is an acdc-only extension; Asciidoctor does not provide a
 `:terminal-preview:` attribute, the `[terminal]` or `[terminal%replay]` block
 styles, or any equivalent built-in terminal preview or replay feature.
 
-NOTE: Terminal rendering is built directly into the HTML converter — the
+NOTE: Terminal rendering is built directly into the HTML converter, the
 `terminal` Cargo feature of `acdc-converters-html`, backed by the
-`acdc-converters-terminal` crate — rather than being loaded as a plug-in. If
+`acdc-converters-terminal` crate, rather than being loaded as a plug-in. If
 acdc grows a first-class extension mechanism, this functionality may migrate to
 an extension instead of being compiled into the converter.
 
@@ -277,9 +277,11 @@ data and does not execute commands, shells, scripts, VHS tapes, or other
 recording formats. Replay blocks require explicit terminal dimensions via
 `cols`/`rows` block attributes or `:terminal-cols:`/`:terminal-rows:`
 document attributes; invalid or missing dimensions fall back to a static
-terminal preview with a structured warning. Dense recordings are sampled so the
-generated HTML stays small even for long output, and playback ends on the final
-frame.
+terminal preview with a structured warning. The default raw-ANSI replay samples
+dense recordings so the generated HTML stays small even for long output.
+`format=asciicast` keeps every recorded frame instead and stays compact by
+emitting each repeated line once and referencing it per frame. Both end playback
+on the final frame.
 
 `[terminal]` and `[terminal%replay]` are acdc-only block styles. Asciidoctor
 renders them as a plain listing or literal block with the raw text (ANSI escapes
@@ -315,13 +317,13 @@ under asciidoctor.
 | Overrides the generated replay's total playback duration in milliseconds.
 |===
 
-#### Syntax highlighting CSS
+==== Syntax highlighting CSS
 
-When using class-based syntax highlighting (`:syntect-css: class`), the highlighting CSS is handled the same way — embedded by default, or linked/written to disk when `:linkcss:` is set. See the <<Syntax Highlighting>> section above.
+When using class-based syntax highlighting (`:syntect-css: class`), the highlighting CSS is handled the same way, embedded by default, or linked/written to disk when `:linkcss:` is set. See the <<Syntax Highlighting>> section above.
 
-### Docinfo files
+=== Docinfo files
 
-Docinfo files let you inject custom HTML into specific positions in the output — analytics snippets, custom `<meta>` tags, banners, footers, or anything else that doesn't belong in the AsciiDoc source itself.
+Docinfo files let you inject custom HTML into specific positions in the output, analytics snippets, custom `<meta>` tags, banners, footers, or anything else that doesn't belong in the AsciiDoc source itself.
 
 Enable docinfo with the `:docinfo:` document attribute:
 
@@ -333,12 +335,12 @@ Enable docinfo with the `:docinfo:` document attribute:
 
 The `:docinfo:` attribute accepts:
 
-- `shared` — load shared docinfo files (used across all documents)
-- `private` — load private docinfo files (specific to this document). This is the default when `:docinfo:` is set with no value
+- `shared`: load shared docinfo files (used across all documents)
+- `private`: load private docinfo files (specific to this document). This is the default when `:docinfo:` is set with no value
 - Granular values: `shared-head`, `shared-header`, `shared-footer`, `private-head`, `private-header`, `private-footer`
 - Comma-separated combinations: `shared, private-footer`
 
-#### File naming
+==== File naming
 
 Docinfo files follow a naming convention based on scope and injection position:
 
@@ -361,7 +363,7 @@ Docinfo files follow a naming convention based on scope and injection position:
 
 For a document named `guide.adoc`, the private head file would be `guide-docinfo.html`.
 
-#### Docinfo directory (`:docinfodir:`)
+==== Docinfo directory (`:docinfodir:`)
 
 By default, docinfo files are loaded from the same directory as the source document. Set `:docinfodir:` to load them from a different location:
 
@@ -374,9 +376,9 @@ By default, docinfo files are loaded from the same directory as the source docum
 
 The path is resolved relative to the source document directory, or can be absolute.
 
-#### Attribute substitution (`:docinfosubs:`)
+==== Attribute substitution (`:docinfosubs:`)
 
-Docinfo content is processed with attribute substitution by default — `\{attribute-name}` references in docinfo files are replaced with their values. Control this with `:docinfosubs:`:
+Docinfo content is processed with attribute substitution by default, `\{attribute-name}` references in docinfo files are replaced with their values. Control this with `:docinfosubs:`:
 
 [source,asciidoc]
 ....
@@ -387,11 +389,11 @@ Docinfo content is processed with attribute substitution by default — `\{attri
 
 NOTE: Currently only `attributes` substitution is supported for docinfo content.
 
-#### Injection points
+==== Injection points
 
-- **Head** — injected just before the closing `</head>` tag
-- **Header** — injected immediately after the opening `<body>` tag
-- **Footer** — injected just before the closing `</body>` tag
+- **Head**: injected just before the closing `</head>` tag
+- **Header**: injected immediately after the opening `<body>` tag
+- **Footer**: injected just before the closing `</body>` tag
 
 When both private and shared files exist for the same position, private content is injected first.
 
@@ -399,7 +401,60 @@ NOTE: Docinfo is disabled when running in secure safe mode (`--safe-mode secure`
 
 For full details, see the https://docs.asciidoctor.org/asciidoc/latest/docinfo/[Asciidoctor docinfo documentation].
 
-### Table Enhancements
+=== Customizing the CSS
+
+The output is class-based, so you can restyle it without forking the converter. Use whichever seam fits:
+
+* **Override specific rules.** Load your own stylesheet after acdc's and target its classes. Body content uses the standard Asciidoctor classes (`.listingblock`, `.admonitionblock`, `.tableblock`, and so on). The terminal replay's window chrome uses this contract:
++
+[cols="1,3"]
+|===
+| Classes | `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__titlebar`, `.terminal-replay__dots`, `.terminal-replay__title`, `.terminal-replay__viewport`, `.terminal-replay__screen`, `.terminal-replay__row`
+| Custom properties | `--acdc-term-bg`, `--acdc-term-fg` (the recorded terminal theme), plus `--acdc-term-font-family`, `--acdc-term-font-size`, `--acdc-term-line-height`, `--acdc-term-radius`, `--acdc-term-padding`
+|===
+
+* **Replace the whole stylesheet.** Use `:stylesheet: my.css` (see <<Custom stylesheet (`:stylesheet:`)>>), embedded or linked with `:linkcss:`. `:copycss:` copies the built-in CSS out as a starting point.
+* **Augment the `<head>`.** Inject extra `<style>`/`<link>` with <<Docinfo files>> (`:docinfo: shared-head`).
+* **Embedded mode.** There is no `<head>`, so the embedding page owns the stylesheet. Override acdc's classes from your page's own CSS.
+
+NOTE: A few elements still carry inline `style` attributes that beat an external stylesheet unless you use `!important`: terminal cell colours (resolved from the recording's own palette), table column and table widths, and image `align`/`float`. Override those with `!important`, or replace the stylesheet with `:stylesheet:`.
+
+=== Content Security Policy
+
+acdc emits self-contained HTML and does not set a CSP. The policy is up to whatever serves the file: your web server, CDN, or the page you embed into. https://antora.org[Antora] works the same way. The output runs under a normal policy you set yourself.
+
+A baseline that covers everything acdc emits:
+
+[source]
+....
+default-src 'self';
+script-src 'self' 'unsafe-inline';
+style-src  'self' 'unsafe-inline';
+img-src    'self' data:;
+font-src   'self';
+connect-src 'self';
+frame-ancestors 'none'
+....
+
+`'unsafe-eval'` is never needed (the terminal-replay player is plain JS). Add the entries below only when you use the matching feature:
+
+[cols="1,2"]
+|===
+| Feature | CSP additions
+
+| Webfonts (on by default) | add `https://fonts.googleapis.com` to `style-src` and `https://fonts.gstatic.com` to `font-src`
+| `:stem:` (MathJax) | add `https://cdn.jsdelivr.net` to `script-src`
+| `icons=font` (Font Awesome) | add `https://cdn.jsdelivr.net` to `style-src`
+| Remote or data-URI images | adjust `img-src`
+|===
+
+For a fully self-contained policy with no external origins, disable webfonts (`:!webfonts:`) and skip `:stem:` and `icons=font`. The baseline above then needs nothing extra.
+
+To keep `script-src` off `'unsafe-inline'`: the replay player is the only inline `<script>`, its code is constant, and its hash is exposed as `acdc_converters_html::REPLAY_PLAYER_SCRIPT_CSP_HASH`. Allowlist it as `script-src 'self' '<that hash>'`. Inline styles still need `style-src 'unsafe-inline'`. If the script is blocked, the replay still shows its final frame and only the animation is lost.
+
+NOTE: Embedded mode has no `<head>`, so the file cannot carry its own `<meta http-equiv="Content-Security-Policy">`. The embedding page or server sets the policy.
+
+=== Table Enhancements
 
 Full table feature support:
 
@@ -408,7 +463,7 @@ Full table feature support:
 - **Nested tables**: Using `!===` delimiter in AsciiDoc cells
 - **Cell-level formatting**: Alignment, styles (strong, emphasis, monospace, etc.)
 
-### Substitution Control
+=== Substitution Control
 
 Verbatim blocks (listing, literal) support the `subs` attribute:
 
@@ -417,7 +472,7 @@ Verbatim blocks (listing, literal) support the `subs` attribute:
 - `subs=+attributes` - enable attribute expansion
 - `subs=+replacements` - enable typography (arrows, dashes, ellipsis)
 
-### Icon support
+=== Icon support
 
 When `:icons: font` is set, icon macros render as https://fontawesome.com/[Font Awesome] `<i>` elements. By default the icon uses `fa-solid`, but you can select a specific FA family with the `set` (or `pack`) attribute on the macro:
 
@@ -475,7 +530,7 @@ Both shorthand and long-form values are supported:
 
 For details on the icon macro syntax, see the https://docs.asciidoctor.org/asciidoc/latest/macros/icons/[AsciiDoc icon macro documentation]. For available icons per family, see the https://fontawesome.com/search[Font Awesome icon gallery].
 
-### Mathematical Formulas (Stem)
+=== Mathematical Formulas (Stem)
 
 Render mathematical formulas using MathJax 4. Enable it by setting the `:stem:` document attribute.
 
@@ -512,7 +567,7 @@ When enabled, MathJax is loaded from the jsdelivr CDN (`cdn.jsdelivr.net/npm/mat
 
 To suppress MathJax processing on specific elements, add the CSS class `nostem`, `nolatexmath`, or `noasciimath`.
 
-### Semantic HTML5 Output (`html5s`)
+=== Semantic HTML5 Output (`html5s`)
 
 An alternative backend that produces semantic HTML5 instead of the traditional div-based layout, inspired by Jakub Jirutka's https://github.com/jirutka/asciidoctor-html5s[asciidoctor-html5s] gem for Asciidoctor. Enable it with `--backend html5s`:
 
@@ -534,11 +589,11 @@ Key differences from the standard backend:
 
 The semantic variant ships with its own stylesheet (light and dark mode) and supports a few additional document attributes:
 
-- `:html5s-force-stem-type:` — override the stem notation (`latexmath` or `asciimath`) regardless of the `:stem:` value
-- `:html5s-image-default-link: self` — make all images link to themselves by default
-- `:html5s-image-self-link-label:` — custom aria label for self-linked images (default: "Open the image in full size")
+- `:html5s-force-stem-type:`: override the stem notation (`latexmath` or `asciimath`) regardless of the `:stem:` value
+- `:html5s-image-default-link: self`: make all images link to themselves by default
+- `:html5s-image-self-link-label:`: custom aria label for self-linked images (default: "Open the image in full size")
 
-### Document Attributes
+=== Document Attributes
 
 Set document attributes via command line:
 
@@ -547,7 +602,7 @@ Set document attributes via command line:
 acdc convert -a toc=left -a toclevels=3 -a icons=font document.adoc
 ....
 
-### Performance Timing
+=== Performance Timing
 
 Enable timing information to see conversion performance:
 
@@ -563,7 +618,7 @@ Input file: document.adoc
 Generated HTML file: document.html
 ....
 
-## Output Structure
+== Output Structure
 
 Generated HTML includes:
 
@@ -573,37 +628,37 @@ Generated HTML includes:
 - Table of contents (if enabled via `:toc:` attribute)
 - Semantic HTML elements matching AsciiDoc structure
 
-## Examples
+== Examples
 
-### Basic Conversion
+=== Basic Conversion
 
 [source,console]
 ....
 acdc convert README.adoc
 ....
 
-### With Table of Contents
+=== With Table of Contents
 
 [source,console]
 ....
 acdc convert -a toc=left -a toclevels=2 guide.adoc
 ....
 
-### Book Doctype
+=== Book Doctype
 
 [source,console]
 ....
 acdc convert --doctype book -a toc book.adoc
 ....
 
-### Safe Mode
+=== Safe Mode
 
 [source,console]
 ....
 acdc convert --safe-mode safe document.adoc
 ....
 
-## Technical Details
+== Technical Details
 
 The HTML converter:
 
@@ -615,7 +670,7 @@ The HTML converter:
 - Embeds the Asciidoctor CSS stylesheet for consistent styling
 - Includes file modification timestamps in metadata
 
-## Differences from Asciidoctor
+== Differences from Asciidoctor
 
 While the HTML converter aims for compatibility with Asciidoctor, there are some known differences and limitations.
 

--- a/converters/html/build.rs
+++ b/converters/html/build.rs
@@ -13,7 +13,10 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use sha2::{Digest, Sha256};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    emit_csp_hash("static/terminal-replay-player.js", "ACDC_REPLAY_PLAYER_CSP_HASH")?;
+    emit_csp_hash(
+        "static/terminal-replay-player.js",
+        "ACDC_REPLAY_PLAYER_CSP_HASH",
+    )?;
     emit_csp_hash("static/mathjax-config.js", "ACDC_MATHJAX_CONFIG_CSP_HASH")?;
     Ok(())
 }

--- a/converters/html/build.rs
+++ b/converters/html/build.rs
@@ -1,0 +1,34 @@
+//! Computes the CSP `script-src` hashes for the inline scripts acdc embeds, so
+//! they never drift from the script contents.
+//!
+//! Each hash is the sha256 of a `static/*.js` file, base64-encoded and prefixed
+//! with the algorithm (`sha256-…`). That is exactly the source a browser expects
+//! in `script-src` for the matching inline `<script>`, whose body is the same
+//! file embedded verbatim via `include_str!`. The values are exposed to the crate
+//! through `cargo::rustc-env`, read back with `env!`.
+
+use std::{env, error::Error, fs, path::Path};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use sha2::{Digest, Sha256};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    emit_csp_hash("static/terminal-replay-player.js", "ACDC_REPLAY_PLAYER_CSP_HASH")?;
+    emit_csp_hash("static/mathjax-config.js", "ACDC_MATHJAX_CONFIG_CSP_HASH")?;
+    Ok(())
+}
+
+/// Hash the script at `relative_path` and expose `sha256-…` as `env_var`.
+fn emit_csp_hash(relative_path: &str, env_var: &str) -> Result<(), Box<dyn Error>> {
+    // Only recompute when the embedded script changes.
+    println!("cargo::rerun-if-changed={relative_path}");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
+    let path = Path::new(&manifest_dir).join(relative_path);
+    let bytes = fs::read(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+
+    // Hash the exact bytes that appear between the <script> tags at runtime.
+    let hash = format!("sha256-{}", STANDARD.encode(Sha256::digest(&bytes)));
+    println!("cargo::rustc-env={env_var}={hash}");
+    Ok(())
+}

--- a/converters/html/samples/asciicast_replay.adoc
+++ b/converters/html/samples/asciicast_replay.adoc
@@ -1,0 +1,43 @@
+= Asciicast Replay Sample
+:author: ACDC
+:toc:
+
+This document demonstrates replaying an https://docs.asciinema.org[asciicast]
+recording in an HTML terminal replay block. The block contains a recorded
+asciicast; acdc parses it as replay data and renders timed HTML frames. It never
+executes the recorded command, environment, or input — only recorded output
+bytes are fed to the terminal emulator.
+
+== Asciicast v2
+
+Set `format=asciicast` on a `[terminal%replay]` block. The terminal size comes
+from the recording header, so `cols`/`rows` are optional (block attributes
+override the header when present). Each event's time field is an absolute offset
+in seconds.
+
+[terminal%replay,format=asciicast]
+----
+{"version": 2, "width": 64, "height": 8, "title": "acdc demo"}
+[0.0, "o", "$ acdc convert guide.adoc --backend html\r\n"]
+[0.6, "o", "Parsing guide.adoc\r\n"]
+[1.2, "o", "\u001b[32mRendering replay frames\u001b[0m\r\n"]
+[1.9, "o", "Generated html file: ./guide.html\r\n"]
+[2.4, "o", "Done\r\n"]
+----
+
+== Asciicast v3
+
+Version 3 nests the terminal size under a `term` object, and each event's time
+field is the interval since the previous event. acdc accumulates those intervals
+into absolute timestamps, so playback timing matches the recording. A grow-only
+resize widens the terminal mid-replay.
+
+[terminal%replay,format=asciicast,replay-duration-ms=2500]
+----
+{"version": 3, "term": {"cols": 40, "rows": 6}}
+[0.0, "o", "starting...\r\n"]
+[0.5, "o", "loading modules\r\n"]
+[0.4, "r", "72x6"]
+[0.3, "o", "now there is room for much wider output lines\r\n"]
+[0.6, "o", "\u001b[1mdone\u001b[0m\r\n"]
+----

--- a/converters/html/samples/terminal_preview.adoc
+++ b/converters/html/samples/terminal_preview.adoc
@@ -2,8 +2,8 @@
 :author: ACDC
 :toc:
 :sectnums:
-:terminal-preview:
-:terminal-cols: 88
+:acdc-terminal:
+:acdc-terminal-cols: 88
 
 This document is normal HTML content with terminal-style source blocks rendered
 as selectable terminal previews when the HTML converter is built with the
@@ -24,8 +24,8 @@ Generated html5s file: /tmp/readme.html
 
 $ acdc convert converters/html/samples/terminal_preview.adoc \
     --backend html \
-    -o /tmp/terminal-preview.html
-Generated html file: /tmp/terminal-preview.html
+    -o /tmp/acdc-terminal.html
+Generated html file: /tmp/acdc-terminal.html
 ----
 
 == Output Checklist
@@ -81,7 +81,7 @@ fn main() {
 
 == Admonition
 
-NOTE: The `:terminal-preview:` attribute is the document-level opt-in. Use
-`:terminal-cols:` / `:terminal-rows:` to control the terminal grid size, or omit
+NOTE: The `:acdc-terminal:` attribute is the document-level opt-in. Use
+`:acdc-terminal-cols:` / `:acdc-terminal-rows:` to control the terminal grid size, or omit
 rows to let acdc size the preview from the rendered text.
-Without `:terminal-preview:`, standard and semantic HTML output stay unchanged.
+Without `:acdc-terminal:`, standard and semantic HTML output stay unchanged.

--- a/converters/html/samples/terminal_replay.adoc
+++ b/converters/html/samples/terminal_replay.adoc
@@ -24,4 +24,4 @@ Done
 == Notes
 
 Replay blocks require fixed terminal dimensions. Use `cols` and `rows` on the
-block, or set `:terminal-cols:` and `:terminal-rows:` document attributes.
+block, or set `:acdc-terminal-cols:` and `:acdc-terminal-rows:` document attributes.

--- a/converters/html/src/csp.rs
+++ b/converters/html/src/csp.rs
@@ -1,0 +1,144 @@
+//! Content Security Policy construction for generated HTML.
+//!
+//! acdc emits self-contained HTML and, by default, sets no CSP. When the `:csp:`
+//! document attribute is set, standalone output carries a
+//! `<meta http-equiv="Content-Security-Policy">` built by
+//! [`content_security_policy`]. The same builder is public so embedded-mode
+//! consumers (who own their own `<head>`) can reproduce acdc's policy.
+//!
+//! A CSP is a restriction, not an enabler: the policy locks scripts down to
+//! acdc's own inline scripts (by hash, no `'unsafe-inline'`) plus the `MathJax`
+//! CDN, while keeping passive resources (images, media, video embeds) permissive
+//! so arbitrary document content keeps loading.
+
+/// Which acdc features a document uses, so the right sources end up in its Content
+/// Security Policy. Defaults to all `false`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent on/off feature flags for selecting CSP sources"
+)]
+pub struct CspFeatures {
+    /// `:stem:` is set, so the inline `MathJax` config and the `MathJax` CDN loader are
+    /// emitted.
+    pub stem: bool,
+    /// Webfonts are linked (Google Fonts CSS + font files).
+    pub webfonts: bool,
+    /// `icons=font` is set, so the Font Awesome stylesheet (and its fonts) are loaded
+    /// from the CDN.
+    pub icons_font: bool,
+    /// A  terminal replay player  may be present, so  its inline script  is allow-listed.
+    /// Ignored unless the `terminal` feature is compiled in.
+    pub replay: bool,
+}
+
+/// Build the Content Security Policy value (the `content="..."` string) for the
+/// given features.
+///
+/// `script-src` allow-lists acdc's inline scripts by hash with no
+/// `'unsafe-inline'`; `style-src` keeps `'unsafe-inline'` because acdc emits
+/// inline `style=` widely (e.g. terminal cell colours from recorded data, which
+/// cannot be hashed). Passive directives stay permissive so remote images,
+/// media, and video embeds in document content still load. `frame-ancestors` is
+/// omitted on purpose: it is ignored in a `<meta>` CSP and must be a response
+/// header.
+#[must_use]
+pub fn content_security_policy(features: &CspFeatures) -> String {
+    let mut script_src = String::from("script-src 'self'");
+    #[cfg(feature = "terminal")]
+    if features.replay {
+        script_src.push_str(" '");
+        script_src.push_str(crate::REPLAY_PLAYER_SCRIPT_CSP_HASH);
+        script_src.push('\'');
+    }
+    if features.stem {
+        script_src.push_str(" '");
+        script_src.push_str(crate::MATHJAX_CONFIG_CSP_HASH);
+        script_src.push_str("' https://cdn.jsdelivr.net");
+    }
+
+    let mut style_src = String::from("style-src 'self' 'unsafe-inline'");
+    if features.webfonts {
+        style_src.push_str(" https://fonts.googleapis.com");
+    }
+    if features.icons_font {
+        style_src.push_str(" https://cdn.jsdelivr.net");
+    }
+
+    let mut font_src = String::from("font-src 'self'");
+    if features.webfonts {
+        font_src.push_str(" https://fonts.gstatic.com");
+    }
+    if features.icons_font {
+        font_src.push_str(" https://cdn.jsdelivr.net");
+    }
+
+    [
+        "default-src 'self'",
+        &script_src,
+        &style_src,
+        &font_src,
+        "img-src 'self' data: https:",
+        "media-src 'self' https:",
+        "frame-src https://www.youtube.com https://player.vimeo.com",
+    ]
+    .join("; ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_locks_scripts_without_unsafe_inline() {
+        let policy = content_security_policy(&CspFeatures::default());
+        assert!(policy.contains("default-src 'self'"));
+        assert!(policy.contains("script-src 'self'"));
+        // Scripts are never allowed inline wholesale.
+        assert!(!policy.contains("script-src 'self' 'unsafe-inline'"));
+        // Styles must allow inline (acdc emits inline style attributes).
+        assert!(policy.contains("style-src 'self' 'unsafe-inline'"));
+        // Passive resources stay permissive so document content keeps loading.
+        assert!(policy.contains("img-src 'self' data: https:"));
+        assert!(policy.contains("media-src 'self' https:"));
+        // No CDN sources without the features that need them.
+        assert!(!policy.contains("cdn.jsdelivr.net"));
+        assert!(!policy.contains("fonts.googleapis.com"));
+    }
+
+    #[test]
+    fn stem_adds_mathjax_hash_and_cdn() {
+        let policy = content_security_policy(&CspFeatures {
+            stem: true,
+            ..CspFeatures::default()
+        });
+        assert!(policy.contains(super::super::MATHJAX_CONFIG_CSP_HASH));
+        assert!(policy.contains("script-src 'self'"));
+        assert!(policy.contains("https://cdn.jsdelivr.net"));
+    }
+
+    #[test]
+    fn webfonts_and_icons_add_font_hosts() {
+        let policy = content_security_policy(&CspFeatures {
+            webfonts: true,
+            icons_font: true,
+            ..CspFeatures::default()
+        });
+        assert!(policy.contains("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"));
+        assert!(policy.contains("https://fonts.gstatic.com"));
+        // Font Awesome's stylesheet and fonts both come from jsDelivr.
+        assert!(
+            policy.contains("font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net")
+        );
+    }
+
+    #[cfg(feature = "terminal")]
+    #[test]
+    fn replay_adds_player_hash() {
+        let policy = content_security_policy(&CspFeatures {
+            replay: true,
+            ..CspFeatures::default()
+        });
+        assert!(policy.contains(crate::REPLAY_PLAYER_SCRIPT_CSP_HASH));
+    }
+}

--- a/converters/html/src/csp.rs
+++ b/converters/html/src/csp.rs
@@ -3,8 +3,8 @@
 //! acdc emits self-contained HTML and, by default, sets no CSP. When the `:csp:`
 //! document attribute is set, standalone output carries a
 //! `<meta http-equiv="Content-Security-Policy">` built by
-//! [`content_security_policy`]. The same builder is public so embedded-mode
-//! consumers (who own their own `<head>`) can reproduce acdc's policy.
+//! [`CspFeatures::content_security_policy`] from the set of features the
+//! rendered document actually uses.
 //!
 //! A CSP is a restriction, not an enabler: the policy locks scripts down to
 //! acdc's own inline scripts (by hash, no `'unsafe-inline'`) plus the `MathJax`
@@ -18,7 +18,7 @@
     clippy::struct_excessive_bools,
     reason = "independent on/off feature flags for selecting CSP sources"
 )]
-pub struct CspFeatures {
+pub(crate) struct CspFeatures {
     /// `:stem:` is set, so the inline `MathJax` config and the `MathJax` CDN loader are
     /// emitted.
     pub stem: bool,
@@ -32,57 +32,59 @@ pub struct CspFeatures {
     pub replay: bool,
 }
 
-/// Build the Content Security Policy value (the `content="..."` string) for the
-/// given features.
-///
-/// `script-src` allow-lists acdc's inline scripts by hash with no
-/// `'unsafe-inline'`; `style-src` keeps `'unsafe-inline'` because acdc emits
-/// inline `style=` widely (e.g. terminal cell colours from recorded data, which
-/// cannot be hashed). Passive directives stay permissive so remote images,
-/// media, and video embeds in document content still load. `frame-ancestors` is
-/// omitted on purpose: it is ignored in a `<meta>` CSP and must be a response
-/// header.
-#[must_use]
-pub fn content_security_policy(features: &CspFeatures) -> String {
-    let mut script_src = String::from("script-src 'self'");
-    #[cfg(feature = "terminal")]
-    if features.replay {
-        script_src.push_str(" '");
-        script_src.push_str(crate::REPLAY_PLAYER_SCRIPT_CSP_HASH);
-        script_src.push('\'');
-    }
-    if features.stem {
-        script_src.push_str(" '");
-        script_src.push_str(crate::MATHJAX_CONFIG_CSP_HASH);
-        script_src.push_str("' https://cdn.jsdelivr.net");
-    }
+impl CspFeatures {
+    /// Build the Content Security Policy value (the `content="..."` string) for
+    /// these features.
+    ///
+    /// `script-src` allow-lists acdc's inline scripts by hash with no
+    /// `'unsafe-inline'`; `style-src` keeps `'unsafe-inline'` because acdc emits
+    /// inline `style=` widely (e.g. terminal cell colours from recorded data,
+    /// which cannot be hashed). Passive directives stay permissive so remote
+    /// images, media, and video embeds in document content still load.
+    /// `frame-ancestors` is omitted on purpose: it is ignored in a `<meta>` CSP
+    /// and must be a response header.
+    #[must_use]
+    pub(crate) fn content_security_policy(self) -> String {
+        let mut script_src = String::from("script-src 'self'");
+        #[cfg(feature = "terminal")]
+        if self.replay {
+            script_src.push_str(" '");
+            script_src.push_str(crate::REPLAY_PLAYER_SCRIPT_CSP_HASH);
+            script_src.push('\'');
+        }
+        if self.stem {
+            script_src.push_str(" '");
+            script_src.push_str(crate::MATHJAX_CONFIG_CSP_HASH);
+            script_src.push_str("' https://cdn.jsdelivr.net");
+        }
 
-    let mut style_src = String::from("style-src 'self' 'unsafe-inline'");
-    if features.webfonts {
-        style_src.push_str(" https://fonts.googleapis.com");
-    }
-    if features.icons_font {
-        style_src.push_str(" https://cdn.jsdelivr.net");
-    }
+        let mut style_src = String::from("style-src 'self' 'unsafe-inline'");
+        if self.webfonts {
+            style_src.push_str(" https://fonts.googleapis.com");
+        }
+        if self.icons_font {
+            style_src.push_str(" https://cdn.jsdelivr.net");
+        }
 
-    let mut font_src = String::from("font-src 'self'");
-    if features.webfonts {
-        font_src.push_str(" https://fonts.gstatic.com");
-    }
-    if features.icons_font {
-        font_src.push_str(" https://cdn.jsdelivr.net");
-    }
+        let mut font_src = String::from("font-src 'self'");
+        if self.webfonts {
+            font_src.push_str(" https://fonts.gstatic.com");
+        }
+        if self.icons_font {
+            font_src.push_str(" https://cdn.jsdelivr.net");
+        }
 
-    [
-        "default-src 'self'",
-        &script_src,
-        &style_src,
-        &font_src,
-        "img-src 'self' data: https:",
-        "media-src 'self' https:",
-        "frame-src https://www.youtube.com https://player.vimeo.com",
-    ]
-    .join("; ")
+        [
+            "default-src 'self'",
+            &script_src,
+            &style_src,
+            &font_src,
+            "img-src 'self' data: https:",
+            "media-src 'self' https:",
+            "frame-src https://www.youtube.com https://player.vimeo.com",
+        ]
+        .join("; ")
+    }
 }
 
 #[cfg(test)]
@@ -91,7 +93,7 @@ mod tests {
 
     #[test]
     fn baseline_locks_scripts_without_unsafe_inline() {
-        let policy = content_security_policy(&CspFeatures::default());
+        let policy = CspFeatures::default().content_security_policy();
         assert!(policy.contains("default-src 'self'"));
         assert!(policy.contains("script-src 'self'"));
         // Scripts are never allowed inline wholesale.
@@ -108,10 +110,11 @@ mod tests {
 
     #[test]
     fn stem_adds_mathjax_hash_and_cdn() {
-        let policy = content_security_policy(&CspFeatures {
+        let policy = CspFeatures {
             stem: true,
             ..CspFeatures::default()
-        });
+        }
+        .content_security_policy();
         assert!(policy.contains(super::super::MATHJAX_CONFIG_CSP_HASH));
         assert!(policy.contains("script-src 'self'"));
         assert!(policy.contains("https://cdn.jsdelivr.net"));
@@ -119,11 +122,12 @@ mod tests {
 
     #[test]
     fn webfonts_and_icons_add_font_hosts() {
-        let policy = content_security_policy(&CspFeatures {
+        let policy = CspFeatures {
             webfonts: true,
             icons_font: true,
             ..CspFeatures::default()
-        });
+        }
+        .content_security_policy();
         assert!(policy.contains("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com"));
         assert!(policy.contains("https://fonts.gstatic.com"));
         // Font Awesome's stylesheet and fonts both come from jsDelivr.
@@ -135,10 +139,11 @@ mod tests {
     #[cfg(feature = "terminal")]
     #[test]
     fn replay_adds_player_hash() {
-        let policy = content_security_policy(&CspFeatures {
+        let policy = CspFeatures {
             replay: true,
             ..CspFeatures::default()
-        });
+        }
+        .content_security_policy();
         assert!(policy.contains(crate::REPLAY_PLAYER_SCRIPT_CSP_HASH));
     }
 }

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -576,11 +576,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     ) -> Result<(), Error> {
         let attrs = self.processor.document_attributes.clone();
         let options = self.processor.options.clone();
-        write_block_div_open(
-            &mut self.writer,
-            metadata,
-            "terminalblock terminal-preview-block",
-        )?;
+        write_block_div_open(&mut self.writer, metadata, "terminalblock terminal-block")?;
 
         if !title.is_empty() {
             self.render_title_with_wrapper(title, "<div class=\"title\">", "</div>\n")?;
@@ -614,12 +610,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         // Direct field access so the writer and diagnostics borrows stay
         // disjoint; `writer_mut()` would borrow all of `self`.
         if title.is_empty() {
-            write_semantic_tag_open(
-                &mut self.writer,
-                "div",
-                metadata,
-                "terminal-block terminal-preview-block",
-            )?;
+            write_semantic_tag_open(&mut self.writer, "div", metadata, "terminal-block")?;
             crate::terminal::render_session(
                 &mut self.writer,
                 inlines,
@@ -630,12 +621,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             )?;
             writeln!(self.writer, "</div>")?;
         } else {
-            write_semantic_tag_open(
-                &mut self.writer,
-                "figure",
-                metadata,
-                "terminal-block terminal-preview-block",
-            )?;
+            write_semantic_tag_open(&mut self.writer, "figure", metadata, "terminal-block")?;
             self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
             crate::terminal::render_session(
                 &mut self.writer,
@@ -659,11 +645,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     ) -> Result<(), Error> {
         let attrs = self.processor.document_attributes.clone();
         let options = self.processor.options.clone();
-        write_block_div_open(
-            &mut self.writer,
-            metadata,
-            "listingblock terminal-preview-block",
-        )?;
+        write_block_div_open(&mut self.writer, metadata, "listingblock terminal-block")?;
 
         if !title.is_empty() {
             self.render_title_with_wrapper(title, "<div class=\"title\">", "</div>\n")?;
@@ -690,7 +672,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 &mut self.writer,
                 "div",
                 metadata,
-                "listing-block terminal-preview-block",
+                "listing-block terminal-block",
             )?;
             crate::terminal::render_listing(&mut self.writer, inlines, metadata, options, &attrs)?;
             writeln!(self.writer, "</div>")?;
@@ -699,7 +681,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 &mut self.writer,
                 "figure",
                 metadata,
-                "listing-block terminal-preview-block",
+                "listing-block terminal-block",
             )?;
             self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
             crate::terminal::render_listing(&mut self.writer, inlines, metadata, options, &attrs)?;

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -790,7 +790,9 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             }
             DelimitedBlockType::DelimitedLiteral(inlines) => {
                 #[cfg(feature = "terminal")]
-                if crate::terminal::is_terminal_session(metadata) && self.terminal_emulator_allowed() {
+                if crate::terminal::is_terminal_session(metadata)
+                    && self.terminal_emulator_allowed()
+                {
                     if self.processor.variant() == HtmlVariant::Semantic {
                         self.render_terminal_session_block_semantic(inlines, title, metadata)?;
                     } else {

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -500,12 +500,14 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         }
 
         #[cfg(feature = "terminal")]
-        if crate::terminal::is_terminal_session(metadata) {
+        if crate::terminal::is_terminal_session(metadata) && self.terminal_emulator_allowed() {
             return self.render_terminal_session_block(inlines, title, metadata);
         }
 
         #[cfg(feature = "terminal")]
-        if crate::terminal::is_terminal_listing(&processor.document_attributes, metadata) {
+        if crate::terminal::is_terminal_listing(&processor.document_attributes, metadata)
+            && self.terminal_emulator_allowed()
+        {
             return self.render_terminal_listing_block(inlines, title, metadata);
         }
 
@@ -543,12 +545,14 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         metadata: &BlockMetadata,
     ) -> Result<(), Error> {
         #[cfg(feature = "terminal")]
-        if crate::terminal::is_terminal_session(metadata) {
+        if crate::terminal::is_terminal_session(metadata) && self.terminal_emulator_allowed() {
             return self.render_terminal_session_block_semantic(inlines, title, metadata);
         }
 
         #[cfg(feature = "terminal")]
-        if crate::terminal::is_terminal_listing(&self.processor.document_attributes, metadata) {
+        if crate::terminal::is_terminal_listing(&self.processor.document_attributes, metadata)
+            && self.terminal_emulator_allowed()
+        {
             return self.render_terminal_listing_block_semantic(inlines, title, metadata);
         }
 
@@ -565,6 +569,24 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             writeln!(self.writer, "</figure>")?;
         }
         Ok(())
+    }
+
+    /// Whether the terminal emulator may render the current block. Terminal
+    /// rendering feeds document-controlled bytes through a native terminal
+    /// emulator (`libghostty-vt`), so it only runs for trusted documents. At
+    /// `SafeMode::Server` and above the block degrades to a plain listing,
+    /// mirroring how Asciidoctor renders an unrecognized block style, and a
+    /// warning records why the preview is absent.
+    #[cfg(feature = "terminal")]
+    fn terminal_emulator_allowed(&mut self) -> bool {
+        let safe_mode = self.processor.options.safe_mode();
+        if safe_mode < acdc_parser::SafeMode::Server {
+            return true;
+        }
+        self.diagnostics.warn(format!(
+            "terminal rendering is disabled at safe mode `{safe_mode:?}`; rendering the block as a plain listing"
+        ));
+        false
     }
 
     #[cfg(feature = "terminal")]
@@ -768,7 +790,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             }
             DelimitedBlockType::DelimitedLiteral(inlines) => {
                 #[cfg(feature = "terminal")]
-                if crate::terminal::is_terminal_session(metadata) {
+                if crate::terminal::is_terminal_session(metadata) && self.terminal_emulator_allowed() {
                     if self.processor.variant() == HtmlVariant::Semantic {
                         self.render_terminal_session_block_semantic(inlines, title, metadata)?;
                     } else {

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -500,12 +500,12 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         }
 
         #[cfg(feature = "terminal")]
-        if crate::terminal_preview::is_terminal_session(metadata) {
+        if crate::terminal::is_terminal_session(metadata) {
             return self.render_terminal_session_block(inlines, title, metadata);
         }
 
         #[cfg(feature = "terminal")]
-        if crate::terminal_preview::is_terminal_listing(&processor.document_attributes, metadata) {
+        if crate::terminal::is_terminal_listing(&processor.document_attributes, metadata) {
             return self.render_terminal_listing_block(inlines, title, metadata);
         }
 
@@ -543,15 +543,12 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         metadata: &BlockMetadata,
     ) -> Result<(), Error> {
         #[cfg(feature = "terminal")]
-        if crate::terminal_preview::is_terminal_session(metadata) {
+        if crate::terminal::is_terminal_session(metadata) {
             return self.render_terminal_session_block_semantic(inlines, title, metadata);
         }
 
         #[cfg(feature = "terminal")]
-        if crate::terminal_preview::is_terminal_listing(
-            &self.processor.document_attributes,
-            metadata,
-        ) {
+        if crate::terminal::is_terminal_listing(&self.processor.document_attributes, metadata) {
             return self.render_terminal_listing_block_semantic(inlines, title, metadata);
         }
 
@@ -592,7 +589,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         writeln!(self.writer, "<div class=\"content\">")?;
         // Direct field access so the writer and diagnostics borrows stay
         // disjoint; `writer_mut()` would borrow all of `self`.
-        crate::terminal_preview::render_session(
+        crate::terminal::render_session(
             &mut self.writer,
             inlines,
             metadata,
@@ -623,7 +620,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 metadata,
                 "terminal-block terminal-preview-block",
             )?;
-            crate::terminal_preview::render_session(
+            crate::terminal::render_session(
                 &mut self.writer,
                 inlines,
                 metadata,
@@ -640,7 +637,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 "terminal-block terminal-preview-block",
             )?;
             self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
-            crate::terminal_preview::render_session(
+            crate::terminal::render_session(
                 &mut self.writer,
                 inlines,
                 metadata,
@@ -673,13 +670,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         }
 
         writeln!(self.writer, "<div class=\"content\">")?;
-        crate::terminal_preview::render_listing(
-            &mut self.writer,
-            inlines,
-            metadata,
-            options,
-            &attrs,
-        )?;
+        crate::terminal::render_listing(&mut self.writer, inlines, metadata, options, &attrs)?;
         writeln!(self.writer, "</div>")?;
         writeln!(self.writer, "</div>")?;
         Ok(())
@@ -701,13 +692,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 metadata,
                 "listing-block terminal-preview-block",
             )?;
-            crate::terminal_preview::render_listing(
-                &mut self.writer,
-                inlines,
-                metadata,
-                options,
-                &attrs,
-            )?;
+            crate::terminal::render_listing(&mut self.writer, inlines, metadata, options, &attrs)?;
             writeln!(self.writer, "</div>")?;
         } else {
             write_semantic_tag_open(
@@ -717,13 +702,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
                 "listing-block terminal-preview-block",
             )?;
             self.render_title_with_wrapper(title, "<figcaption>", "</figcaption>\n")?;
-            crate::terminal_preview::render_listing(
-                &mut self.writer,
-                inlines,
-                metadata,
-                options,
-                &attrs,
-            )?;
+            crate::terminal::render_listing(&mut self.writer, inlines, metadata, options, &attrs)?;
             writeln!(self.writer, "</figure>")?;
         }
         Ok(())
@@ -807,7 +786,7 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
             }
             DelimitedBlockType::DelimitedLiteral(inlines) => {
                 #[cfg(feature = "terminal")]
-                if crate::terminal_preview::is_terminal_session(metadata) {
+                if crate::terminal::is_terminal_session(metadata) {
                     if self.processor.variant() == HtmlVariant::Semantic {
                         self.render_terminal_session_block_semantic(inlines, title, metadata)?;
                     } else {

--- a/converters/html/src/error.rs
+++ b/converters/html/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
 
     #[cfg(feature = "terminal")]
     #[error(transparent)]
-    TerminalRenderState(#[from] acdc_converters_terminal::cell_grid::Error),
+    TerminalGrid(#[from] acdc_converters_terminal::cell_grid::Error),
 
     #[cfg(feature = "terminal")]
     #[error(transparent)]

--- a/converters/html/src/html_visitor.rs
+++ b/converters/html/src/html_visitor.rs
@@ -363,7 +363,7 @@ impl<'a, 'd, W: Write> HtmlVisitor<'a, 'd, W> {
             writeln!(
                 self.writer,
                 r#"<meta http-equiv="Content-Security-Policy" content="{}">"#,
-                crate::content_security_policy(&self.csp_features())
+                self.csp_features().content_security_policy()
             )?;
         }
 

--- a/converters/html/src/html_visitor.rs
+++ b/converters/html/src/html_visitor.rs
@@ -114,11 +114,10 @@ pub const MATHJAX_CONFIG_SCRIPT: &str = concat!(
 );
 
 /// CSP `script-src` source (sha256) for [`MATHJAX_CONFIG_SCRIPT`]'s inline code,
-/// so a host can allowlist it without `'unsafe-inline'`. The hash is the sha256 of
-/// `static/mathjax-config.js` (the code between the `<script>` tags). If you edit
-/// that file, recompute it with:
-/// `openssl dgst -sha256 -binary static/mathjax-config.js | openssl base64`
-pub const MATHJAX_CONFIG_CSP_HASH: &str = "sha256-/viRmZJXKJF/fjIESAG3yWbh5QeUhdiM/Hr7b7qKm+c=";
+/// so a host can allowlist it without `'unsafe-inline'`. Computed in `build.rs`
+/// as the sha256 of `static/mathjax-config.js`, so it always matches the embedded
+/// script.
+pub const MATHJAX_CONFIG_CSP_HASH: &str = env!("ACDC_MATHJAX_CONFIG_CSP_HASH");
 
 fn add_mathjax<W: Write>(writer: &mut W) -> Result<(), Error> {
     writeln!(writer, "{MATHJAX_CONFIG_SCRIPT}")?;

--- a/converters/html/src/html_visitor.rs
+++ b/converters/html/src/html_visitor.rs
@@ -98,47 +98,33 @@ fn resolve_custom_css(
     }
 }
 
+/// The `MathJax` loader script URL acdc references when `:stem:` is set. Exposed
+/// so an embedded-mode consumer (no `<head>` is generated) can load the same
+/// `MathJax` build on their own page.
+pub const MATHJAX_LOADER_URL: &str = "https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js";
+
+/// The inline `MathJax` configuration `<script>` acdc emits when `:stem:` is set,
+/// wrapping the JavaScript in `static/mathjax-config.js` (embedded at compile
+/// time). Exposed for embedded-mode consumers to reproduce the same
+/// configuration; its CSP `script-src` hash is [`MATHJAX_CONFIG_CSP_HASH`].
+pub const MATHJAX_CONFIG_SCRIPT: &str = concat!(
+    "<script>",
+    include_str!("../static/mathjax-config.js"),
+    "</script>"
+);
+
+/// CSP `script-src` source (sha256) for [`MATHJAX_CONFIG_SCRIPT`]'s inline code,
+/// so a host can allowlist it without `'unsafe-inline'`. The hash is the sha256 of
+/// `static/mathjax-config.js` (the code between the `<script>` tags). If you edit
+/// that file, recompute it with:
+/// `openssl dgst -sha256 -binary static/mathjax-config.js | openssl base64`
+pub const MATHJAX_CONFIG_CSP_HASH: &str = "sha256-/viRmZJXKJF/fjIESAG3yWbh5QeUhdiM/Hr7b7qKm+c=";
+
 fn add_mathjax<W: Write>(writer: &mut W) -> Result<(), Error> {
+    writeln!(writer, "{MATHJAX_CONFIG_SCRIPT}")?;
     writeln!(
         writer,
-        r#"<script>
-MathJax = {{
-      loader: {{load: ['input/asciimath']}},
-      tex: {{
-        processEscapes: false,
-        inlineMath: [['\\(', '\\)']],
-        displayMath: [['\\[', '\\]']]
-      }},
-      asciimath: {{
-        delimiters: {{'[+]': [['\\$','\\$']]}},
-        displaystyle: false
-      }},
-      options: {{
-        ignoreHtmlClass: 'tex2jax_ignore|nostem|nolatexmath|noasciimath',
-        processHtmlClass: 'tex2jax_process'
-      }},
-      startup: {{
-        ready() {{
-          MathJax.startup.defaultReady();
-          MathJax.startup.promise.then(() => {{
-            const asciimath = MathJax._.input.asciimath.AsciiMath;
-            if (asciimath) {{
-              const originalCompile = asciimath.compile;
-              asciimath.compile = function(math, display) {{
-                const node = math.math;
-                if (node && node.parentElement && node.parentElement.parentElement &&
-                  node.parentElement.parentElement.classList.contains('stemblock')) {{
-                  display = true;
-                }}
-                return originalCompile.call(this, math, display);
-              }};
-            }}
-          }});
-        }}
-      }}
-}};
-</script>
-<script defer src="https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"></script>"#
+        r#"<script defer src="{MATHJAX_LOADER_URL}"></script>"#
     )?;
     Ok(())
 }
@@ -328,6 +314,31 @@ impl<'a, 'd, W: Write> HtmlVisitor<'a, 'd, W> {
         Ok(())
     }
 
+    /// Whether the `:csp:` attribute opts this document into a `<meta>` Content
+    /// Security Policy (standalone output only).
+    fn is_csp_enabled(&self) -> bool {
+        self.processor
+            .document_attributes
+            .get("csp")
+            .is_some_and(|v| !matches!(v, AttributeValue::Bool(false) | AttributeValue::None))
+    }
+
+    /// The acdc features this document uses, for building its CSP. Mirrors the
+    /// gating the head uses to decide which scripts, fonts, and CDNs it emits.
+    fn csp_features(&self) -> crate::CspFeatures {
+        let attrs = &self.processor.document_attributes;
+        let stylesheet_disabled = attrs
+            .get("stylesheet")
+            .is_some_and(|v| matches!(v, AttributeValue::Bool(false)));
+        crate::CspFeatures {
+            stem: attrs.get("stem").is_some(),
+            webfonts: !stylesheet_disabled
+                && !matches!(attrs.get("webfonts"), Some(AttributeValue::Bool(false))),
+            icons_font: attrs.get("icons").is_some_and(|v| v.to_string() == "font"),
+            replay: cfg!(feature = "terminal"),
+        }
+    }
+
     fn render_head(&mut self, document: &Document) -> Result<(), Error> {
         let dark_mode = self.is_dark_mode();
 
@@ -343,6 +354,17 @@ impl<'a, 'd, W: Write> HtmlVisitor<'a, 'd, W> {
 
         if dark_mode {
             writeln!(self.writer, r#"<meta name="color-scheme" content="dark">"#)?;
+        }
+
+        // Content Security Policy (opt-in via `:csp:`). A `<meta>` CSP governs
+        // everything after it, so emit it before the stylesheet, fonts, and
+        // scripts below.
+        if self.is_csp_enabled() {
+            writeln!(
+                self.writer,
+                r#"<meta http-equiv="Content-Security-Policy" content="{}">"#,
+                crate::content_security_policy(&self.csp_features())
+            )?;
         }
 
         if let Some(header) = &document.header {

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -45,6 +45,7 @@ pub use error::Error;
 pub use html_visitor::HtmlVisitor;
 /// CSP `script-src` hash for the inline terminal-replay player script, for hosts
 /// that want to allowlist it without `'unsafe-inline'`.
+#[cfg(feature = "terminal")]
 pub use terminal::REPLAY_PLAYER_SCRIPT_CSP_HASH;
 
 /// HTML output flavour, owned by the html converter.

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -17,6 +17,7 @@ use acdc_parser::{
 mod admonition;
 mod audio;
 mod constants;
+mod csp;
 mod delimited;
 mod docinfo;
 mod document;
@@ -41,12 +42,17 @@ pub(crate) use acdc_converters_core::section::{
     AppendixTracker, PartNumberTracker, SectionNumberTracker, SpecialSectionTracker,
     last_section_has_style,
 };
+pub use csp::{CspFeatures, content_security_policy};
 pub use error::Error;
 pub use html_visitor::HtmlVisitor;
-/// CSP `script-src` hash for the inline terminal-replay player script, for hosts
-/// that want to allowlist it without `'unsafe-inline'`.
+/// The `MathJax` assets acdc emits when `:stem:` is set, exposed so embedded-mode
+/// consumers can reproduce them: the inline configuration `<script>`, its CSP
+/// hash, and the loader URL.
+pub use html_visitor::{MATHJAX_CONFIG_CSP_HASH, MATHJAX_CONFIG_SCRIPT, MATHJAX_LOADER_URL};
+/// The inline terminal-replay player script and its CSP `script-src` hash, for
+/// embedded-mode consumers and hosts that allowlist it without `'unsafe-inline'`.
 #[cfg(feature = "terminal")]
-pub use terminal::REPLAY_PLAYER_SCRIPT_CSP_HASH;
+pub use terminal::{REPLAY_PLAYER_SCRIPT, REPLAY_PLAYER_SCRIPT_CSP_HASH};
 
 /// HTML output flavour, owned by the html converter.
 ///
@@ -1501,6 +1507,88 @@ This is a paragraph.
             "body should have dark class"
         );
         Ok(())
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Content Security Policy (:csp:) tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    fn convert(content: &str, embedded: bool) -> Result<String, Box<dyn std::error::Error>> {
+        let parsed = acdc_parser::parse(content, &acdc_parser::Options::default())?;
+        let doc = parsed.document();
+        let processor = Processor::new(
+            acdc_converters_core::Options::default(),
+            doc.attributes.clone(),
+        );
+        let render_options = RenderOptions {
+            embedded,
+            ..RenderOptions::default()
+        };
+        Ok(processor.convert_to_string(doc, &render_options)?)
+    }
+
+    #[test]
+    fn csp_attribute_emits_hardening_meta() -> TestResult {
+        let html = convert("= T\n:csp:\n\nHi.\n", false)?;
+        assert!(html.contains(r#"<meta http-equiv="Content-Security-Policy" content=""#));
+        assert!(html.contains("default-src 'self'"));
+        assert!(html.contains("script-src 'self'"));
+        // Scripts are never allowed inline wholesale (the point of the hardening).
+        assert!(!html.contains("script-src 'self' 'unsafe-inline'"));
+        // Inline styles must stay allowed (acdc emits inline style attributes).
+        assert!(html.contains("style-src 'self' 'unsafe-inline'"));
+        Ok(())
+    }
+
+    #[cfg(feature = "terminal")]
+    #[test]
+    fn csp_allowlists_the_replay_player_hash() -> TestResult {
+        let html = convert("= T\n:csp:\n\nHi.\n", false)?;
+        assert!(html.contains(REPLAY_PLAYER_SCRIPT_CSP_HASH));
+        Ok(())
+    }
+
+    #[test]
+    fn csp_with_stem_allowlists_mathjax() -> TestResult {
+        let html = convert("= T\n:csp:\n:stem:\n\nstem:[x^2]\n", false)?;
+        let csp = html
+            .lines()
+            .find(|line| line.contains("Content-Security-Policy"))
+            .ok_or("missing CSP meta")?;
+        assert!(csp.contains(MATHJAX_CONFIG_CSP_HASH));
+        assert!(csp.contains("https://cdn.jsdelivr.net"));
+        Ok(())
+    }
+
+    #[test]
+    fn no_csp_attribute_emits_no_meta() -> TestResult {
+        let html = convert("= T\n\nHi.\n", false)?;
+        assert!(!html.contains("Content-Security-Policy"));
+        Ok(())
+    }
+
+    #[test]
+    fn csp_is_standalone_only_not_embedded() -> TestResult {
+        let html = convert("= T\n:csp:\n\nHi.\n", true)?;
+        assert!(!html.contains("Content-Security-Policy"));
+        Ok(())
+    }
+
+    #[test]
+    fn mathjax_config_hash_stays_in_sync() {
+        // Tripwire: the documented CSP hash covers the JS between the <script>
+        // tags. If this length changes, the config changed; recompute
+        // MATHJAX_CONFIG_CSP_HASH (see its doc) and update it here.
+        let inner = MATHJAX_CONFIG_SCRIPT
+            .strip_prefix("<script>")
+            .and_then(|script| script.strip_suffix("</script>"))
+            .unwrap_or_default();
+        assert_eq!(
+            inner.len(),
+            1157,
+            "MathJax config changed; recompute MATHJAX_CONFIG_CSP_HASH"
+        );
+        assert!(MATHJAX_CONFIG_CSP_HASH.starts_with("sha256-"));
     }
 
     #[test]

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -33,7 +33,7 @@ mod section;
 mod syntax;
 mod table;
 #[cfg(feature = "terminal")]
-mod terminal_preview;
+mod terminal;
 mod toc;
 mod video;
 
@@ -43,6 +43,9 @@ pub(crate) use acdc_converters_core::section::{
 };
 pub use error::Error;
 pub use html_visitor::HtmlVisitor;
+/// CSP `script-src` hash for the inline terminal-replay player script, for hosts
+/// that want to allowlist it without `'unsafe-inline'`.
+pub use terminal::REPLAY_PLAYER_SCRIPT_CSP_HASH;
 
 /// HTML output flavour, owned by the html converter.
 ///

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -42,7 +42,7 @@ pub(crate) use acdc_converters_core::section::{
     AppendixTracker, PartNumberTracker, SectionNumberTracker, SpecialSectionTracker,
     last_section_has_style,
 };
-pub use csp::{CspFeatures, content_security_policy};
+pub(crate) use csp::CspFeatures;
 pub use error::Error;
 pub use html_visitor::HtmlVisitor;
 /// The `MathJax` assets acdc emits when `:stem:` is set, exposed so embedded-mode

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -1572,7 +1572,10 @@ This is a paragraph.
             .strip_prefix("<script>")
             .and_then(|script| script.strip_suffix("</script>"))
             .ok_or("MathJax config must be wrapped in <script> tags")?;
-        let expected = format!("sha256-{}", STANDARD.encode(Sha256::digest(inner.as_bytes())));
+        let expected = format!(
+            "sha256-{}",
+            STANDARD.encode(Sha256::digest(inner.as_bytes()))
+        );
         assert_eq!(MATHJAX_CONFIG_CSP_HASH, expected);
         Ok(())
     }

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -1561,6 +1561,23 @@ This is a paragraph.
     }
 
     #[test]
+    fn mathjax_config_hash_matches_embedded_script() -> TestResult {
+        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use sha2::{Digest, Sha256};
+
+        // The build-time hash must cover exactly the code between the <script>
+        // tags. Recomputing it here keeps build.rs and the runtime wrapping in
+        // sync without any manual step.
+        let inner = MATHJAX_CONFIG_SCRIPT
+            .strip_prefix("<script>")
+            .and_then(|script| script.strip_suffix("</script>"))
+            .ok_or("MathJax config must be wrapped in <script> tags")?;
+        let expected = format!("sha256-{}", STANDARD.encode(Sha256::digest(inner.as_bytes())));
+        assert_eq!(MATHJAX_CONFIG_CSP_HASH, expected);
+        Ok(())
+    }
+
+    #[test]
     fn no_csp_attribute_emits_no_meta() -> TestResult {
         let html = convert("= T\n\nHi.\n", false)?;
         assert!(!html.contains("Content-Security-Policy"));
@@ -1572,23 +1589,6 @@ This is a paragraph.
         let html = convert("= T\n:csp:\n\nHi.\n", true)?;
         assert!(!html.contains("Content-Security-Policy"));
         Ok(())
-    }
-
-    #[test]
-    fn mathjax_config_hash_stays_in_sync() {
-        // Tripwire: the documented CSP hash covers the JS between the <script>
-        // tags. If this length changes, the config changed; recompute
-        // MATHJAX_CONFIG_CSP_HASH (see its doc) and update it here.
-        let inner = MATHJAX_CONFIG_SCRIPT
-            .strip_prefix("<script>")
-            .and_then(|script| script.strip_suffix("</script>"))
-            .unwrap_or_default();
-        assert_eq!(
-            inner.len(),
-            1157,
-            "MathJax config changed; recompute MATHJAX_CONFIG_CSP_HASH"
-        );
-        assert!(MATHJAX_CONFIG_CSP_HASH.starts_with("sha256-"));
     }
 
     #[test]

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -1249,12 +1249,21 @@ mod tests {
         input: &str,
         variant: crate::HtmlVariant,
     ) -> Result<(String, Vec<Warning>), Box<dyn std::error::Error>> {
+        render_with_safe_mode(input, variant, acdc_parser::SafeMode::Unsafe)
+    }
+
+    fn render_with_safe_mode(
+        input: &str,
+        variant: crate::HtmlVariant,
+        safe_mode: acdc_parser::SafeMode,
+    ) -> Result<(String, Vec<Warning>), Box<dyn std::error::Error>> {
         let parser_options =
             ParserOptions::with_attributes(acdc_converters_core::default_rendering_attributes());
         let parsed = acdc_parser::parse(input, &parser_options)?;
         let doc = parsed.document();
         let options = ConverterOptions::builder()
             .generator_metadata(GeneratorMetadata::new("acdc", "0.1.0"))
+            .safe_mode(safe_mode)
             .build();
         let processor = Processor::new_with_variant(options, doc.attributes.clone(), variant);
         let mut output = Vec::new();
@@ -1616,6 +1625,38 @@ mod tests {
             .ok_or("player script must be wrapped in <script> tags")?;
         let expected = format!("sha256-{}", STANDARD.encode(Sha256::digest(inner.as_bytes())));
         assert_eq!(super::REPLAY_PLAYER_SCRIPT_CSP_HASH, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn terminal_rendering_degrades_to_listing_under_server_safe_mode() -> TestResult {
+        // The emulator feeds document-controlled bytes through libghostty-vt, so
+        // at Server/Secure it must not run: the block falls back to a plain
+        // listing and the author is told why.
+        let input = "= Example\n\n[terminal%replay,format=asciicast]\n----\n{\"version\":2,\"width\":30,\"height\":5}\n[0.0,\"o\",\"hi\\r\\n\"]\n----\n";
+        let (html, warnings) = render_with_safe_mode(
+            input,
+            crate::HtmlVariant::Standard,
+            acdc_parser::SafeMode::Server,
+        )?;
+
+        // Match the rendered element, not the `.terminal-view` CSS rule that the
+        // embedded stylesheet always carries.
+        assert!(
+            !html.contains("class=\"terminal-view"),
+            "emulator preview should not render under Server safe mode, got: {html}"
+        );
+        assert!(!html.contains(super::REPLAY_PLAYER_SCRIPT_CSP_HASH));
+        assert!(
+            html.contains("class=\"listingblock\""),
+            "expected plain listing fallback, got: {html}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.message.contains("terminal rendering is disabled")),
+            "expected a safe-mode fallback warning, got: {warnings:?}"
+        );
         Ok(())
     }
 

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -1,6 +1,23 @@
-//! HTML rendering for terminal-styled blocks: selectable cell-grid previews of
-//! terminal/source listings and terminal sessions, plus animated replay of
-//! recorded terminal output (raw ANSI and asciicast) as a CSS filmstrip.
+//! HTML rendering for terminal blocks.
+//!
+//! One "terminal screen" renderer (a `libghostty-vt` cell grid captured into
+//! acdc-owned rows, then written as styled HTML) drives two modes:
+//!
+//! - **static** — a single snapshot: `[terminal]` session/literal blocks and
+//!   `:terminal-preview:` source blocks. Rendered by [`render_static`].
+//! - **replay** — animated playback of recorded output (raw ANSI or asciicast)
+//!   via a small inline JS player ([`render_replay_player`]); the final frame is
+//!   server-rendered so no-JS / reduced-motion readers still see it.
+//!
+//! Both modes share the base CSS class `.terminal-view` (the box, the
+//! `.terminal-view--light`/`--dark` theme colours, and the static `.terminal-view__screen`
+//! `<pre>`). A replay additionally carries the `.terminal-view--replay` marker (which
+//! is also the player's JS hook) and its own inner structure —
+//! `.terminal-view__viewport` > `.terminal-view__stream` > `.terminal-view__row`. A recording
+//! that carried its own theme is painted with inline colours; otherwise the
+//! `.terminal-view--{light,dark}` class colours it. The authoring surface keeps the
+//! `terminal-preview`/`terminal`/`replay` names; only the rendered classes use
+//! the `terminal-view` hierarchy.
 
 use std::{borrow::Cow, io::Write};
 
@@ -44,35 +61,6 @@ impl Theme {
             Self::Dark
         } else {
             Self::Light
-        }
-    }
-
-    const fn colors(self) -> (Rgb, Rgb) {
-        match self {
-            Self::Dark => (
-                Rgb {
-                    r: 13,
-                    g: 17,
-                    b: 23,
-                },
-                Rgb {
-                    r: 230,
-                    g: 237,
-                    b: 243,
-                },
-            ),
-            Self::Light => (
-                Rgb {
-                    r: 246,
-                    g: 248,
-                    b: 250,
-                },
-                Rgb {
-                    r: 31,
-                    g: 35,
-                    b: 40,
-                },
-            ),
         }
     }
 
@@ -205,7 +193,7 @@ fn render_with_options<W: Write>(
     let size = preview_options.size_for_output(&ansi);
     let grid = capture_ansi(&ansi, size)?;
 
-    render_grid(&mut writer, &grid, preview_options.theme)?;
+    render_static(&mut writer, &grid, preview_options.theme)?;
     Ok(())
 }
 
@@ -328,7 +316,7 @@ fn render_replay_ansi<W: Write>(
         // the final screen.
         diagnostics.warn(REPLAY_NO_FRAMES_MESSAGE);
         let grid = capture_ansi(&ansi, size)?;
-        return render_grid(&mut writer, &grid, preview_options.theme);
+        return render_static(&mut writer, &grid, preview_options.theme);
     }
     // Raw ANSI carries no recorded theme or title, so the player uses the
     // generic light/dark colours and emits no `data-title`.
@@ -518,7 +506,7 @@ fn render_blank_preview<W: Write>(
     theme: Theme,
 ) -> Result<(), Error> {
     let grid = capture_ansi(&[], size)?;
-    render_grid(writer, &grid, theme)
+    render_static(writer, &grid, theme)
 }
 
 fn replay_size(
@@ -696,20 +684,19 @@ fn normalize_terminal_newlines(ansi: &[u8]) -> Vec<u8> {
     normalized
 }
 
-fn render_grid<W: Write>(writer: &mut W, grid: &CellGrid, theme: Theme) -> Result<(), Error> {
-    let (bg, fg) = theme.colors();
+fn render_static<W: Write>(writer: &mut W, grid: &CellGrid, theme: Theme) -> Result<(), Error> {
+    // Colours come from the `.terminal-view--{light,dark}` stylesheet classes, so they
+    // are overridable with plain CSS (no inline style to fight).
     write!(
         writer,
-        "<div class=\"terminal-preview terminal-preview--{}\" style=\"background-color:{};color:{}\" data-cols=\"{}\" data-rows=\"{}\">",
+        "<div class=\"terminal-view terminal-view--{}\" data-cols=\"{}\" data-rows=\"{}\">",
         theme.as_str(),
-        rgb_css(bg),
-        rgb_css(fg),
         grid.cols(),
         grid.rows()
     )?;
     writeln!(
         writer,
-        "<pre class=\"terminal-preview__screen\" aria-label=\"Terminal preview\">"
+        "<pre class=\"terminal-view__screen\" aria-label=\"Terminal preview\">"
     )?;
     for (row_index, row) in grid.rows_iter().enumerate() {
         render_row(writer, row)?;
@@ -739,7 +726,7 @@ pub const REPLAY_PLAYER_SCRIPT: &str = concat!(
 /// tags). If you edit that file, recompute it with:
 /// `openssl dgst -sha256 -binary static/terminal-replay-player.js | openssl base64`
 pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str =
-    "sha256-UCil6i+s7nDZjHY7yXxLIM0dkhXJFMvaoxLaoHlYXDQ=";
+    "sha256-z2t/X8Ok+lAYeDw8UsWjjM7TntIjoggVHhJSfFmhTyQ=";
 
 /// Render a recording as an interactive replay player. This is the single
 /// renderer for every replay block (raw ANSI and asciicast alike).
@@ -760,15 +747,14 @@ pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str =
 /// # CSS contract
 ///
 /// acdc emits no window chrome; the markup is class-based so a consumer (e.g. an
-/// embedding editor) can add its own. The stable seams are the classes
-/// `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__viewport`,
-/// `.terminal-replay__screen`, `.terminal-replay__row`, the `data-title`
-/// attribute (the recorded title, present only when the recording carried one,
-/// for building custom chrome via `::before{content:attr(data-title)}`), the
-/// custom properties `--acdc-term-bg`/`--acdc-term-fg` (the recorded theme,
-/// emitted inline on the container) and the stylesheet-defaulted
-/// `--acdc-term-font-family`/`--acdc-term-font-size`/`--acdc-term-line-height`/
-/// `--acdc-term-radius`/`--acdc-term-padding`.
+/// embedding editor) can add its own. The stable seams are the base class
+/// `.terminal`, the `.terminal-view--replay` marker (also the player's JS hook), the
+/// inner `.terminal-view__viewport` > `.terminal-view__stream` > `.terminal-view__row`, and the
+/// `data-title` attribute (the recorded title, present only when the recording
+/// carried one, for building custom chrome via `::before{content:attr(data-title)}`).
+/// A theme-less replay takes its colours from the `.terminal-view--{light,dark}` class
+/// (overridable with plain CSS); a recording's own theme is painted inline
+/// (override it with `!important`).
 ///
 /// Per-cell colours are emitted as inline `style` colours (resolved against the
 /// recording's own palette via [`resolve_cell_color`]), matching the static
@@ -821,17 +807,25 @@ fn render_replay_player<W: Write>(
         })
         .collect();
 
-    // Recorded theme colours win over the generic light/dark default.
-    let (bg, fg) = recorded.map_or_else(|| theme.colors(), |t| (t.bg, t.fg));
+    // A recording that carried its own theme is painted faithfully with an inline
+    // background/foreground (its palette also colours the cells). Without one (raw
+    // ANSI, or a theme-less cast) the generic `.terminal-view--{light,dark}`
+    // class colours it, so no inline style is emitted and a consumer can restyle
+    // it with plain CSS.
+    let colour_style = recorded.map_or_else(String::new, |t| {
+        format!(
+            " style=\"background-color:{};color:{}\"",
+            rgb_css(t.bg),
+            rgb_css(t.fg)
+        )
+    });
 
     // The replay rests on the full terminal height, so the configured `rows` is
     // also the minimum number of lines shown at the end of the run: the box
     // stays `rows` tall instead of collapsing to the final line's content.
     let final_rows = rows;
 
-    // The container carries the per-recording theme bg/fg as custom properties
-    // (cell colours are inline per span; everything else is class-based). acdc
-    // emits no window chrome; the recorded title, when present, is exposed as
+    // acdc emits no window chrome; the recorded title, when present, is exposed as
     // `data-title` so a consumer can render its own chrome in CSS
     // (`::before{content:attr(data-title)}`).
     let title_attr = title.map_or_else(String::new, |title| {
@@ -839,10 +833,9 @@ fn render_replay_player<W: Write>(
     });
     writeln!(
         writer,
-        "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--{}\" style=\"--acdc-term-bg:{};--acdc-term-fg:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\"{}>",
+        "<div class=\"terminal-view terminal-view--replay terminal-view--{}\"{} data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\"{}>",
         theme.as_str(),
-        rgb_css(bg),
-        rgb_css(fg),
+        colour_style,
         cols,
         rows,
         frames.len(),
@@ -856,13 +849,13 @@ fn render_replay_player<W: Write>(
     // animates from there.
     writeln!(
         writer,
-        "<div class=\"terminal-replay__viewport\"><div class=\"terminal-replay__screen\" aria-label=\"Terminal replay\">"
+        "<div class=\"terminal-view__viewport\"><div class=\"terminal-view__stream\" aria-label=\"Terminal replay\">"
     )?;
     let final_frame = frame_rows.last().map_or(&[] as &[usize], Vec::as_slice);
     for index in final_frame.iter().take(final_rows) {
         writeln!(
             writer,
-            "<div class=\"terminal-replay__row\">{}</div>",
+            "<div class=\"terminal-view__row\">{}</div>",
             pool.get(*index).map_or("", String::as_str)
         )?;
     }
@@ -872,7 +865,7 @@ fn render_replay_player<W: Write>(
     // recorded content can break out of the script element.
     write!(
         writer,
-        "<script type=\"application/json\" class=\"terminal-replay__data\">"
+        "<script type=\"application/json\" class=\"terminal-view__data\">"
     )?;
     write_replay_json(
         &mut writer,
@@ -1287,15 +1280,17 @@ mod tests {
         )?;
 
         assert!(html.contains("<div id=\"content\">"));
-        assert!(html.contains("<div class=\"listingblock terminal-preview-block\">"));
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
-        assert!(html.contains("background-color:#f6f8fa;color:#1f2328"));
+        assert!(html.contains("<div class=\"listingblock terminal-block\">"));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
+        // Preview colours come from the stylesheet class, not an inline style.
+        assert!(html.contains(".terminal-view--light{background-color:#f6f8fa;color:#1f2328}"));
+        assert!(html.contains("terminal-view--light\" data-cols="));
         assert!(html.contains("$</span>"));
         assert!(html.contains(" acdc"));
         assert!(html.contains("--version"));
         assert!(html.contains("0.2.0"));
         let preview_offset = html
-            .find("terminal-preview")
+            .find("terminal-view terminal-view--")
             .ok_or("missing terminal preview")?;
         let after_offset = html
             .find("After preview.")
@@ -1312,8 +1307,8 @@ mod tests {
         )?;
 
         assert!(html.contains("<main id=\"content\">"));
-        assert!(html.contains("listing-block terminal-preview-block"));
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(html.contains("listing-block terminal-block"));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
         assert!(html.contains("$</span>"));
         assert!(html.contains(" echo semantic"));
         Ok(())
@@ -1326,8 +1321,10 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--dark\""));
-        assert!(html.contains("background-color:#0d1117;color:#e6edf3"));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--dark\""));
+        // Preview colours come from the stylesheet class, not an inline style.
+        assert!(html.contains(".terminal-view--dark{background-color:#0d1117;color:#e6edf3}"));
+        assert!(html.contains("terminal-view--dark\" data-cols="));
         Ok(())
     }
 
@@ -1352,8 +1349,8 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("<div class=\"terminalblock terminal-preview-block\">"));
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(html.contains("<div class=\"terminalblock terminal-block\">"));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
         assert!(html.contains("$ cargo build"));
         assert!(html.contains(">error</span>"));
         assert!(html.contains("<span style=\"color:"));
@@ -1367,10 +1364,10 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
         assert!(html.contains("data-cols=\"12\""));
         assert!(html.contains("data-rows=\"4\""));
-        assert!(html.contains("background-color:#f6f8fa;color:#1f2328"));
+        assert!(html.contains(".terminal-view--light{background-color:#f6f8fa;color:#1f2328}"));
         Ok(())
     }
 
@@ -1381,10 +1378,10 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--dark\""));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--dark\""));
         assert!(html.contains("data-cols=\"12\""));
         assert!(html.contains("data-rows=\"7\""));
-        assert!(html.contains("background-color:#0d1117;color:#e6edf3"));
+        assert!(html.contains(".terminal-view--dark{background-color:#0d1117;color:#e6edf3}"));
         Ok(())
     }
 
@@ -1395,9 +1392,9 @@ mod tests {
             crate::HtmlVariant::Semantic,
         )?;
 
-        assert!(html.contains("<figure class=\"terminal-block terminal-preview-block\""));
+        assert!(html.contains("<figure class=\"terminal-block\""));
         assert!(html.contains("<figcaption>Terminal</figcaption>"));
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
         assert!(html.contains("$ echo semantic"));
         Ok(())
     }
@@ -1409,7 +1406,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("<div class=\"terminalblock terminal-preview-block\">"));
+        assert!(html.contains("<div class=\"terminalblock terminal-block\">"));
         assert!(html.contains("data-cols=\"20\""));
         assert!(html.contains("$ echo literal"));
         Ok(())
@@ -1425,18 +1422,18 @@ mod tests {
         // Raw ANSI replay renders through the same JS player as asciicast: a
         // player container, an inline JSON payload, the shared init script, and
         // server-rendered rows. No CSS filmstrip and no window chrome.
-        assert!(html.contains(
-            "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--light\""
-        ));
+        assert!(
+            html.contains(
+                "<div class=\"terminal-view terminal-view--replay terminal-view--light\""
+            )
+        );
         assert!(html.contains("data-cols=\"20\""));
         assert!(html.contains("data-rows=\"4\""));
         assert!(html.contains("data-frames=\"2\""));
         assert!(html.contains("data-duration-ms=\"1000\""));
-        assert!(
-            html.contains("<script type=\"application/json\" class=\"terminal-replay__data\">")
-        );
+        assert!(html.contains("<script type=\"application/json\" class=\"terminal-view__data\">"));
         assert!(html.contains("window.__acdcReplayInit"));
-        assert!(html.contains("class=\"terminal-replay__row\""));
+        assert!(html.contains("class=\"terminal-view__row\""));
         // No CSS filmstrip leftovers and no chrome (raw ANSI carries no title).
         assert!(!html.contains("@keyframes terminal-replay-scroll"));
         assert!(!html.contains("terminal-replay__scroll"));
@@ -1456,7 +1453,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        let payloads = html.matches("class=\"terminal-replay__data\"").count();
+        let payloads = html.matches("class=\"terminal-view__data\"").count();
         assert_eq!(payloads, 2, "each replay block emits its own data payload");
         assert!(html.contains("window.__acdcReplayInit"));
         Ok(())
@@ -1527,7 +1524,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("terminal-replay--player"));
+        assert!(html.contains("terminal-view--replay"));
         assert!(html.contains("Working 0%"));
         assert!(html.contains("Working 50%"));
         assert!(html.contains("Working 100%"));
@@ -1542,8 +1539,8 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(!html.contains("terminal-preview terminal-replay"));
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(!html.contains("terminal-view terminal-view--replay"));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
         assert!(warnings.iter().any(|warning| {
             warning
                 .message
@@ -1564,18 +1561,46 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains(
-            "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--light\""
-        ));
-        // A JSON payload + the shared inline player drive the row swaps.
         assert!(
-            html.contains("<script type=\"application/json\" class=\"terminal-replay__data\">")
+            html.contains(
+                "<div class=\"terminal-view terminal-view--replay terminal-view--light\""
+            )
         );
+        // A JSON payload + the shared inline player drive the row swaps.
+        assert!(html.contains("<script type=\"application/json\" class=\"terminal-view__data\">"));
         assert!(html.contains("window.__acdcReplayInit"));
         // Final frame is server-rendered (no-JS / reduced-motion fallback).
-        assert!(html.contains("class=\"terminal-replay__row\""));
+        assert!(html.contains("class=\"terminal-view__row\""));
         assert!(html.contains("first"));
         assert!(html.contains("second"));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_replay_with_recorded_theme_inlines_its_colours() -> TestResult {
+        // A cast that recorded its own theme is painted faithfully: the recorded
+        // background/foreground are inlined on the container.
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast,cols=20,rows=4]\n----\n{\"version\":2,\"width\":20,\"height\":4,\"theme\":{\"fg\":\"#c0caf5\",\"bg\":\"#1a1b26\",\"palette\":\"#000000:#ff0000:#00ff00:#ffff00:#0000ff:#ff00ff:#00ffff:#ffffff\"}}\n[0.0,\"o\",\"first\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("terminal-view--replay"));
+        assert!(html.contains("style=\"background-color:#1a1b26;color:#c0caf5\""));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_replay_without_recorded_theme_is_class_based() -> TestResult {
+        // A theme-less cast takes its colours from `.terminal-view--{theme}`,
+        // so the container carries no inline colour (overridable with plain CSS).
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast,cols=20,rows=4]\n----\n{\"version\":2,\"width\":20,\"height\":4}\n[0.0,\"o\",\"first\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("terminal-view--replay terminal-view--light\" data-cols="));
+        assert!(!html.contains("terminal-view--replay terminal-view--light\" style="));
         Ok(())
     }
 
@@ -1590,7 +1615,7 @@ mod tests {
             .unwrap_or_default();
         assert_eq!(
             inner.len(),
-            2666,
+            2656,
             "player script changed; recompute REPLAY_PLAYER_SCRIPT_CSP_HASH"
         );
         assert!(super::REPLAY_PLAYER_SCRIPT_CSP_HASH.starts_with("sha256-"));
@@ -1603,7 +1628,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("terminal-preview terminal-replay"));
+        assert!(html.contains("terminal-view terminal-view--replay"));
         assert!(html.contains("data-cols=\"30\""));
         assert!(html.contains("data-rows=\"5\""));
         Ok(())
@@ -1628,7 +1653,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("terminal-preview terminal-replay"));
+        assert!(html.contains("terminal-view terminal-view--replay"));
         assert!(html.contains("alpha"));
         assert!(html.contains("beta"));
         Ok(())
@@ -1680,8 +1705,8 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(!html.contains("terminal-preview terminal-replay"));
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(!html.contains("terminal-view terminal-view--replay"));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
         assert!(
             warnings
                 .iter()
@@ -1697,7 +1722,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("terminal-preview terminal-replay"));
+        assert!(html.contains("terminal-view terminal-view--replay"));
         assert!(warnings.iter().any(|warning| {
             warning
                 .message
@@ -1720,7 +1745,9 @@ mod tests {
     fn skips_terminal_preview_without_attribute() -> TestResult {
         let html = render("= Example\n\nPlain HTML\n", crate::HtmlVariant::Standard)?;
 
-        assert!(!html.contains("terminal-preview--"));
+        // No preview container is rendered (the `.terminal-view--*` rules in the
+        // embedded stylesheet don't count).
+        assert!(!html.contains("<div class=\"terminal-view terminal-view--"));
         assert!(html.contains("Plain HTML"));
         Ok(())
     }
@@ -1733,9 +1760,9 @@ mod tests {
         )?;
 
         assert!(html.contains(r#"<link rel="stylesheet" href="./asciidoctor-light-mode.css">"#));
-        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
-        assert!(!html.contains(".terminal-preview{"));
-        assert!(!html.contains(".terminal-preview__screen{"));
+        assert!(html.contains("<div class=\"terminal-view terminal-view--light\""));
+        assert!(!html.contains(".terminal-view{"));
+        assert!(!html.contains(".terminal-view__screen{"));
         Ok(())
     }
 

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -1,9 +1,12 @@
-//! Selectable HTML rendering for terminal cell-grid previews.
+//! HTML rendering for terminal-styled blocks: selectable cell-grid previews of
+//! terminal/source listings and terminal sessions, plus animated replay of
+//! recorded terminal output (raw ANSI and asciicast) as a CSS filmstrip.
 
 use std::{borrow::Cow, io::Write};
 
 use acdc_converters_core::{Diagnostics, Options, code::detect_language};
 use acdc_converters_terminal::{
+    asciicast,
     cell_grid::{Cell, CellDecorations, CellGrid, Rgb, TerminalSize, capture_ansi},
     replay::{self, Options as ReplayOptions},
 };
@@ -15,10 +18,16 @@ const DEFAULT_COLS: usize = 80;
 const AUTO_ROW_PADDING: usize = 1;
 const MAX_AUTO_ROWS: usize = 200;
 const REPLAY_OPTION: &str = "replay";
+const REPLAY_FORMAT_ATTR: &str = "format";
 const REPLAY_FRAME_DURATION_MS: u64 = 500;
+const REPLAY_FRAME_DURATION: std::time::Duration =
+    std::time::Duration::from_millis(REPLAY_FRAME_DURATION_MS);
 const REPLAY_DURATION_MS_ATTR: &str = "replay-duration-ms";
+const REPLAY_IDLE_LIMIT_MS_ATTR: &str = "replay-idle-limit-ms";
 const REPLAY_RENDER_FPS: u128 = 30;
 const MAX_REPLAY_RENDER_FRAMES: usize = 120;
+const REPLAY_NO_FRAMES_MESSAGE: &str =
+    "terminal replay produced no visible frames; rendering a static terminal preview instead";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Theme {
@@ -210,8 +219,63 @@ fn render_with_options<W: Write>(
     Ok(())
 }
 
+/// The recording format a `[terminal%replay]` block carries. Selected by the
+/// `format` block attribute; absent defaults to the original raw-ANSI format.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReplayFormat {
+    Ansi,
+    Asciicast,
+}
+
+fn replay_format(metadata: &BlockMetadata<'_>, diagnostics: &mut Diagnostics<'_>) -> ReplayFormat {
+    let Some(value) = metadata.attributes.get(REPLAY_FORMAT_ATTR) else {
+        return ReplayFormat::Ansi;
+    };
+    match value.to_string().trim().to_ascii_lowercase().as_str() {
+        "" | "ansi" => ReplayFormat::Ansi,
+        "asciicast" | "cast" => ReplayFormat::Asciicast,
+        other => {
+            diagnostics.warn(format!(
+                "unknown terminal replay `format` value `{other}`; expected `ansi` or `asciicast`. Replaying as raw ANSI."
+            ));
+            ReplayFormat::Ansi
+        }
+    }
+}
+
 fn render_replay<W: Write>(
-    mut writer: W,
+    writer: W,
+    inlines: &[InlineNode<'_>],
+    metadata: &BlockMetadata<'_>,
+    options: Options,
+    attrs: &DocumentAttributes<'_>,
+    preview_options: PreviewOptions,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Result<(), Error> {
+    match replay_format(metadata, diagnostics) {
+        ReplayFormat::Ansi => render_replay_ansi(
+            writer,
+            inlines,
+            metadata,
+            options,
+            attrs,
+            preview_options,
+            diagnostics,
+        ),
+        ReplayFormat::Asciicast => render_replay_asciicast(
+            writer,
+            inlines,
+            metadata,
+            options,
+            attrs,
+            preview_options,
+            diagnostics,
+        ),
+    }
+}
+
+fn render_replay_ansi<W: Write>(
+    writer: W,
     inlines: &[InlineNode<'_>],
     metadata: &BlockMetadata<'_>,
     options: Options,
@@ -222,12 +286,7 @@ fn render_replay<W: Write>(
     let Some(size) = replay_size(attrs, metadata, diagnostics) else {
         return render_with_options(writer, inlines, metadata, options, attrs, preview_options);
     };
-    let playback_duration = positive_attr(
-        REPLAY_DURATION_MS_ATTR,
-        metadata.attributes.get(REPLAY_DURATION_MS_ATTR),
-        diagnostics,
-    )
-    .map(|ms| std::time::Duration::from_millis(ms as u64));
+    let playback_duration = replay_playback_override(metadata, diagnostics);
 
     let ansi = normalize_terminal_newlines(&acdc_converters_terminal::render_listing_to_ansi(
         options,
@@ -238,8 +297,7 @@ fn render_replay<W: Write>(
         preview_options.theme == Theme::Dark,
     )?);
     let boundaries = chunk_boundaries(&ansi);
-    let frame_duration = std::time::Duration::from_millis(REPLAY_FRAME_DURATION_MS);
-    let estimated_playback_ms = frame_duration
+    let estimated_playback_ms = REPLAY_FRAME_DURATION
         .as_millis()
         .saturating_mul(boundaries.len() as u128)
         .max(1);
@@ -250,7 +308,7 @@ fn render_replay<W: Write>(
         &ansi,
         &boundaries,
         replay_frame_budget(playback_ms),
-        frame_duration,
+        REPLAY_FRAME_DURATION,
     );
 
     // Append-only recordings (logs, build/test output) can be captured into a
@@ -266,28 +324,170 @@ fn render_replay<W: Write>(
         // counting bytes over-estimates display width, so it never
         // under-allocates.
         let tall = TerminalSize::new(size.cols, estimate_rows(&ansi, size.cols).max(size.rows));
-        let replay_options = ReplayOptions::new(tall).with_default_frame_duration(frame_duration);
+        let replay_options =
+            ReplayOptions::new(tall).with_default_frame_duration(REPLAY_FRAME_DURATION);
         replay::capture_windowed(events, replay_options, size.rows)?.into_frames()
     } else {
-        let replay_options = ReplayOptions::new(size).with_default_frame_duration(frame_duration);
+        let replay_options =
+            ReplayOptions::new(size).with_default_frame_duration(REPLAY_FRAME_DURATION);
         replay::capture(events, replay_options)?.into_frames()
     };
 
-    if frames.is_empty() {
-        diagnostics.warn(
-            "terminal replay produced no visible frames; rendering a static terminal preview instead",
-        );
-        let grid = capture_ansi(&ansi, size)?;
-        return render_grid(&mut writer, &grid, preview_options.theme);
-    }
-
-    render_replay_filmstrip(
-        &mut writer,
+    finish_replay(
+        writer,
         &frames,
         preview_options.theme,
         playback_duration,
-    )?;
-    Ok(())
+        diagnostics,
+        |writer| {
+            let grid = capture_ansi(&ansi, size)?;
+            render_grid(writer, &grid, preview_options.theme)
+        },
+    )
+}
+
+fn render_replay_asciicast<W: Write>(
+    mut writer: W,
+    inlines: &[InlineNode<'_>],
+    metadata: &BlockMetadata<'_>,
+    options: Options,
+    attrs: &DocumentAttributes<'_>,
+    preview_options: PreviewOptions,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Result<(), Error> {
+    // `replay-idle-limit-ms` caps dead air (e.g. a build before a test run) so
+    // playback dwells on real output; absent, the header or a default applies.
+    let idle_limit = positive_attr(
+        REPLAY_IDLE_LIMIT_MS_ATTR,
+        metadata.attributes.get(REPLAY_IDLE_LIMIT_MS_ATTR),
+        diagnostics,
+    )
+    .map(|ms| std::time::Duration::from_millis(ms as u64));
+
+    let recording = match asciicast::parse_inlines_with(inlines, idle_limit) {
+        Ok(recording) => recording,
+        Err(err) => {
+            diagnostics.warn_with_advice(
+                format!(
+                    "could not parse asciicast replay: {err}; rendering a static terminal preview instead"
+                ),
+                "Provide a valid asciicast v2 or v3 recording, or drop `format=asciicast` to replay raw ANSI.",
+            );
+            return render_with_options(writer, inlines, metadata, options, attrs, preview_options);
+        }
+    };
+
+    // Block `cols`/`rows` override the recording; the asciicast header supplies
+    // the size otherwise, so dimensions are never required on the block.
+    let size = replay_size_with_default(attrs, metadata, recording.size(), diagnostics);
+    let playback_duration = replay_playback_override(metadata, diagnostics);
+    // Header metadata paints the replay chrome; read it before `capture` consumes
+    // the recording.
+    let recorded_theme = recording.theme();
+    let title = recording.title().map(str::to_owned);
+
+    // Capture every distinct screen the session produced (deduplicated, but never
+    // sampled): a terminal session may rewrite the screen in place (progress
+    // bars, status lines, full-screen TUIs), so faithful playback needs each
+    // visible state, not a scrolled window of one transcript. Capture errors are
+    // caught here because the events come from user-supplied cast data, not acdc.
+    let frames = match recording.capture(size, usize::MAX, REPLAY_FRAME_DURATION) {
+        Ok(timeline) => timeline.into_frames(),
+        Err(err) => {
+            diagnostics.warn(format!(
+                "asciicast replay capture failed: {err}; rendering a static terminal preview instead"
+            ));
+            return render_blank_preview(&mut writer, size, preview_options.theme);
+        }
+    };
+
+    if frames.is_empty() {
+        diagnostics.warn(REPLAY_NO_FRAMES_MESSAGE);
+        return render_blank_preview(&mut writer, size, preview_options.theme);
+    }
+
+    render_replay_player(
+        writer,
+        &frames,
+        preview_options.theme,
+        recorded_theme,
+        title.as_deref(),
+        playback_duration,
+    )
+}
+
+/// The `replay-duration-ms` playback override, if set to a positive integer.
+fn replay_playback_override(
+    metadata: &BlockMetadata<'_>,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Option<std::time::Duration> {
+    positive_attr(
+        REPLAY_DURATION_MS_ATTR,
+        metadata.attributes.get(REPLAY_DURATION_MS_ATTR),
+        diagnostics,
+    )
+    .map(|ms| std::time::Duration::from_millis(ms as u64))
+}
+
+/// Render captured replay `frames` as a filmstrip, or, when capture produced no
+/// visible frames, warn and let `on_empty` render a static fallback preview.
+/// Shared by both replay formats; only the fallback differs between them.
+fn finish_replay<W: Write>(
+    mut writer: W,
+    frames: &[replay::Frame],
+    theme: Theme,
+    playback_duration: Option<std::time::Duration>,
+    diagnostics: &mut Diagnostics<'_>,
+    on_empty: impl FnOnce(&mut W) -> Result<(), Error>,
+) -> Result<(), Error> {
+    if frames.is_empty() {
+        diagnostics.warn(REPLAY_NO_FRAMES_MESSAGE);
+        return on_empty(&mut writer);
+    }
+    render_replay_filmstrip(&mut writer, frames, theme, playback_duration)
+}
+
+/// Resolve the replay terminal size, letting block `cols`/`rows` (or the
+/// `terminal-cols`/`terminal-rows` block/document attributes) override
+/// `default`. Unlike [`replay_size`], a missing size is not a warning here
+/// because the asciicast header supplies the default.
+fn replay_size_with_default(
+    attrs: &DocumentAttributes<'_>,
+    metadata: &BlockMetadata<'_>,
+    default: TerminalSize,
+    diagnostics: &mut Diagnostics<'_>,
+) -> TerminalSize {
+    let cols = replay_dimension(attrs, metadata, "cols", "terminal-cols", diagnostics)
+        .unwrap_or(default.cols);
+    let rows = replay_dimension(attrs, metadata, "rows", "terminal-rows", diagnostics)
+        .unwrap_or(default.rows);
+    TerminalSize::new(cols, rows)
+}
+
+/// Resolve one replay dimension by checking, in order: the block's `primary`
+/// attribute (`cols`/`rows`), the block's `document` attribute
+/// (`terminal-cols`/`terminal-rows`), then the document attribute of the same
+/// name. Returns `None` when none is set; a present but non-positive value is
+/// warned about by [`positive_attr`].
+fn replay_dimension(
+    attrs: &DocumentAttributes<'_>,
+    metadata: &BlockMetadata<'_>,
+    primary: &'static str,
+    document: &'static str,
+    diagnostics: &mut Diagnostics<'_>,
+) -> Option<usize> {
+    positive_attr(primary, metadata.attributes.get(primary), diagnostics)
+        .or_else(|| positive_attr(document, metadata.attributes.get(document), diagnostics))
+        .or_else(|| positive_attr(document, attrs.get(document), diagnostics))
+}
+
+fn render_blank_preview<W: Write>(
+    writer: &mut W,
+    size: TerminalSize,
+    theme: Theme,
+) -> Result<(), Error> {
+    let grid = capture_ansi(&[], size)?;
+    render_grid(writer, &grid, theme)
 }
 
 fn replay_size(
@@ -295,24 +495,8 @@ fn replay_size(
     metadata: &BlockMetadata<'_>,
     diagnostics: &mut Diagnostics<'_>,
 ) -> Option<TerminalSize> {
-    let cols = positive_attr("cols", metadata.attributes.get("cols"), diagnostics)
-        .or_else(|| {
-            positive_attr(
-                "terminal-cols",
-                metadata.attributes.get("terminal-cols"),
-                diagnostics,
-            )
-        })
-        .or_else(|| positive_attr("terminal-cols", attrs.get("terminal-cols"), diagnostics));
-    let rows = positive_attr("rows", metadata.attributes.get("rows"), diagnostics)
-        .or_else(|| {
-            positive_attr(
-                "terminal-rows",
-                metadata.attributes.get("terminal-rows"),
-                diagnostics,
-            )
-        })
-        .or_else(|| positive_attr("terminal-rows", attrs.get("terminal-rows"), diagnostics));
+    let cols = replay_dimension(attrs, metadata, "cols", "terminal-cols", diagnostics);
+    let rows = replay_dimension(attrs, metadata, "rows", "terminal-rows", diagnostics);
 
     if let (Some(cols), Some(rows)) = (cols, rows) {
         Some(TerminalSize::new(cols, rows))
@@ -379,7 +563,7 @@ fn sampled_events<'a>(
     frame_budget: usize,
     frame_duration: std::time::Duration,
 ) -> Vec<replay::Event<'a>> {
-    let sampled = sampled_indexes(boundaries.len(), frame_budget);
+    let sampled = replay::sampled_indexes(boundaries.len(), frame_budget);
     let mut events = Vec::with_capacity(sampled.len());
     let mut start = 0;
 
@@ -537,7 +721,7 @@ fn render_replay_filmstrip<W: Write>(
 
     write!(
         writer,
-        "<div class=\"terminal-preview terminal-replay terminal-preview--{}\" style=\"background-color:{};color:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\">",
+        "<div class=\"terminal-preview terminal-replay terminal-preview--{}\" style=\"--acdc-term-bg:{};--acdc-term-fg:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\">",
         theme.as_str(),
         rgb_css(bg),
         rgb_css(fg),
@@ -585,6 +769,388 @@ fn render_replay_filmstrip<W: Write>(
     writeln!(writer, "</div>")?;
     writeln!(writer, "</div>")?;
     Ok(())
+}
+
+/// A tiny, self-contained vanilla-JS player shared by every replay block on the
+/// page. It reads each block's JSON payload, swaps the visible rows on a clock
+/// (only touching rows that actually change), and honours `prefers-reduced-motion`
+/// by leaving the server-rendered final frame in place. Defining
+/// `__acdcReplayInit` is idempotent, so emitting this once per block is safe;
+/// every call initialises any not-yet-initialised player on the page.
+const REPLAY_PLAYER_SCRIPT: &str = "<script>(function(){function init(el){el.setAttribute('data-acdc-ready','1');var dataEl=el.querySelector('script.terminal-replay__data');if(!dataEl)return;var d;try{d=JSON.parse(dataEl.textContent);}catch(e){return;}var screen=el.querySelector('.terminal-replay__screen');if(!screen)return;if(window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches)return;while(screen.children.length<d.rows){var r=document.createElement('div');r.className='terminal-replay__row';screen.appendChild(r);}var slots=screen.querySelectorAll('.terminal-replay__row');function show(s,on){slots[s].style.display=on?'':'none';}function fill(){for(var s=d.finalRows;s<slots.length;s++)show(s,true);}function trim(){for(var s=d.finalRows;s<slots.length;s++)show(s,false);}function apply(f){var idx=d.frames[f];for(var s=0;s<idx.length;s++){var h=d.pool[idx[s]];if(slots[s].__h!==h){slots[s].innerHTML=h;slots[s].__h=h;}}}fill();apply(0);var n=d.frames.length,i=0,start=null;function step(ts){if(start===null)start=ts;var t=ts-start;while(i<n-1&&d.times[i+1]<=t)i++;apply(i);if(i<n-1){requestAnimationFrame(step);}else{apply(n-1);trim();}}requestAnimationFrame(step);}window.__acdcReplayInit=function(){var els=document.querySelectorAll('.terminal-replay--player:not([data-acdc-ready])');for(var i=0;i<els.length;i++)init(els[i]);};window.__acdcReplayInit();})();</script>";
+
+/// CSP `script-src` source for [`REPLAY_PLAYER_SCRIPT`]'s inline code, so a
+/// consumer can allowlist the player under a strict policy without
+/// `'unsafe-inline'` (e.g. `script-src 'self' 'sha256-...'`). The hash covers the
+/// code *between* the `<script>` tags. If you change `REPLAY_PLAYER_SCRIPT`,
+/// recompute it from a generated file with:
+/// `perl -0ne 'print $1 if m{<script>(\(function.*?\)\(\);)</script>}s' out.html | openssl dgst -sha256 -binary | openssl base64`
+pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str =
+    "sha256-/mhN+UdwCNRQ7MxmgzvMM5DZpJy6Rs63LrQRESyqfNw=";
+
+/// Render a recording as an interactive replay player.
+///
+/// Every distinct visible screen is captured, but identical rows are pooled and
+/// emitted once; each frame is just a list of indices into that pool plus a
+/// timestamp. A small inline script swaps the visible rows on a clock. This
+/// reproduces in-place rewrites (progress bars, status lines, full-screen TUIs)
+/// faithfully and smoothly while keeping the payload compact: a long session
+/// costs one copy of each unique line, not one screen per frame.
+///
+/// The player wears the recording's own colours (when its header carried a
+/// theme) and a terminal-window title bar. The final frame is rendered into the
+/// DOM server-side, so readers with scripting disabled (or who prefer reduced
+/// motion) see the finished screen.
+///
+/// # CSS contract
+///
+/// The window chrome is class-based in the built-in stylesheet, so a consumer
+/// (e.g. an embedding editor) can restyle it. The stable seams are the classes
+/// `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__titlebar`,
+/// `.terminal-replay__dots`, `.terminal-replay__title`,
+/// `.terminal-replay__viewport`, `.terminal-replay__screen`,
+/// `.terminal-replay__row`, plus custom properties `--acdc-term-bg`/
+/// `--acdc-term-fg` (the recorded theme, emitted inline on the container) and the
+/// stylesheet-defaulted `--acdc-term-font-family`/`--acdc-term-font-size`/
+/// `--acdc-term-line-height`/`--acdc-term-radius`/`--acdc-term-padding`.
+///
+/// Per-cell colours are emitted as inline `style` colours (resolved against the
+/// recording's own palette via [`resolve_cell_color`]), matching the static
+/// terminal preview. Under a strict CSP these inline styles need
+/// `style-src 'unsafe-inline'`; the inline player `<script>` can be allowlisted
+/// by hash ([`REPLAY_PLAYER_SCRIPT_CSP_HASH`]) for a script-src without
+/// `'unsafe-inline'`. With the script blocked, the server-rendered final frame
+/// still shows.
+fn render_replay_player<W: Write>(
+    mut writer: W,
+    frames: &[replay::Frame],
+    theme: Theme,
+    recorded: Option<asciicast::ReplayTheme>,
+    title: Option<&str>,
+    playback_duration: Option<std::time::Duration>,
+) -> Result<(), Error> {
+    let rows = frames
+        .iter()
+        .map(|frame| frame.grid.rows())
+        .max()
+        .unwrap_or(1);
+    let cols = frames
+        .iter()
+        .map(|frame| frame.grid.cols())
+        .max()
+        .unwrap_or(0);
+
+    // Pool unique rendered rows; each frame becomes a list of indices into the
+    // pool. Identical lines across frames (most of them) are stored once. Cell
+    // colours are resolved against the recording's own palette (when it carried
+    // one) so the replay shows the colours it was recorded with.
+    let palette = recorded.map_or([None; 16], |theme| theme.palette);
+    let (pool, frame_rows) = build_row_pool(frames, rows, &palette)?;
+
+    // Frame times scale to `replay-duration-ms` when set, else play at the
+    // recording's own (idle-compressed) pace.
+    let record_ms = frames.last().map_or(0, |frame| frame.at.as_millis());
+    let total_ms = playback_duration
+        .map_or(record_ms, |d| d.as_millis())
+        .max(1);
+    let times: Vec<u128> = frames
+        .iter()
+        .map(|frame| {
+            frame
+                .at
+                .as_millis()
+                .saturating_mul(total_ms)
+                .checked_div(record_ms)
+                .unwrap_or(0)
+        })
+        .collect();
+
+    // Recorded theme colours win over the generic light/dark default.
+    let (bg, fg) = recorded.map_or_else(|| theme.colors(), |t| (t.bg, t.fg));
+
+    // Rows the final frame actually fills (trailing blank rows are the emptied
+    // live region, not real output). The replay rests on this height so it ends
+    // on its last line instead of a block of empty terminal rows.
+    let final_rows = frames
+        .last()
+        .map_or(0, |frame| last_content_row(&frame.grid))
+        .max(1);
+
+    // The container's only inline style is the per-recording theme bg/fg (as
+    // custom properties the chrome stylesheet consumes); cell colours are inline
+    // per span, and the rest of the chrome is class-based. See the CSS contract
+    // documented on `render_replay_player`.
+    writeln!(
+        writer,
+        "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--{}\" style=\"--acdc-term-bg:{};--acdc-term-fg:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\">",
+        theme.as_str(),
+        rgb_css(bg),
+        rgb_css(fg),
+        cols,
+        rows,
+        frames.len(),
+        total_ms
+    )?;
+
+    render_replay_titlebar(&mut writer, title)?;
+
+    // The screen holds one block per terminal row. The final frame is rendered
+    // server-side (trimmed of trailing blank rows) so it shows without scripting;
+    // the player builds the rest of the rows, resets to the first frame, and
+    // animates from there.
+    writeln!(
+        writer,
+        "<div class=\"terminal-replay__viewport\"><div class=\"terminal-replay__screen\" aria-label=\"Terminal replay\">"
+    )?;
+    let final_frame = frame_rows.last().map_or(&[] as &[usize], Vec::as_slice);
+    for index in final_frame.iter().take(final_rows) {
+        writeln!(
+            writer,
+            "<div class=\"terminal-replay__row\">{}</div>",
+            pool.get(*index).map_or("", String::as_str)
+        )?;
+    }
+    writeln!(writer, "</div></div>")?;
+
+    // Payload as inline JSON. `<` is escaped to `<` inside strings, so no
+    // recorded content can break out of the script element.
+    write!(
+        writer,
+        "<script type=\"application/json\" class=\"terminal-replay__data\">"
+    )?;
+    write_replay_json(
+        &mut writer,
+        &ReplayData {
+            cols,
+            rows,
+            final_rows,
+            total_ms,
+            times: &times,
+            pool: &pool,
+            frame_rows: &frame_rows,
+        },
+    )?;
+    writeln!(writer, "</script>")?;
+    writeln!(writer, "</div>")?;
+    writeln!(writer, "{REPLAY_PLAYER_SCRIPT}")?;
+    Ok(())
+}
+
+/// Pool the unique rendered rows across all frames and map each frame to a list
+/// of `rows` indices into that pool. Identical lines (the bulk of a session) are
+/// stored once; short frames are padded with blank rows.
+fn build_row_pool(
+    frames: &[replay::Frame],
+    rows: usize,
+    palette: &[Option<Rgb>; 16],
+) -> Result<(Vec<String>, Vec<Vec<usize>>), Error> {
+    let mut pool: Vec<String> = Vec::new();
+    let mut index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut frame_rows: Vec<Vec<usize>> = Vec::with_capacity(frames.len());
+    for frame in frames {
+        let mut indices = Vec::with_capacity(rows);
+        for row in 0..rows {
+            let html = match frame.grid.row(row) {
+                Some(cells) => row_to_html(cells, palette)?,
+                None => String::new(),
+            };
+            indices.push(intern_row(&mut pool, &mut index, html));
+        }
+        frame_rows.push(indices);
+    }
+    Ok((pool, frame_rows))
+}
+
+/// Render the replay's title bar: traffic-light dots and the recording's title.
+/// All styling lives in the stylesheet (`.terminal-replay__titlebar`, `__dots`,
+/// `__title`); only structure is emitted here.
+fn render_replay_titlebar<W: Write>(writer: &mut W, title: Option<&str>) -> Result<(), Error> {
+    write!(
+        writer,
+        "<div class=\"terminal-replay__titlebar\" aria-hidden=\"true\"><span class=\"terminal-replay__dots\"><span></span><span></span><span></span></span>"
+    )?;
+    if let Some(title) = title {
+        write!(
+            writer,
+            "<span class=\"terminal-replay__title\">{}</span>",
+            escape_html(title)
+        )?;
+    }
+    writeln!(writer, "</div>")?;
+    Ok(())
+}
+
+/// Number of rows from the top of `grid` up to and including its last row that
+/// holds any visible content (so trailing blank rows are excluded). Interior
+/// blank lines are kept.
+fn last_content_row(grid: &CellGrid) -> usize {
+    (0..grid.rows())
+        .rev()
+        .find(|&row| {
+            grid.row(row)
+                .is_some_and(|cells| cells.iter().any(|cell| !cell.is_blank()))
+        })
+        .map_or(0, |row| row + 1)
+}
+
+/// Render one terminal row to its HTML string for the player pool, with the same
+/// inline-styled markup as the static preview's [`render_row`] but with cell
+/// colours resolved against the recording's own palette (see
+/// [`resolve_cell_color`]).
+fn row_to_html(row: &[Cell], palette: &[Option<Rgb>; 16]) -> Result<String, Error> {
+    let mut buffer: Vec<u8> = Vec::new();
+    render_player_row(&mut buffer, row, palette)?;
+    Ok(String::from_utf8(buffer).unwrap_or_default())
+}
+
+/// Resolve a cell colour for the player: a palette index maps to the recording's
+/// own palette colour when present, so the replay shows the colours it was
+/// recorded with (libghostty resolves indices against its built-in palette;
+/// `palette` from the cast header overrides that). Truecolor / 256-colour cells
+/// have no index and use their already-resolved RGB.
+fn resolve_cell_color(
+    index: Option<u8>,
+    rgb: Option<Rgb>,
+    palette: &[Option<Rgb>; 16],
+) -> Option<Rgb> {
+    match index {
+        Some(slot) => palette.get(usize::from(slot)).copied().flatten().or(rgb),
+        None => rgb,
+    }
+}
+
+/// Render a terminal row as inline-styled spans (same markup as the static
+/// preview's [`render_row`]) but with recorded-palette colour resolution for the
+/// player pool.
+fn render_player_row<W: Write>(
+    writer: &mut W,
+    row: &[Cell],
+    palette: &[Option<Rgb>; 16],
+) -> Result<(), Error> {
+    let mut current_style = SpanStyle::default();
+    let mut buffer = String::new();
+    let mut has_open_span = false;
+
+    for cell in row {
+        let style = SpanStyle {
+            fg: resolve_cell_color(cell.fg_index, cell.fg, palette),
+            bg: resolve_cell_color(cell.bg_index, cell.bg, palette),
+            decorations: cell.decorations,
+        };
+        if style != current_style {
+            flush_span(writer, &buffer, current_style, has_open_span)?;
+            buffer.clear();
+            current_style = style;
+            has_open_span = !is_default_style(style);
+        }
+        let text = if cell.text.is_empty() {
+            " "
+        } else {
+            cell.text.as_str()
+        };
+        buffer.push_str(text);
+    }
+
+    flush_span(writer, buffer.trim_end(), current_style, has_open_span)?;
+    Ok(())
+}
+
+/// Return the pool index for `html`, inserting it if new, so identical rows are
+/// stored once.
+fn intern_row(
+    pool: &mut Vec<String>,
+    index: &mut std::collections::HashMap<String, usize>,
+    html: String,
+) -> usize {
+    if let Some(&existing) = index.get(&html) {
+        return existing;
+    }
+    let position = pool.len();
+    index.insert(html.clone(), position);
+    pool.push(html);
+    position
+}
+
+/// Write the player payload as JSON: the unique-row pool, per-frame row indices,
+/// and frame times.
+/// The replay player's payload, ready to serialise as JSON.
+struct ReplayData<'a> {
+    cols: usize,
+    rows: usize,
+    final_rows: usize,
+    total_ms: u128,
+    times: &'a [u128],
+    pool: &'a [String],
+    frame_rows: &'a [Vec<usize>],
+}
+
+fn write_replay_json<W: Write>(writer: &mut W, data: &ReplayData<'_>) -> Result<(), Error> {
+    let ReplayData {
+        cols,
+        rows,
+        final_rows,
+        total_ms,
+        times,
+        pool,
+        frame_rows,
+    } = *data;
+    write!(
+        writer,
+        "{{\"cols\":{cols},\"rows\":{rows},\"finalRows\":{final_rows},\"durationMs\":{total_ms},\"times\":["
+    )?;
+    for (position, time) in times.iter().enumerate() {
+        if position > 0 {
+            write!(writer, ",")?;
+        }
+        write!(writer, "{time}")?;
+    }
+    write!(writer, "],\"pool\":[")?;
+    for (position, html) in pool.iter().enumerate() {
+        if position > 0 {
+            write!(writer, ",")?;
+        }
+        write!(writer, "{}", json_string(html))?;
+    }
+    write!(writer, "],\"frames\":[")?;
+    for (position, indices) in frame_rows.iter().enumerate() {
+        if position > 0 {
+            write!(writer, ",")?;
+        }
+        write!(writer, "[")?;
+        for (slot, index) in indices.iter().enumerate() {
+            if slot > 0 {
+                write!(writer, ",")?;
+            }
+            write!(writer, "{index}")?;
+        }
+        write!(writer, "]")?;
+    }
+    write!(writer, "]}}")?;
+    Ok(())
+}
+
+/// Quote and escape `value` as a JSON string. `<` becomes `<` so embedding
+/// the JSON inside a `<script>` element can never be broken out of.
+fn json_string(value: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '<' => out.push_str("\\u003c"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// A deterministic, per-block CSS animation name. Every replay block emits its
@@ -664,38 +1230,6 @@ fn replay_frame_budget(playback_ms: u128) -> usize {
         .try_into()
         .unwrap_or(MAX_REPLAY_RENDER_FRAMES);
     budget.clamp(2, MAX_REPLAY_RENDER_FRAMES)
-}
-
-fn sampled_indexes(item_count: usize, budget: usize) -> Vec<usize> {
-    if item_count == 0 {
-        return Vec::new();
-    }
-    let budget = budget.min(item_count);
-    if item_count <= budget {
-        return (0..item_count).collect();
-    }
-    if budget <= 1 {
-        return vec![item_count - 1];
-    }
-
-    let last_index = item_count - 1;
-    let last_slot = budget - 1;
-    let mut indexes = Vec::with_capacity(budget);
-    let mut previous_index = None;
-
-    for slot in 0..budget {
-        let index = if slot == last_slot {
-            last_index
-        } else {
-            slot.saturating_mul(last_index) / last_slot
-        };
-        if previous_index != Some(index) {
-            indexes.push(index);
-            previous_index = Some(index);
-        }
-    }
-
-    indexes
 }
 
 fn render_row<W: Write>(writer: &mut W, row: &[Cell]) -> Result<(), Error> {
@@ -1207,7 +1741,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(!html.contains("terminal-replay"));
+        assert!(!html.contains("terminal-preview terminal-replay"));
         assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
         assert!(warnings.iter().any(|warning| {
             warning
@@ -1218,6 +1752,131 @@ mod tests {
             warning
                 .message
                 .contains("terminal replay requires positive `cols` and `rows`")
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_v2_replay_renders_player() -> TestResult {
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast,cols=20,rows=4]\n----\n{\"version\":2,\"width\":20,\"height\":4}\n[0.0,\"o\",\"first\\r\\n\"]\n[0.5,\"o\",\"second\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains(
+            "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--light\""
+        ));
+        // A JSON payload + the shared inline player drive the row swaps.
+        assert!(
+            html.contains("<script type=\"application/json\" class=\"terminal-replay__data\">")
+        );
+        assert!(html.contains("window.__acdcReplayInit"));
+        // Final frame is server-rendered (no-JS / reduced-motion fallback).
+        assert!(html.contains("class=\"terminal-replay__row\""));
+        assert!(html.contains("first"));
+        assert!(html.contains("second"));
+        Ok(())
+    }
+
+    #[test]
+    fn player_script_csp_hash_stays_in_sync() {
+        // Tripwire: the documented CSP hash covers the JS between the <script>
+        // tags. If this length changes, the script changed; recompute
+        // REPLAY_PLAYER_SCRIPT_CSP_HASH (see its doc) and update it here.
+        let inner = super::REPLAY_PLAYER_SCRIPT
+            .strip_prefix("<script>")
+            .and_then(|script| script.strip_suffix("</script>"))
+            .unwrap_or_default();
+        assert_eq!(
+            inner.len(),
+            1353,
+            "player script changed; recompute REPLAY_PLAYER_SCRIPT_CSP_HASH"
+        );
+        assert!(super::REPLAY_PLAYER_SCRIPT_CSP_HASH.starts_with("sha256-"));
+    }
+
+    #[test]
+    fn asciicast_replay_uses_header_dimensions_without_block_attributes() -> TestResult {
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast]\n----\n{\"version\":2,\"width\":30,\"height\":5}\n[0.0,\"o\",\"hi\\r\\n\"]\n[0.5,\"o\",\"bye\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("terminal-preview terminal-replay"));
+        assert!(html.contains("data-cols=\"30\""));
+        assert!(html.contains("data-rows=\"5\""));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_block_dimensions_override_header() -> TestResult {
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast,cols=12,rows=3]\n----\n{\"version\":2,\"width\":30,\"height\":5}\n[0.0,\"o\",\"hi\\r\\n\"]\n[0.5,\"o\",\"bye\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("data-cols=\"12\""));
+        assert!(html.contains("data-rows=\"3\""));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_v3_relative_timing_renders() -> TestResult {
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast,cols=20,rows=4]\n----\n{\"version\":3,\"term\":{\"cols\":20,\"rows\":4}}\n[0.0,\"o\",\"alpha\\r\\n\"]\n[0.3,\"o\",\"beta\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("terminal-preview terminal-replay"));
+        assert!(html.contains("alpha"));
+        assert!(html.contains("beta"));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_preserves_special_characters_in_output() -> TestResult {
+        // Output bytes containing `<`, `>`, `&` must survive parse -> capture and
+        // be HTML-escaped exactly once by the renderer (not double-escaped, which
+        // would mean the parser had escaped them before asciicast parsing).
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast,cols=40,rows=4]\n----\n{\"version\":2,\"width\":40,\"height\":4}\n[0.0,\"o\",\"<div> & </div>\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("&lt;div&gt; &amp; &lt;/div&gt;"));
+        assert!(!html.contains("&amp;lt;"));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_unsupported_version_falls_back_with_warning() -> TestResult {
+        let (html, warnings) = render_with_warnings(
+            "= Example\n\n[terminal%replay,format=asciicast,cols=20,rows=4]\n----\n{\"version\":1,\"width\":20,\"height\":4,\"duration\":1.0,\"stdout\":[[0.0,\"x\\r\\n\"]]}\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(!html.contains("terminal-preview terminal-replay"));
+        assert!(html.contains("<div class=\"terminal-preview terminal-preview--light\""));
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| { warning.message.contains("unsupported asciicast version 1") })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_replay_format_warns_and_replays_as_ansi() -> TestResult {
+        let (html, warnings) = render_with_warnings(
+            "= Example\n\n[terminal%replay,format=bogus,cols=20,rows=4]\n----\nfirst\nsecond\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("terminal-preview terminal-replay"));
+        assert!(warnings.iter().any(|warning| {
+            warning
+                .message
+                .contains("unknown terminal replay `format` value `bogus`")
         }));
         Ok(())
     }

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -330,10 +330,14 @@ fn render_replay_ansi<W: Write>(
         let grid = capture_ansi(&ansi, size)?;
         return render_grid(&mut writer, &grid, preview_options.theme);
     }
-    render_replay_filmstrip(
-        &mut writer,
+    // Raw ANSI carries no recorded theme or title, so the player uses the
+    // generic light/dark colours and emits no `data-title`.
+    render_replay_player(
+        writer,
         &frames,
         preview_options.theme,
+        None,
+        None,
         playback_duration,
     )
 }
@@ -378,13 +382,20 @@ fn render_replay_asciicast<W: Write>(
     let recorded_theme = recording.theme();
     let title = recording.title().map(str::to_owned);
 
+    // Replay at the recording's native height so its cursor positioning renders
+    // the way it was recorded (a live progress region, full-screen TUI, etc.);
+    // capturing straight into a shorter `size.rows` would leave output stuck at
+    // the top with blank rows below. The captured frames are then windowed to
+    // `size.rows` for display (below).
+    let capture_size = TerminalSize::new(size.cols, recording.size().rows.max(size.rows));
+
     // Capture every distinct screen the session produced (deduplicated, but never
     // sampled): a terminal session may rewrite the screen in place (progress
     // bars, status lines, full-screen TUIs), so faithful playback needs each
     // visible state, not a scrolled window of one transcript. Capture errors are
     // caught here because the events come from user-supplied cast data, not acdc.
-    let frames = match recording.capture(size) {
-        Ok(timeline) => timeline.into_frames(),
+    let timeline = match recording.capture(capture_size) {
+        Ok(timeline) => timeline,
         Err(err) => {
             diagnostics.warn(format!(
                 "asciicast replay capture failed: {err}; rendering a static terminal preview instead"
@@ -392,6 +403,11 @@ fn render_replay_asciicast<W: Write>(
             return render_blank_preview(&mut writer, size, preview_options.theme);
         }
     };
+
+    // Show a `size.rows`-tall window of each frame, anchoring the last line with
+    // content to the bottom so the replay follows the output like a scrolling
+    // terminal (and rests on the final lines, not a region the recording cleared).
+    let frames = window_frames_to_bottom(timeline.into_frames(), size.rows);
 
     if frames.is_empty() {
         diagnostics.warn(REPLAY_NO_FRAMES_MESSAGE);
@@ -406,6 +422,47 @@ fn render_replay_asciicast<W: Write>(
         title.as_deref(),
         playback_duration,
     )
+}
+
+/// Window every captured frame to `display_rows`, anchoring each frame's last
+/// line with content to the bottom. The replay then follows the output like a
+/// scrolling terminal instead of leaving content stuck at the top, and rests on
+/// the final lines rather than a region the recording erased at the end.
+fn window_frames_to_bottom(frames: Vec<replay::Frame>, display_rows: usize) -> Vec<replay::Frame> {
+    let display_rows = display_rows.max(1);
+    frames
+        .into_iter()
+        .map(|frame| replay::Frame {
+            at: frame.at,
+            grid: window_grid_to_bottom(&frame.grid, display_rows),
+        })
+        .collect()
+}
+
+/// Extract a `display_rows`-tall window of `grid` whose bottom is the last row
+/// holding visible content (trailing blank rows are dropped). When the content
+/// is shorter than `display_rows` it sits at the top with blank rows below, like
+/// fresh terminal output; once it exceeds the window the oldest rows scroll off
+/// the top.
+fn window_grid_to_bottom(grid: &CellGrid, display_rows: usize) -> CellGrid {
+    let cols = grid.cols();
+    let content_end = (0..grid.rows())
+        .rev()
+        .find(|&row| {
+            grid.row(row)
+                .is_some_and(|cells| cells.iter().any(|cell| !cell.is_blank()))
+        })
+        .map_or(0, |row| row + 1);
+    let start = content_end.saturating_sub(display_rows);
+    let mut cells = Vec::with_capacity(cols.saturating_mul(display_rows));
+    for offset in 0..display_rows {
+        let row = start + offset;
+        match grid.row(row) {
+            Some(row_cells) if row < content_end => cells.extend_from_slice(row_cells),
+            _ => cells.extend(std::iter::repeat_with(Cell::default).take(cols)),
+        }
+    }
+    CellGrid::new(cells, TerminalSize::new(cols, display_rows))
 }
 
 /// The `replay-duration-ms` playback override, if set to a positive integer.
@@ -665,86 +722,6 @@ fn render_grid<W: Write>(writer: &mut W, grid: &CellGrid, theme: Theme) -> Resul
     Ok(())
 }
 
-/// Render the replay as a single "filmstrip": every sampled frame stacked into
-/// one `<pre>`, with a clipped viewport showing one frame at a time and a single
-/// stepped `translateY` animation advancing through them. This keeps the DOM to
-/// one grid and one animation regardless of recording length, instead of N
-/// stacked frame layers. Playback ends on the final frame (no scroll-back).
-fn render_replay_filmstrip<W: Write>(
-    writer: &mut W,
-    frames: &[replay::Frame],
-    theme: Theme,
-    playback_duration: Option<std::time::Duration>,
-) -> Result<(), Error> {
-    let Some(first) = frames.first() else {
-        return Ok(());
-    };
-    let (bg, fg) = theme.colors();
-    let frame_duration = std::time::Duration::from_millis(REPLAY_FRAME_DURATION_MS);
-    let first_at = first.at;
-    let total_duration = frames.last().map_or(frame_duration, |frame| {
-        frame.at.saturating_sub(first_at) + frame_duration
-    });
-    let total_ms = playback_duration
-        .unwrap_or(total_duration)
-        .as_millis()
-        .max(1);
-    let cols = first.grid.cols();
-    let rows = first.grid.rows();
-    let animation_name = replay_animation_name(frames, rows, total_duration);
-
-    write!(
-        writer,
-        "<div class=\"terminal-preview terminal-replay terminal-preview--{}\" style=\"--acdc-term-bg:{};--acdc-term-fg:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\">",
-        theme.as_str(),
-        rgb_css(bg),
-        rgb_css(fg),
-        cols,
-        rows,
-        frames.len(),
-        total_ms
-    )?;
-    render_replay_scroll_keyframes(
-        writer,
-        &animation_name,
-        frames,
-        rows,
-        first_at,
-        total_duration,
-    )?;
-    // The viewport keeps the terminal padding and any horizontal scrolling; the
-    // clip is exactly `rows` tall (font-size pins `em` to the screen's line box)
-    // and hides everything but the current frame as the filmstrip scrolls.
-    writeln!(
-        writer,
-        "<div class=\"terminal-replay__viewport\" style=\"overflow:auto;max-width:100%;padding:18px;font-size:14px\">"
-    )?;
-    writeln!(
-        writer,
-        "<div class=\"terminal-replay__clip\" style=\"position:relative;overflow:hidden;width:max-content;height:{}\">",
-        row_em(rows)
-    )?;
-    writeln!(
-        writer,
-        "<pre class=\"terminal-preview__screen terminal-replay__scroll\" aria-label=\"Terminal replay\" style=\"margin:0;padding:0;animation:{animation_name} {total_ms}ms step-end both\">"
-    )?;
-    let mut first_row = true;
-    for frame in frames {
-        for row in frame.grid.rows_iter() {
-            if !first_row {
-                writeln!(writer)?;
-            }
-            first_row = false;
-            render_row(writer, row)?;
-        }
-    }
-    writeln!(writer, "</pre>")?;
-    writeln!(writer, "</div>")?;
-    writeln!(writer, "</div>")?;
-    writeln!(writer, "</div>")?;
-    Ok(())
-}
-
 /// A tiny, self-contained vanilla-JS player shared by every replay block on the
 /// page. It reads each block's JSON payload, swaps the visible rows on a clock
 /// (only touching rows that actually change), and honours `prefers-reduced-motion`
@@ -762,7 +739,8 @@ const REPLAY_PLAYER_SCRIPT: &str = "<script>(function(){function init(el){el.set
 pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str =
     "sha256-/mhN+UdwCNRQ7MxmgzvMM5DZpJy6Rs63LrQRESyqfNw=";
 
-/// Render a recording as an interactive replay player.
+/// Render a recording as an interactive replay player. This is the single
+/// renderer for every replay block (raw ANSI and asciicast alike).
 ///
 /// Every distinct visible screen is captured, but identical rows are pooled and
 /// emitted once; each frame is just a list of indices into that pool plus a
@@ -771,22 +749,24 @@ pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str =
 /// faithfully and smoothly while keeping the payload compact: a long session
 /// costs one copy of each unique line, not one screen per frame.
 ///
-/// The player wears the recording's own colours (when its header carried a
-/// theme) and a terminal-window title bar. The final frame is rendered into the
-/// DOM server-side, so readers with scripting disabled (or who prefer reduced
-/// motion) see the finished screen.
+/// The player wears the recording's own colours when its header carried a theme
+/// (raw ANSI has none, so it uses the generic light/dark colours). The final
+/// frame is rendered into the DOM server-side, so readers with scripting
+/// disabled (or who prefer reduced motion) see the finished screen; only the
+/// animation is lost.
 ///
 /// # CSS contract
 ///
-/// The window chrome is class-based in the built-in stylesheet, so a consumer
-/// (e.g. an embedding editor) can restyle it. The stable seams are the classes
-/// `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__titlebar`,
-/// `.terminal-replay__dots`, `.terminal-replay__title`,
-/// `.terminal-replay__viewport`, `.terminal-replay__screen`,
-/// `.terminal-replay__row`, plus custom properties `--acdc-term-bg`/
-/// `--acdc-term-fg` (the recorded theme, emitted inline on the container) and the
-/// stylesheet-defaulted `--acdc-term-font-family`/`--acdc-term-font-size`/
-/// `--acdc-term-line-height`/`--acdc-term-radius`/`--acdc-term-padding`.
+/// acdc emits no window chrome; the markup is class-based so a consumer (e.g. an
+/// embedding editor) can add its own. The stable seams are the classes
+/// `.terminal-replay`, `.terminal-replay--player`, `.terminal-replay__viewport`,
+/// `.terminal-replay__screen`, `.terminal-replay__row`, the `data-title`
+/// attribute (the recorded title, present only when the recording carried one,
+/// for building custom chrome via `::before{content:attr(data-title)}`), the
+/// custom properties `--acdc-term-bg`/`--acdc-term-fg` (the recorded theme,
+/// emitted inline on the container) and the stylesheet-defaulted
+/// `--acdc-term-font-family`/`--acdc-term-font-size`/`--acdc-term-line-height`/
+/// `--acdc-term-radius`/`--acdc-term-padding`.
 ///
 /// Per-cell colours are emitted as inline `style` colours (resolved against the
 /// recording's own palette via [`resolve_cell_color`]), matching the static
@@ -842,31 +822,31 @@ fn render_replay_player<W: Write>(
     // Recorded theme colours win over the generic light/dark default.
     let (bg, fg) = recorded.map_or_else(|| theme.colors(), |t| (t.bg, t.fg));
 
-    // Rows the final frame actually fills (trailing blank rows are the emptied
-    // live region, not real output). The replay rests on this height so it ends
-    // on its last line instead of a block of empty terminal rows.
-    let final_rows = frames
-        .last()
-        .map_or(0, |frame| last_content_row(&frame.grid))
-        .max(1);
+    // The replay rests on the full terminal height, so the configured `rows` is
+    // also the minimum number of lines shown at the end of the run: the box
+    // stays `rows` tall instead of collapsing to the final line's content.
+    let final_rows = rows;
 
-    // The container's only inline style is the per-recording theme bg/fg (as
-    // custom properties the chrome stylesheet consumes); cell colours are inline
-    // per span, and the rest of the chrome is class-based. See the CSS contract
-    // documented on `render_replay_player`.
+    // The container carries the per-recording theme bg/fg as custom properties
+    // (cell colours are inline per span; everything else is class-based). acdc
+    // emits no window chrome; the recorded title, when present, is exposed as
+    // `data-title` so a consumer can render its own chrome in CSS
+    // (`::before{content:attr(data-title)}`).
+    let title_attr = title.map_or_else(String::new, |title| {
+        format!(" data-title=\"{}\"", escape_html(title))
+    });
     writeln!(
         writer,
-        "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--{}\" style=\"--acdc-term-bg:{};--acdc-term-fg:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\">",
+        "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--{}\" style=\"--acdc-term-bg:{};--acdc-term-fg:{}\" data-cols=\"{}\" data-rows=\"{}\" data-frames=\"{}\" data-duration-ms=\"{}\"{}>",
         theme.as_str(),
         rgb_css(bg),
         rgb_css(fg),
         cols,
         rows,
         frames.len(),
-        total_ms
+        total_ms,
+        title_attr
     )?;
-
-    render_replay_titlebar(&mut writer, title)?;
 
     // The screen holds one block per terminal row. The final frame is rendered
     // server-side (trimmed of trailing blank rows) so it shows without scripting;
@@ -942,38 +922,6 @@ fn build_row_pool(
         }
     }
     Ok((pool, frame_rows))
-}
-
-/// Render the replay's title bar: traffic-light dots and the recording's title.
-/// All styling lives in the stylesheet (`.terminal-replay__titlebar`, `__dots`,
-/// `__title`); only structure is emitted here.
-fn render_replay_titlebar<W: Write>(writer: &mut W, title: Option<&str>) -> Result<(), Error> {
-    write!(
-        writer,
-        "<div class=\"terminal-replay__titlebar\" aria-hidden=\"true\"><span class=\"terminal-replay__dots\"><span></span><span></span><span></span></span>"
-    )?;
-    if let Some(title) = title {
-        write!(
-            writer,
-            "<span class=\"terminal-replay__title\">{}</span>",
-            escape_html(title)
-        )?;
-    }
-    writeln!(writer, "</div>")?;
-    Ok(())
-}
-
-/// Number of rows from the top of `grid` up to and including its last row that
-/// holds any visible content (so trailing blank rows are excluded). Interior
-/// blank lines are kept.
-fn last_content_row(grid: &CellGrid) -> usize {
-    (0..grid.rows())
-        .rev()
-        .find(|&row| {
-            grid.row(row)
-                .is_some_and(|cells| cells.iter().any(|cell| !cell.is_blank()))
-        })
-        .map_or(0, |row| row + 1)
 }
 
 /// Render one terminal row to its HTML string for the player pool, using the
@@ -1082,75 +1030,6 @@ fn json_string(value: &str) -> String {
     }
     out.push('"');
     out
-}
-
-/// A deterministic, per-block CSS animation name. Every replay block emits its
-/// own `@keyframes`, so a single shared global name would let a later block's
-/// keyframes override an earlier block's, animating the earlier block with the
-/// wrong offsets. The name hashes the inputs that define the keyframes (frame
-/// timings and row geometry); blocks that animate identically share a name,
-/// which is harmless.
-fn replay_animation_name(
-    frames: &[replay::Frame],
-    rows: usize,
-    total_duration: std::time::Duration,
-) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    rows.hash(&mut hasher);
-    total_duration.hash(&mut hasher);
-    frames.len().hash(&mut hasher);
-    for frame in frames {
-        frame.at.hash(&mut hasher);
-    }
-    format!("terminal-replay-scroll-{:016x}", hasher.finish())
-}
-
-fn render_replay_scroll_keyframes<W: Write>(
-    writer: &mut W,
-    name: &str,
-    frames: &[replay::Frame],
-    rows: usize,
-    first_at: std::time::Duration,
-    total_duration: std::time::Duration,
-) -> Result<(), Error> {
-    writeln!(writer, "<style>")?;
-    write!(writer, "@keyframes {name}{{")?;
-    for (index, frame) in frames.iter().enumerate() {
-        let percent = replay_frame_percent(frame.at.saturating_sub(first_at), total_duration);
-        let offset = row_em(index.saturating_mul(rows));
-        write!(writer, "{percent:.4}%{{transform:translateY(-{offset})}}")?;
-    }
-    // Hold the final frame to the end of the timeline.
-    let last_offset = row_em(frames.len().saturating_sub(1).saturating_mul(rows));
-    writeln!(writer, "100%{{transform:translateY(-{last_offset})}}}}")?;
-    writeln!(writer, "</style>")?;
-    Ok(())
-}
-
-/// A length in hundredths of an `em`, formatted as a CSS `em` value
-/// (e.g. `145` -> `1.45em`).
-#[derive(Clone, Copy)]
-struct Em(usize);
-
-impl std::fmt::Display for Em {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{:02}em", self.0 / 100, self.0 % 100)
-    }
-}
-
-/// Height of `rows` terminal rows, matching the screen's `font: 14px/1.45`
-/// line box (1.45em per row).
-fn row_em(rows: usize) -> Em {
-    Em(rows.saturating_mul(145))
-}
-
-fn replay_frame_percent(elapsed: std::time::Duration, total_duration: std::time::Duration) -> f64 {
-    let total = total_duration.as_secs_f64();
-    if total == 0.0 {
-        return 0.0;
-    }
-    (elapsed.as_secs_f64() / total * 100.0).clamp(0.0, 100.0)
 }
 
 fn replay_frame_budget(playback_ms: u128) -> usize {
@@ -1541,64 +1420,43 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(
-            html.contains(
-                "<div class=\"terminal-preview terminal-replay terminal-preview--light\""
-            )
-        );
+        // Raw ANSI replay renders through the same JS player as asciicast: a
+        // player container, an inline JSON payload, the shared init script, and
+        // server-rendered rows. No CSS filmstrip and no window chrome.
+        assert!(html.contains(
+            "<div class=\"terminal-preview terminal-replay terminal-replay--player terminal-preview--light\""
+        ));
         assert!(html.contains("data-cols=\"20\""));
         assert!(html.contains("data-rows=\"4\""));
         assert!(html.contains("data-frames=\"2\""));
         assert!(html.contains("data-duration-ms=\"1000\""));
-        // Single filmstrip grid + one stepped scroll animation, no per-frame
-        // layers or visibility toggling.
-        assert!(html.contains("@keyframes terminal-replay-scroll"));
-        assert!(html.contains("terminal-replay__scroll"));
-        assert!(html.contains("transform:translateY("));
-        assert!(html.contains("1000ms step-end both"));
-        assert!(!html.contains("<script>"));
-        assert!(!html.contains("terminal-replay__frame"));
-        assert!(!html.contains("terminal-replay__stage"));
-        assert!(!html.contains("terminal-replay__scrollback"));
-        assert!(!html.contains("@keyframes terminal-replay-frame-"));
+        assert!(
+            html.contains("<script type=\"application/json\" class=\"terminal-replay__data\">")
+        );
+        assert!(html.contains("window.__acdcReplayInit"));
+        assert!(html.contains("class=\"terminal-replay__row\""));
+        // No CSS filmstrip leftovers and no chrome (raw ANSI carries no title).
+        assert!(!html.contains("@keyframes terminal-replay-scroll"));
+        assert!(!html.contains("terminal-replay__scroll"));
+        assert!(!html.contains("class=\"terminal-replay__titlebar\""));
+        assert!(!html.contains("data-title"));
         assert!(html.contains("first"));
         assert!(html.contains("second</span>"));
         Ok(())
     }
 
     #[test]
-    fn terminal_replay_blocks_use_distinct_animation_names() -> TestResult {
-        // Two replay blocks in one document must not share a global
-        // `@keyframes` name, or the later block's keyframes would override the
-        // earlier block's and animate it with the wrong offsets.
+    fn terminal_replay_blocks_each_emit_their_own_payload() -> TestResult {
+        // Two replay blocks in one document each emit their own JSON payload;
+        // the single shared init script animates every player on the page.
         let html = render(
             "= Example\n\n[terminal%replay,cols=20,rows=4]\n----\nfirst\nsecond\n----\n\n[terminal%replay,cols=20,rows=4]\n----\nalpha\nbeta\ngamma\n----\n",
             crate::HtmlVariant::Standard,
         )?;
 
-        let names: Vec<&str> = html
-            .split("@keyframes ")
-            .skip(1)
-            .filter_map(|rest| rest.split('{').next())
-            .filter(|name| name.starts_with("terminal-replay-scroll-"))
-            .collect();
-
-        assert_eq!(
-            names.len(),
-            2,
-            "each replay block defines its own keyframes"
-        );
-        assert_ne!(
-            names.first(),
-            names.get(1),
-            "animation names must be unique per block"
-        );
-        for name in &names {
-            assert!(
-                html.contains(&format!("animation:{name} ")),
-                "each block animates with its own keyframes name"
-            );
-        }
+        let payloads = html.matches("class=\"terminal-replay__data\"").count();
+        assert_eq!(payloads, 2, "each replay block emits its own data payload");
+        assert!(html.contains("window.__acdcReplayInit"));
         Ok(())
     }
 
@@ -1610,7 +1468,7 @@ mod tests {
         )?;
 
         assert!(html.contains("data-duration-ms=\"250\""));
-        assert!(html.contains("250ms step-end both"));
+        assert!(html.contains("\"durationMs\":250"));
         Ok(())
     }
 
@@ -1667,7 +1525,7 @@ mod tests {
             crate::HtmlVariant::Standard,
         )?;
 
-        assert!(html.contains("terminal-replay__scroll"));
+        assert!(html.contains("terminal-replay--player"));
         assert!(html.contains("Working 0%"));
         assert!(html.contains("Working 50%"));
         assert!(html.contains("Working 100%"));
@@ -1771,6 +1629,30 @@ mod tests {
         assert!(html.contains("terminal-preview terminal-replay"));
         assert!(html.contains("alpha"));
         assert!(html.contains("beta"));
+        Ok(())
+    }
+
+    #[test]
+    fn asciicast_replay_rests_on_the_last_rows_when_taller_than_the_block() -> TestResult {
+        // The recording is 6 rows tall but the block asks for rows=3. A single
+        // burst prints five lines, so the only captured screen has line4 at the
+        // bottom. The replay must rest on the LAST rows (line2..line4), windowed
+        // to the block height, not the first lines or a block of blanks.
+        let html = render(
+            "= Example\n\n[terminal%replay,format=asciicast,rows=3]\n----\n{\"version\":2,\"width\":20,\"height\":6}\n[0.0,\"o\",\"line0\\r\\nline1\\r\\nline2\\r\\nline3\\r\\nline4\\r\\n\"]\n----\n",
+            crate::HtmlVariant::Standard,
+        )?;
+
+        assert!(html.contains("data-rows=\"3\""));
+        assert!(html.contains("line4"), "the last line is visible");
+        assert!(
+            html.contains("line2"),
+            "the window is filled with the last rows"
+        );
+        assert!(
+            !html.contains("line0"),
+            "the earliest lines scrolled out of the window"
+        );
         Ok(())
     }
 

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -721,12 +721,10 @@ pub const REPLAY_PLAYER_SCRIPT: &str = concat!(
 
 /// CSP `script-src` source for [`REPLAY_PLAYER_SCRIPT`]'s inline code, so a
 /// consumer can allowlist the player under a strict policy without
-/// `'unsafe-inline'` (e.g. `script-src 'self' 'sha256-...'`). The hash is the
-/// sha256 of `static/terminal-replay-player.js` (the code between the `<script>`
-/// tags). If you edit that file, recompute it with:
-/// `openssl dgst -sha256 -binary static/terminal-replay-player.js | openssl base64`
-pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str =
-    "sha256-z2t/X8Ok+lAYeDw8UsWjjM7TntIjoggVHhJSfFmhTyQ=";
+/// `'unsafe-inline'` (e.g. `script-src 'self' 'sha256-...'`). Computed in
+/// `build.rs` as the sha256 of `static/terminal-replay-player.js`, so it always
+/// matches the embedded script.
+pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str = env!("ACDC_REPLAY_PLAYER_CSP_HASH");
 
 /// Render a recording as an interactive replay player. This is the single
 /// renderer for every replay block (raw ANSI and asciicast alike).
@@ -1605,20 +1603,20 @@ mod tests {
     }
 
     #[test]
-    fn player_script_csp_hash_stays_in_sync() {
-        // Tripwire: the documented CSP hash covers the JS between the <script>
-        // tags. If this length changes, the script changed; recompute
-        // REPLAY_PLAYER_SCRIPT_CSP_HASH (see its doc) and update it here.
+    fn player_script_csp_hash_matches_embedded_script() -> TestResult {
+        use base64::{Engine as _, engine::general_purpose::STANDARD};
+        use sha2::{Digest, Sha256};
+
+        // The build-time hash must cover exactly the code between the <script>
+        // tags. Recomputing it here keeps build.rs and the runtime wrapping in
+        // sync without any manual step.
         let inner = super::REPLAY_PLAYER_SCRIPT
             .strip_prefix("<script>")
             .and_then(|script| script.strip_suffix("</script>"))
-            .unwrap_or_default();
-        assert_eq!(
-            inner.len(),
-            2656,
-            "player script changed; recompute REPLAY_PLAYER_SCRIPT_CSP_HASH"
-        );
-        assert!(super::REPLAY_PLAYER_SCRIPT_CSP_HASH.starts_with("sha256-"));
+            .ok_or("player script must be wrapped in <script> tags")?;
+        let expected = format!("sha256-{}", STANDARD.encode(Sha256::digest(inner.as_bytes())));
+        assert_eq!(super::REPLAY_PLAYER_SCRIPT_CSP_HASH, expected);
+        Ok(())
     }
 
     #[test]

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -1623,7 +1623,10 @@ mod tests {
             .strip_prefix("<script>")
             .and_then(|script| script.strip_suffix("</script>"))
             .ok_or("player script must be wrapped in <script> tags")?;
-        let expected = format!("sha256-{}", STANDARD.encode(Sha256::digest(inner.as_bytes())));
+        let expected = format!(
+            "sha256-{}",
+            STANDARD.encode(Sha256::digest(inner.as_bytes()))
+        );
         assert_eq!(super::REPLAY_PLAYER_SCRIPT_CSP_HASH, expected);
         Ok(())
     }

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -131,16 +131,6 @@ struct SpanStyle {
     decorations: CellDecorations,
 }
 
-impl From<&Cell> for SpanStyle {
-    fn from(cell: &Cell) -> Self {
-        Self {
-            fg: cell.fg,
-            bg: cell.bg,
-            decorations: cell.decorations,
-        }
-    }
-}
-
 pub(crate) fn is_enabled(attrs: &DocumentAttributes<'_>) -> bool {
     attrs
         .get("terminal-preview")
@@ -275,7 +265,7 @@ fn render_replay<W: Write>(
 }
 
 fn render_replay_ansi<W: Write>(
-    writer: W,
+    mut writer: W,
     inlines: &[InlineNode<'_>],
     metadata: &BlockMetadata<'_>,
     options: Options,
@@ -333,16 +323,18 @@ fn render_replay_ansi<W: Write>(
         replay::capture(events, replay_options)?.into_frames()
     };
 
-    finish_replay(
-        writer,
+    if frames.is_empty() {
+        // No visible frames captured: warn and fall back to a static preview of
+        // the final screen.
+        diagnostics.warn(REPLAY_NO_FRAMES_MESSAGE);
+        let grid = capture_ansi(&ansi, size)?;
+        return render_grid(&mut writer, &grid, preview_options.theme);
+    }
+    render_replay_filmstrip(
+        &mut writer,
         &frames,
         preview_options.theme,
         playback_duration,
-        diagnostics,
-        |writer| {
-            let grid = capture_ansi(&ansi, size)?;
-            render_grid(writer, &grid, preview_options.theme)
-        },
     )
 }
 
@@ -391,7 +383,7 @@ fn render_replay_asciicast<W: Write>(
     // bars, status lines, full-screen TUIs), so faithful playback needs each
     // visible state, not a scrolled window of one transcript. Capture errors are
     // caught here because the events come from user-supplied cast data, not acdc.
-    let frames = match recording.capture(size, usize::MAX, REPLAY_FRAME_DURATION) {
+    let frames = match recording.capture(size) {
         Ok(timeline) => timeline.into_frames(),
         Err(err) => {
             diagnostics.warn(format!(
@@ -427,24 +419,6 @@ fn replay_playback_override(
         diagnostics,
     )
     .map(|ms| std::time::Duration::from_millis(ms as u64))
-}
-
-/// Render captured replay `frames` as a filmstrip, or, when capture produced no
-/// visible frames, warn and let `on_empty` render a static fallback preview.
-/// Shared by both replay formats; only the fallback differs between them.
-fn finish_replay<W: Write>(
-    mut writer: W,
-    frames: &[replay::Frame],
-    theme: Theme,
-    playback_duration: Option<std::time::Duration>,
-    diagnostics: &mut Diagnostics<'_>,
-    on_empty: impl FnOnce(&mut W) -> Result<(), Error>,
-) -> Result<(), Error> {
-    if frames.is_empty() {
-        diagnostics.warn(REPLAY_NO_FRAMES_MESSAGE);
-        return on_empty(&mut writer);
-    }
-    render_replay_filmstrip(&mut writer, frames, theme, playback_duration)
 }
 
 /// Resolve the replay terminal size, letting block `cols`/`rows` (or the
@@ -944,7 +918,9 @@ fn build_row_pool(
     rows: usize,
     palette: &[Option<Rgb>; 16],
 ) -> Result<(Vec<String>, Vec<Vec<usize>>), Error> {
-    let mut pool: Vec<String> = Vec::new();
+    // Each rendered row lives once, as a key in `index` mapping its HTML to its
+    // assigned pool slot. The pool itself is rebuilt from the map afterwards,
+    // placing each row at its slot, so a unique row's HTML is never cloned.
     let mut index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     let mut frame_rows: Vec<Vec<usize>> = Vec::with_capacity(frames.len());
     for frame in frames {
@@ -954,9 +930,16 @@ fn build_row_pool(
                 Some(cells) => row_to_html(cells, palette)?,
                 None => String::new(),
             };
-            indices.push(intern_row(&mut pool, &mut index, html));
+            let next = index.len();
+            indices.push(*index.entry(html).or_insert(next));
         }
         frame_rows.push(indices);
+    }
+    let mut pool = vec![String::new(); index.len()];
+    for (html, slot) in index {
+        if let Some(entry) = pool.get_mut(slot) {
+            *entry = html;
+        }
     }
     Ok((pool, frame_rows))
 }
@@ -993,13 +976,13 @@ fn last_content_row(grid: &CellGrid) -> usize {
         .map_or(0, |row| row + 1)
 }
 
-/// Render one terminal row to its HTML string for the player pool, with the same
-/// inline-styled markup as the static preview's [`render_row`] but with cell
-/// colours resolved against the recording's own palette (see
+/// Render one terminal row to its HTML string for the player pool, using the
+/// same inline-styled markup as the static preview's [`render_row`] but with
+/// cell colours resolved against the recording's own palette (see
 /// [`resolve_cell_color`]).
 fn row_to_html(row: &[Cell], palette: &[Option<Rgb>; 16]) -> Result<String, Error> {
     let mut buffer: Vec<u8> = Vec::new();
-    render_player_row(&mut buffer, row, palette)?;
+    render_row_with(&mut buffer, row, palette)?;
     Ok(String::from_utf8(buffer).unwrap_or_default())
 }
 
@@ -1019,60 +1002,6 @@ fn resolve_cell_color(
     }
 }
 
-/// Render a terminal row as inline-styled spans (same markup as the static
-/// preview's [`render_row`]) but with recorded-palette colour resolution for the
-/// player pool.
-fn render_player_row<W: Write>(
-    writer: &mut W,
-    row: &[Cell],
-    palette: &[Option<Rgb>; 16],
-) -> Result<(), Error> {
-    let mut current_style = SpanStyle::default();
-    let mut buffer = String::new();
-    let mut has_open_span = false;
-
-    for cell in row {
-        let style = SpanStyle {
-            fg: resolve_cell_color(cell.fg_index, cell.fg, palette),
-            bg: resolve_cell_color(cell.bg_index, cell.bg, palette),
-            decorations: cell.decorations,
-        };
-        if style != current_style {
-            flush_span(writer, &buffer, current_style, has_open_span)?;
-            buffer.clear();
-            current_style = style;
-            has_open_span = !is_default_style(style);
-        }
-        let text = if cell.text.is_empty() {
-            " "
-        } else {
-            cell.text.as_str()
-        };
-        buffer.push_str(text);
-    }
-
-    flush_span(writer, buffer.trim_end(), current_style, has_open_span)?;
-    Ok(())
-}
-
-/// Return the pool index for `html`, inserting it if new, so identical rows are
-/// stored once.
-fn intern_row(
-    pool: &mut Vec<String>,
-    index: &mut std::collections::HashMap<String, usize>,
-    html: String,
-) -> usize {
-    if let Some(&existing) = index.get(&html) {
-        return existing;
-    }
-    let position = pool.len();
-    index.insert(html.clone(), position);
-    pool.push(html);
-    position
-}
-
-/// Write the player payload as JSON: the unique-row pool, per-frame row indices,
-/// and frame times.
 /// The replay player's payload, ready to serialise as JSON.
 struct ReplayData<'a> {
     cols: usize,
@@ -1084,6 +1013,8 @@ struct ReplayData<'a> {
     frame_rows: &'a [Vec<usize>],
 }
 
+/// Write the player payload as JSON: the unique-row pool, per-frame row indices,
+/// and frame times.
 fn write_replay_json<W: Write>(writer: &mut W, data: &ReplayData<'_>) -> Result<(), Error> {
     let ReplayData {
         cols,
@@ -1232,18 +1163,35 @@ fn replay_frame_budget(playback_ms: u128) -> usize {
     budget.clamp(2, MAX_REPLAY_RENDER_FRAMES)
 }
 
-fn render_row<W: Write>(writer: &mut W, row: &[Cell]) -> Result<(), Error> {
+/// The empty palette used by the static preview: libghostty has already resolved
+/// every palette index to RGB, so there is nothing to re-resolve against.
+const NO_PALETTE: [Option<Rgb>; 16] = [None; 16];
+
+/// Render a terminal row as inline-styled spans, resolving each cell's colours
+/// against `palette` (see [`resolve_cell_color`]). The static preview passes an
+/// empty [`NO_PALETTE`] (the cells already carry resolved RGB); the replay player
+/// passes the recording's own palette so it shows the colours it was recorded
+/// with.
+fn render_row_with<W: Write>(
+    writer: &mut W,
+    row: &[Cell],
+    palette: &[Option<Rgb>; 16],
+) -> Result<(), Error> {
     let mut current_style = SpanStyle::default();
     let mut buffer = String::new();
     let mut has_open_span = false;
 
     for cell in row {
-        let style = SpanStyle::from(cell);
+        let style = SpanStyle {
+            fg: resolve_cell_color(cell.fg_index, cell.fg, palette),
+            bg: resolve_cell_color(cell.bg_index, cell.bg, palette),
+            decorations: cell.decorations,
+        };
         if style != current_style {
             flush_span(writer, &buffer, current_style, has_open_span)?;
             buffer.clear();
             current_style = style;
-            has_open_span = !is_default_style(style);
+            has_open_span = style != SpanStyle::default();
         }
         let text = if cell.text.is_empty() {
             " "
@@ -1255,6 +1203,10 @@ fn render_row<W: Write>(writer: &mut W, row: &[Cell]) -> Result<(), Error> {
 
     flush_span(writer, buffer.trim_end(), current_style, has_open_span)?;
     Ok(())
+}
+
+fn render_row<W: Write>(writer: &mut W, row: &[Cell]) -> Result<(), Error> {
+    render_row_with(writer, row, &NO_PALETTE)
 }
 
 fn flush_span<W: Write>(
@@ -1350,17 +1302,6 @@ where
         }
         Some(_) | None => {}
     }
-}
-
-fn is_default_style(style: SpanStyle) -> bool {
-    style.fg.is_none()
-        && style.bg.is_none()
-        && !style.decorations.bold
-        && !style.decorations.italic
-        && !style.decorations.underline
-        && !style.decorations.dim
-        && !style.decorations.inverse
-        && !style.decorations.strikethrough
 }
 
 fn style_attr(style: SpanStyle) -> String {

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -722,22 +722,24 @@ fn render_grid<W: Write>(writer: &mut W, grid: &CellGrid, theme: Theme) -> Resul
     Ok(())
 }
 
-/// A tiny, self-contained vanilla-JS player shared by every replay block on the
-/// page. It reads each block's JSON payload, swaps the visible rows on a clock
-/// (only touching rows that actually change), and honours `prefers-reduced-motion`
-/// by leaving the server-rendered final frame in place. Defining
-/// `__acdcReplayInit` is idempotent, so emitting this once per block is safe;
-/// every call initialises any not-yet-initialised player on the page.
-const REPLAY_PLAYER_SCRIPT: &str = "<script>(function(){function init(el){el.setAttribute('data-acdc-ready','1');var dataEl=el.querySelector('script.terminal-replay__data');if(!dataEl)return;var d;try{d=JSON.parse(dataEl.textContent);}catch(e){return;}var screen=el.querySelector('.terminal-replay__screen');if(!screen)return;if(window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches)return;while(screen.children.length<d.rows){var r=document.createElement('div');r.className='terminal-replay__row';screen.appendChild(r);}var slots=screen.querySelectorAll('.terminal-replay__row');function show(s,on){slots[s].style.display=on?'':'none';}function fill(){for(var s=d.finalRows;s<slots.length;s++)show(s,true);}function trim(){for(var s=d.finalRows;s<slots.length;s++)show(s,false);}function apply(f){var idx=d.frames[f];for(var s=0;s<idx.length;s++){var h=d.pool[idx[s]];if(slots[s].__h!==h){slots[s].innerHTML=h;slots[s].__h=h;}}}fill();apply(0);var n=d.frames.length,i=0,start=null;function step(ts){if(start===null)start=ts;var t=ts-start;while(i<n-1&&d.times[i+1]<=t)i++;apply(i);if(i<n-1){requestAnimationFrame(step);}else{apply(n-1);trim();}}requestAnimationFrame(step);}window.__acdcReplayInit=function(){var els=document.querySelectorAll('.terminal-replay--player:not([data-acdc-ready])');for(var i=0;i<els.length;i++)init(els[i]);};window.__acdcReplayInit();})();</script>";
+/// The terminal-replay player `<script>`, wrapping the JavaScript in
+/// `static/terminal-replay-player.js` (embedded at compile time). Exposed so an
+/// embedded-mode consumer can include it themselves; its CSP `script-src` hash is
+/// [`REPLAY_PLAYER_SCRIPT_CSP_HASH`].
+pub const REPLAY_PLAYER_SCRIPT: &str = concat!(
+    "<script>",
+    include_str!("../static/terminal-replay-player.js"),
+    "</script>"
+);
 
 /// CSP `script-src` source for [`REPLAY_PLAYER_SCRIPT`]'s inline code, so a
 /// consumer can allowlist the player under a strict policy without
-/// `'unsafe-inline'` (e.g. `script-src 'self' 'sha256-...'`). The hash covers the
-/// code *between* the `<script>` tags. If you change `REPLAY_PLAYER_SCRIPT`,
-/// recompute it from a generated file with:
-/// `perl -0ne 'print $1 if m{<script>(\(function.*?\)\(\);)</script>}s' out.html | openssl dgst -sha256 -binary | openssl base64`
+/// `'unsafe-inline'` (e.g. `script-src 'self' 'sha256-...'`). The hash is the
+/// sha256 of `static/terminal-replay-player.js` (the code between the `<script>`
+/// tags). If you edit that file, recompute it with:
+/// `openssl dgst -sha256 -binary static/terminal-replay-player.js | openssl base64`
 pub const REPLAY_PLAYER_SCRIPT_CSP_HASH: &str =
-    "sha256-/mhN+UdwCNRQ7MxmgzvMM5DZpJy6Rs63LrQRESyqfNw=";
+    "sha256-UCil6i+s7nDZjHY7yXxLIM0dkhXJFMvaoxLaoHlYXDQ=";
 
 /// Render a recording as an interactive replay player. This is the single
 /// renderer for every replay block (raw ANSI and asciicast alike).
@@ -1588,7 +1590,7 @@ mod tests {
             .unwrap_or_default();
         assert_eq!(
             inner.len(),
-            1353,
+            2666,
             "player script changed; recompute REPLAY_PLAYER_SCRIPT_CSP_HASH"
         );
         assert!(super::REPLAY_PLAYER_SCRIPT_CSP_HASH.starts_with("sha256-"));

--- a/converters/html/src/terminal.rs
+++ b/converters/html/src/terminal.rs
@@ -4,7 +4,7 @@
 //! acdc-owned rows, then written as styled HTML) drives two modes:
 //!
 //! - **static** — a single snapshot: `[terminal]` session/literal blocks and
-//!   `:terminal-preview:` source blocks. Rendered by [`render_static`].
+//!   `:acdc-terminal:` source blocks. Rendered by [`render_static`].
 //! - **replay** — animated playback of recorded output (raw ANSI or asciicast)
 //!   via a small inline JS player ([`render_replay_player`]); the final frame is
 //!   server-rendered so no-JS / reduced-motion readers still see it.
@@ -16,7 +16,7 @@
 //! `.terminal-view__viewport` > `.terminal-view__stream` > `.terminal-view__row`. A recording
 //! that carried its own theme is painted with inline colours; otherwise the
 //! `.terminal-view--{light,dark}` class colours it. The authoring surface keeps the
-//! `terminal-preview`/`terminal`/`replay` names; only the rendered classes use
+//! `acdc-terminal`/`terminal`/`replay` names; only the rendered classes use
 //! the `terminal-view` hierarchy.
 
 use std::{borrow::Cow, io::Write};
@@ -81,22 +81,22 @@ struct PreviewOptions {
 
 impl PreviewOptions {
     fn resolve(attrs: &DocumentAttributes<'_>, metadata: Option<&BlockMetadata<'_>>) -> Self {
-        let document_cols = attr_usize(attrs.get("terminal-cols"));
-        let document_rows = attr_usize(attrs.get("terminal-rows"));
+        let document_cols = attr_usize(attrs.get("acdc-terminal-cols"));
+        let document_rows = attr_usize(attrs.get("acdc-terminal-rows"));
         let document_theme = Theme::from_document_attributes(attrs);
 
         Self {
             cols: metadata
                 .and_then(|metadata| {
                     attr_usize(metadata.attributes.get("cols"))
-                        .or_else(|| attr_usize(metadata.attributes.get("terminal-cols")))
+                        .or_else(|| attr_usize(metadata.attributes.get("acdc-terminal-cols")))
                 })
                 .or(document_cols)
                 .unwrap_or(DEFAULT_COLS),
             rows: metadata
                 .and_then(|metadata| {
                     attr_usize(metadata.attributes.get("rows"))
-                        .or_else(|| attr_usize(metadata.attributes.get("terminal-rows")))
+                        .or_else(|| attr_usize(metadata.attributes.get("acdc-terminal-rows")))
                 })
                 .or(document_rows),
             theme: document_theme,
@@ -121,7 +121,7 @@ struct SpanStyle {
 
 pub(crate) fn is_enabled(attrs: &DocumentAttributes<'_>) -> bool {
     attrs
-        .get("terminal-preview")
+        .get("acdc-terminal")
         .is_some_and(|value| !matches!(value, AttributeValue::Bool(false) | AttributeValue::None))
 }
 
@@ -467,7 +467,7 @@ fn replay_playback_override(
 }
 
 /// Resolve the replay terminal size, letting block `cols`/`rows` (or the
-/// `terminal-cols`/`terminal-rows` block/document attributes) override
+/// `acdc-terminal-cols`/`acdc-terminal-rows` block/document attributes) override
 /// `default`. Unlike [`replay_size`], a missing size is not a warning here
 /// because the asciicast header supplies the default.
 fn replay_size_with_default(
@@ -476,16 +476,16 @@ fn replay_size_with_default(
     default: TerminalSize,
     diagnostics: &mut Diagnostics<'_>,
 ) -> TerminalSize {
-    let cols = replay_dimension(attrs, metadata, "cols", "terminal-cols", diagnostics)
+    let cols = replay_dimension(attrs, metadata, "cols", "acdc-terminal-cols", diagnostics)
         .unwrap_or(default.cols);
-    let rows = replay_dimension(attrs, metadata, "rows", "terminal-rows", diagnostics)
+    let rows = replay_dimension(attrs, metadata, "rows", "acdc-terminal-rows", diagnostics)
         .unwrap_or(default.rows);
     TerminalSize::new(cols, rows)
 }
 
 /// Resolve one replay dimension by checking, in order: the block's `primary`
 /// attribute (`cols`/`rows`), the block's `document` attribute
-/// (`terminal-cols`/`terminal-rows`), then the document attribute of the same
+/// (`acdc-terminal-cols`/`acdc-terminal-rows`), then the document attribute of the same
 /// name. Returns `None` when none is set; a present but non-positive value is
 /// warned about by [`positive_attr`].
 fn replay_dimension(
@@ -514,14 +514,14 @@ fn replay_size(
     metadata: &BlockMetadata<'_>,
     diagnostics: &mut Diagnostics<'_>,
 ) -> Option<TerminalSize> {
-    let cols = replay_dimension(attrs, metadata, "cols", "terminal-cols", diagnostics);
-    let rows = replay_dimension(attrs, metadata, "rows", "terminal-rows", diagnostics);
+    let cols = replay_dimension(attrs, metadata, "cols", "acdc-terminal-cols", diagnostics);
+    let rows = replay_dimension(attrs, metadata, "rows", "acdc-terminal-rows", diagnostics);
 
     if let (Some(cols), Some(rows)) = (cols, rows) {
         Some(TerminalSize::new(cols, rows))
     } else {
         diagnostics.warn_with_advice(
-            "terminal replay requires positive `cols` and `rows` block attributes or `terminal-cols` and `terminal-rows` document attributes; rendering a static terminal preview instead",
+            "terminal replay requires positive `cols` and `rows` block attributes or `acdc-terminal-cols` and `acdc-terminal-rows` document attributes; rendering a static terminal preview instead",
             "Use a replay block such as `[terminal%replay,cols=80,rows=24]`.",
         );
         None
@@ -1275,7 +1275,7 @@ mod tests {
     #[test]
     fn standard_html_can_include_selectable_terminal_preview() -> TestResult {
         let html = render(
-            "= Example\n:terminal-preview:\n\n[source,console]\n----\n$ acdc --version\nacdc 0.2.0\n----\n\nAfter preview.\n",
+            "= Example\n:acdc-terminal:\n\n[source,console]\n----\n$ acdc --version\nacdc 0.2.0\n----\n\nAfter preview.\n",
             crate::HtmlVariant::Standard,
         )?;
 
@@ -1302,7 +1302,7 @@ mod tests {
     #[test]
     fn semantic_html_can_include_selectable_terminal_preview() -> TestResult {
         let html = render(
-            "= Example\n:terminal-preview:\n\n[source,terminal]\n----\n$ echo semantic\nsemantic\n----\n",
+            "= Example\n:acdc-terminal:\n\n[source,terminal]\n----\n$ echo semantic\nsemantic\n----\n",
             crate::HtmlVariant::Semantic,
         )?;
 
@@ -1317,7 +1317,7 @@ mod tests {
     #[test]
     fn dark_mode_uses_dark_terminal_preview_theme() -> TestResult {
         let html = render(
-            "= Example\n:terminal-preview:\n:dark-mode:\n\n[source,console]\n----\n$ echo dark\n----\n",
+            "= Example\n:acdc-terminal:\n:dark-mode:\n\n[source,console]\n----\n$ echo dark\n----\n",
             crate::HtmlVariant::Standard,
         )?;
 
@@ -1331,7 +1331,7 @@ mod tests {
     #[test]
     fn terminal_preview_preserves_syntax_colors() -> TestResult {
         let html = render(
-            "= Example\n:terminal-preview:\n\n[source,bash]\n----\necho \"hello\"\n----\n",
+            "= Example\n:acdc-terminal:\n\n[source,bash]\n----\necho \"hello\"\n----\n",
             crate::HtmlVariant::Standard,
         )?;
 
@@ -1374,7 +1374,7 @@ mod tests {
     #[test]
     fn terminal_session_options_layer_block_dimensions_over_document_dimensions() -> TestResult {
         let html = render(
-            "= Example\n:terminal-cols: 30\n:terminal-rows: 7\n:dark-mode:\n\n[terminal,cols=12]\n----\n$ echo layered\n----\n",
+            "= Example\n:acdc-terminal-cols: 30\n:acdc-terminal-rows: 7\n:dark-mode:\n\n[terminal,cols=12]\n----\n$ echo layered\n----\n",
             crate::HtmlVariant::Standard,
         )?;
 
@@ -1755,7 +1755,7 @@ mod tests {
     #[test]
     fn linkcss_uses_built_in_stylesheet_for_terminal_preview_styles() -> TestResult {
         let html = render(
-            "= Example\n:linkcss:\n:terminal-preview:\n\n[source,console]\n----\n$ echo linked\n----\n",
+            "= Example\n:linkcss:\n:acdc-terminal:\n\n[source,console]\n----\n$ echo linked\n----\n",
             crate::HtmlVariant::Standard,
         )?;
 
@@ -1769,7 +1769,7 @@ mod tests {
     #[test]
     fn escapes_terminal_text() -> TestResult {
         let html = render(
-            "= Example\n:terminal-preview:\n\n[source,console]\n----\n<&>\n----\n",
+            "= Example\n:acdc-terminal:\n\n[source,console]\n----\n<&>\n----\n",
             crate::HtmlVariant::Standard,
         )?;
 

--- a/converters/html/static/asciidoctor-dark-mode.css
+++ b/converters/html/static/asciidoctor-dark-mode.css
@@ -386,12 +386,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#1e1e1e;border-color:#383838;box-shadow:0 1px 4px rgba(0,0,0,.4)}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/asciidoctor-dark-mode.css
+++ b/converters/html/static/asciidoctor-dark-mode.css
@@ -389,13 +389,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/static/asciidoctor-dark-mode.css
+++ b/converters/html/static/asciidoctor-dark-mode.css
@@ -388,6 +388,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#1e1e1e;border-color:#383838;box-shadow:0 1px 4px rgba(0,0,0,.4)}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/asciidoctor-light-mode.css
+++ b/converters/html/static/asciidoctor-light-mode.css
@@ -385,12 +385,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/asciidoctor-light-mode.css
+++ b/converters/html/static/asciidoctor-light-mode.css
@@ -387,6 +387,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/asciidoctor-light-mode.css
+++ b/converters/html/static/asciidoctor-light-mode.css
@@ -388,13 +388,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/static/html5s-dark-mode.css
+++ b/converters/html/static/html5s-dark-mode.css
@@ -511,6 +511,17 @@ p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/html5s-dark-mode.css
+++ b/converters/html/static/html5s-dark-mode.css
@@ -509,12 +509,13 @@ p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
 p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/html5s-dark-mode.css
+++ b/converters/html/static/html5s-dark-mode.css
@@ -512,13 +512,6 @@ aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/static/html5s-light-mode.css
+++ b/converters/html/static/html5s-light-mode.css
@@ -511,6 +511,17 @@ p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/html5s-light-mode.css
+++ b/converters/html/static/html5s-light-mode.css
@@ -509,12 +509,13 @@ p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
 p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/static/html5s-light-mode.css
+++ b/converters/html/static/html5s-light-mode.css
@@ -512,13 +512,6 @@ aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/static/mathjax-config.js
+++ b/converters/html/static/mathjax-config.js
@@ -1,0 +1,37 @@
+// MathJax configuration acdc emits when `:stem:` is set. Loaded before the
+// MathJax bundle so it is picked up at startup.
+MathJax = {
+  loader: {load: ['input/asciimath']},
+  tex: {
+    processEscapes: false,
+    inlineMath: [['\\(', '\\)']],
+    displayMath: [['\\[', '\\]']]
+  },
+  asciimath: {
+    delimiters: {'[+]': [['\\$', '\\$']]},
+    displaystyle: false
+  },
+  options: {
+    ignoreHtmlClass: 'tex2jax_ignore|nostem|nolatexmath|noasciimath',
+    processHtmlClass: 'tex2jax_process'
+  },
+  startup: {
+    ready() {
+      MathJax.startup.defaultReady();
+      MathJax.startup.promise.then(() => {
+        const asciimath = MathJax._.input.asciimath.AsciiMath;
+        if (asciimath) {
+          const originalCompile = asciimath.compile;
+          asciimath.compile = function(math, display) {
+            const node = math.math;
+            if (node && node.parentElement && node.parentElement.parentElement &&
+              node.parentElement.parentElement.classList.contains('stemblock')) {
+              display = true;
+            }
+            return originalCompile.call(this, math, display);
+          };
+        }
+      });
+    }
+  }
+};

--- a/converters/html/static/terminal-replay-player.js
+++ b/converters/html/static/terminal-replay-player.js
@@ -1,0 +1,88 @@
+// Terminal-replay player: a tiny, self-contained vanilla-JS player shared by
+// every replay block on the page. It reads each block's JSON payload, swaps the
+// visible rows on a clock (only touching rows that actually change), and honours
+// `prefers-reduced-motion` by leaving the server-rendered final frame in place.
+// Defining `__acdcReplayInit` is idempotent, so emitting this once per block is
+// safe; every call initialises any not-yet-initialised player on the page.
+(function () {
+  function init(el) {
+    el.setAttribute('data-acdc-ready', '1');
+
+    var dataEl = el.querySelector('script.terminal-replay__data');
+    if (!dataEl) return;
+
+    var d;
+    try {
+      d = JSON.parse(dataEl.textContent);
+    } catch (e) {
+      return;
+    }
+
+    var screen = el.querySelector('.terminal-replay__screen');
+    if (!screen) return;
+
+    // Reduced motion: leave the server-rendered final frame as-is.
+    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    // The server renders only the final frame; build the remaining row slots.
+    while (screen.children.length < d.rows) {
+      var r = document.createElement('div');
+      r.className = 'terminal-replay__row';
+      screen.appendChild(r);
+    }
+
+    var slots = screen.querySelectorAll('.terminal-replay__row');
+
+    function show(s, on) {
+      slots[s].style.display = on ? '' : 'none';
+    }
+
+    // Every row is shown during playback; at rest only the final frame's rows.
+    function fill() {
+      for (var s = d.finalRows; s < slots.length; s++) show(s, true);
+    }
+    function trim() {
+      for (var s = d.finalRows; s < slots.length; s++) show(s, false);
+    }
+
+    // Render frame `f`, touching only the rows whose HTML actually changed.
+    function apply(f) {
+      var idx = d.frames[f];
+      for (var s = 0; s < idx.length; s++) {
+        var h = d.pool[idx[s]];
+        if (slots[s].__h !== h) {
+          slots[s].innerHTML = h;
+          slots[s].__h = h;
+        }
+      }
+    }
+
+    fill();
+    apply(0);
+
+    var n = d.frames.length;
+    var i = 0;
+    var start = null;
+
+    function step(ts) {
+      if (start === null) start = ts;
+      var t = ts - start;
+      while (i < n - 1 && d.times[i + 1] <= t) i++;
+      apply(i);
+      if (i < n - 1) {
+        requestAnimationFrame(step);
+      } else {
+        apply(n - 1);
+        trim();
+      }
+    }
+
+    requestAnimationFrame(step);
+  }
+
+  window.__acdcReplayInit = function () {
+    var els = document.querySelectorAll('.terminal-replay--player:not([data-acdc-ready])');
+    for (var i = 0; i < els.length; i++) init(els[i]);
+  };
+  window.__acdcReplayInit();
+})();

--- a/converters/html/static/terminal-replay-player.js
+++ b/converters/html/static/terminal-replay-player.js
@@ -8,7 +8,7 @@
   function init(el) {
     el.setAttribute('data-acdc-ready', '1');
 
-    var dataEl = el.querySelector('script.terminal-replay__data');
+    var dataEl = el.querySelector('script.terminal-view__data');
     if (!dataEl) return;
 
     var d;
@@ -18,20 +18,20 @@
       return;
     }
 
-    var screen = el.querySelector('.terminal-replay__screen');
-    if (!screen) return;
+    var stream = el.querySelector('.terminal-view__stream');
+    if (!stream) return;
 
     // Reduced motion: leave the server-rendered final frame as-is.
     if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
     // The server renders only the final frame; build the remaining row slots.
-    while (screen.children.length < d.rows) {
+    while (stream.children.length < d.rows) {
       var r = document.createElement('div');
-      r.className = 'terminal-replay__row';
-      screen.appendChild(r);
+      r.className = 'terminal-view__row';
+      stream.appendChild(r);
     }
 
-    var slots = screen.querySelectorAll('.terminal-replay__row');
+    var slots = stream.querySelectorAll('.terminal-view__row');
 
     function show(s, on) {
       slots[s].style.display = on ? '' : 'none';
@@ -81,7 +81,7 @@
   }
 
   window.__acdcReplayInit = function () {
-    var els = document.querySelectorAll('.terminal-replay--player:not([data-acdc-ready])');
+    var els = document.querySelectorAll('.terminal-view--replay:not([data-acdc-ready])');
     for (var i = 0; i < els.length; i++) init(els[i]);
   };
   window.__acdcReplayInit();

--- a/converters/html/tests/fixtures/expected/html/standalone/author_attribute_overrides_line.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_attribute_overrides_line.html
@@ -398,6 +398,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_attribute_overrides_line.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_attribute_overrides_line.html
@@ -396,12 +396,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_attribute_overrides_line.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_attribute_overrides_line.html
@@ -399,13 +399,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute.html
@@ -398,6 +398,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute.html
@@ -396,12 +396,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute.html
@@ -399,13 +399,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute_with_email.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute_with_email.html
@@ -398,6 +398,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute_with_email.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute_with_email.html
@@ -396,12 +396,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute_with_email.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/author_from_attribute_with_email.html
@@ -399,13 +399,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/doctitle_only.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/doctitle_only.html
@@ -398,13 +398,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/doctitle_only.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/doctitle_only.html
@@ -395,12 +395,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/doctitle_only.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/doctitle_only.html
@@ -397,6 +397,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/firstname_lastname_alone.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/firstname_lastname_alone.html
@@ -398,13 +398,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/firstname_lastname_alone.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/firstname_lastname_alone.html
@@ -395,12 +395,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/firstname_lastname_alone.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/firstname_lastname_alone.html
@@ -397,6 +397,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/level0_appendix_numbering.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/level0_appendix_numbering.html
@@ -398,13 +398,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/level0_appendix_numbering.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/level0_appendix_numbering.html
@@ -395,12 +395,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/level0_appendix_numbering.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/level0_appendix_numbering.html
@@ -397,6 +397,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/outline.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/outline.html
@@ -400,13 +400,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/outline.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/outline.html
@@ -397,12 +397,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/outline.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/outline.html
@@ -399,6 +399,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/revision_header_footer.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/revision_header_footer.html
@@ -398,6 +398,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/revision_header_footer.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/revision_header_footer.html
@@ -396,12 +396,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/revision_header_footer.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/revision_header_footer.html
@@ -399,13 +399,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/special_section_numbering.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/special_section_numbering.html
@@ -398,13 +398,6 @@ p{margin-bottom:1.25rem}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html/standalone/special_section_numbering.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/special_section_numbering.html
@@ -395,12 +395,13 @@ p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html/standalone/special_section_numbering.html
+++ b/converters/html/tests/fixtures/expected/html/standalone/special_section_numbering.html
@@ -397,6 +397,17 @@ p{margin-bottom:1.25rem}
 .exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html5s/standalone/outline.html
+++ b/converters/html/tests/fixtures/expected/html5s/standalone/outline.html
@@ -523,6 +523,17 @@ p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html5s/standalone/outline.html
+++ b/converters/html/tests/fixtures/expected/html5s/standalone/outline.html
@@ -524,13 +524,6 @@ aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html5s/standalone/outline.html
+++ b/converters/html/tests/fixtures/expected/html5s/standalone/outline.html
@@ -521,12 +521,13 @@ p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
 p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html5s/standalone/special_section_numbering.html
+++ b/converters/html/tests/fixtures/expected/html5s/standalone/special_section_numbering.html
@@ -519,12 +519,13 @@ p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
 p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
-.terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
-.terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
-.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
-.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
-.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
+.terminal-view{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
+.terminal-view__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-view--light{background-color:#f6f8fa;color:#1f2328}
+.terminal-view--dark{background-color:#0d1117;color:#e6edf3}
+.terminal-view__viewport{overflow:auto;max-width:100%;padding:0 18px 18px}
+.terminal-view__stream{margin:0;padding:0;width:max-content;font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;font-size:14px;line-height:1.2;white-space:normal;tab-size:4}
+.terminal-view__row{white-space:pre;min-height:1.2em}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/html/tests/fixtures/expected/html5s/standalone/special_section_numbering.html
+++ b/converters/html/tests/fixtures/expected/html5s/standalone/special_section_numbering.html
@@ -522,13 +522,6 @@ aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
 .terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
-.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
-.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
-.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
-.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
-.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
-.terminal-replay__dots>span:nth-child(3){background:#27c93f}
-.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
 .terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
 .terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}

--- a/converters/html/tests/fixtures/expected/html5s/standalone/special_section_numbering.html
+++ b/converters/html/tests/fixtures/expected/html5s/standalone/special_section_numbering.html
@@ -521,6 +521,17 @@ p{margin-bottom:1.25rem}
 aside.sidebar p,aside.sidebar dt,aside.sidebar td.content,p.tableblock{font-size:1em}
 .terminal-preview{margin:1.25em 0;max-width:100%;overflow:auto;border-radius:8px;box-shadow:0 16px 50px rgba(0,0,0,.18)}
 .terminal-preview__screen{margin:0;padding:18px;font:14px/1.45 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;white-space:pre;tab-size:4}
+.terminal-replay{background:var(--acdc-term-bg,#0d1117);color:var(--acdc-term-fg,#e6edf3);border-radius:var(--acdc-term-radius,8px)}
+.terminal-replay__titlebar{display:flex;align-items:center;gap:8px;padding:9px 13px}
+.terminal-replay__dots{display:inline-flex;gap:6px;flex:none}
+.terminal-replay__dots>span{display:inline-block;width:11px;height:11px;border-radius:50%}
+.terminal-replay__dots>span:nth-child(1){background:#ff5f56}
+.terminal-replay__dots>span:nth-child(2){background:#ffbd2e}
+.terminal-replay__dots>span:nth-child(3){background:#27c93f}
+.terminal-replay__title{flex:1;min-width:0;font:600 12px/1 ui-monospace,SFMono-Regular,Menlo,monospace;opacity:.75;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.terminal-replay__viewport{overflow:auto;max-width:100%;padding:var(--acdc-term-padding,0 18px 18px)}
+.terminal-replay__screen{margin:0;padding:0;width:max-content;font-family:var(--acdc-term-font-family,ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace);font-size:var(--acdc-term-font-size,14px);line-height:var(--acdc-term-line-height,1.2);white-space:normal;tab-size:4}
+.terminal-replay__row{white-space:pre;min-height:calc(var(--acdc-term-line-height,1.2)*1em)}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
 @media print{*{box-shadow:none!important;text-shadow:none!important}

--- a/converters/terminal/CHANGELOG.md
+++ b/converters/terminal/CHANGELOG.md
@@ -17,17 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An ordered list with an explicit numbering style (`[loweralpha]`, `[upperalpha]`,
   `[lowerroman]`, `[upperroman]`, `[lowergreek]`, `[arabic]`, `[decimal]`) renders
   its markers in that style (e.g. `a.`, `IV.`, `α.`) instead of always `1.`, `2.`.
-- Terminal replay frame capture (`replay::capture` / `capture_windowed`) builds
-  ordered, deduplicated `CellGrid` frames from recorded ANSI for animated replay
-  renderers; `capture_windowed` is a fast path for append-only recordings.
-  Captured cells carry their palette index alongside the resolved colour, so a
-  player can re-resolve against a recording's own palette.
-- `asciicast` module parses asciicast v2 and v3 (`.cast`) recordings (via the
-  `asciicast-rs` crate) into a `Recording` of replay frames. Recorded commands
-  and input are never executed. Long idle gaps are compressed to the header's
-  `idle_time_limit` (or a caller override, or a default) so playback dwells on
-  real output, and the recording's theme colours, palette, and command/title are
-  exposed for a player to render chrome and faithful colours.
+- Terminal replay frame capture (`replay::capture` / `capture_windowed`) turns
+  recorded ANSI into ordered, deduplicated `CellGrid` frames for animated replay
+  renderers; `capture_windowed` is a fast path for append-only recordings. Each
+  captured cell keeps its palette index alongside the resolved colour, so a
+  player can re-resolve it against a recording's own palette.
+- The `asciicast` module parses asciicast v2/v3 (`.cast`) recordings into a
+  `Recording` of replay frames (via `asciicast-rs`). Recorded commands and input
+  are never executed; long idle gaps are compressed (the header's
+  `idle_time_limit`, a caller override, or a default), and the recording's theme,
+  palette, and title are exposed for faithful playback.
 - `[subs="-replacements"]` on a paragraph now keeps typography source (`--`,
   `(C)`, `->`, `...`) literal instead of converting to Unicode.
 - User-facing converter warnings are now collected in `ConversionResult` for

--- a/converters/terminal/CHANGELOG.md
+++ b/converters/terminal/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terminal replay frame capture (`replay::capture` / `capture_windowed`) builds
   ordered, deduplicated `CellGrid` frames from recorded ANSI for animated replay
   renderers; `capture_windowed` is a fast path for append-only recordings.
+  Captured cells carry their palette index alongside the resolved colour, so a
+  player can re-resolve against a recording's own palette.
+- `asciicast` module parses asciicast v2 and v3 (`.cast`) recordings (via the
+  `asciicast-rs` crate) into a `Recording` of replay frames. Recorded commands
+  and input are never executed. Long idle gaps are compressed to the header's
+  `idle_time_limit` (or a caller override, or a default) so playback dwells on
+  real output, and the recording's theme colours, palette, and command/title are
+  exposed for a player to render chrome and faithful colours.
 - `[subs="-replacements"]` on a paragraph now keeps typography source (`--`,
   `(C)`, `->`, `...`) literal instead of converting to Unicode.
 - User-facing converter warnings are now collected in `ConversionResult` for

--- a/converters/terminal/Cargo.toml
+++ b/converters/terminal/Cargo.toml
@@ -12,7 +12,7 @@ default = ["pre-spec-subs"]
 pre-spec-subs = ["acdc-parser/pre-spec-subs", "acdc-converters-core/pre-spec-subs"]
 images = ["dep:viuer"]
 highlighting = ["dep:syntect"]
-render-state = ["dep:libghostty-vt", "dep:asciicast-rs", "dep:serde", "dep:serde_json"]
+emulator = ["dep:libghostty-vt", "dep:asciicast-rs", "dep:serde", "dep:serde_json"]
 
 [dependencies]
 acdc-converters-core.workspace = true
@@ -23,9 +23,9 @@ thiserror.workspace = true
 tracing.workspace = true
 unicode-width.workspace = true
 libghostty-vt = { version = "0.2.0", optional = true }
-# asciicast (.cast) replay parsing (optional - only needed with render-state)
+# asciicast (.cast) replay parsing (optional - only needed with emulator)
 asciicast-rs = { version = "0.3", optional = true }
-# peek the asciicast version before picking a streaming reader (render-state only)
+# peek the asciicast version before picking a streaming reader (emulator only)
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 # syntax highlighting (optional - saves ~7s compile time when disabled)

--- a/converters/terminal/Cargo.toml
+++ b/converters/terminal/Cargo.toml
@@ -12,7 +12,7 @@ default = ["pre-spec-subs"]
 pre-spec-subs = ["acdc-parser/pre-spec-subs", "acdc-converters-core/pre-spec-subs"]
 images = ["dep:viuer"]
 highlighting = ["dep:syntect"]
-render-state = ["dep:libghostty-vt"]
+render-state = ["dep:libghostty-vt", "dep:asciicast-rs", "dep:serde", "dep:serde_json"]
 
 [dependencies]
 acdc-converters-core.workspace = true
@@ -23,6 +23,11 @@ thiserror.workspace = true
 tracing.workspace = true
 unicode-width.workspace = true
 libghostty-vt = { version = "0.2.0", optional = true }
+# asciicast (.cast) replay parsing (optional - only needed with render-state)
+asciicast-rs = { version = "0.2", optional = true }
+# peek the asciicast version before picking a streaming reader (render-state only)
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 # syntax highlighting (optional - saves ~7s compile time when disabled)
 syntect = { version = "5.3", optional = true }
 # images on the terminal (optional - saves ~16s compile time when disabled)

--- a/converters/terminal/Cargo.toml
+++ b/converters/terminal/Cargo.toml
@@ -24,7 +24,7 @@ tracing.workspace = true
 unicode-width.workspace = true
 libghostty-vt = { version = "0.2.0", optional = true }
 # asciicast (.cast) replay parsing (optional - only needed with render-state)
-asciicast-rs = { version = "0.2", optional = true }
+asciicast-rs = { version = "0.3", optional = true }
 # peek the asciicast version before picking a streaming reader (render-state only)
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }

--- a/converters/terminal/src/asciicast.rs
+++ b/converters/terminal/src/asciicast.rs
@@ -1,0 +1,604 @@
+//! Convert asciicast (`.cast`) recordings into source-neutral replay events.
+//!
+//! Parsing is delegated to the [`asciicast-rs`](https://crates.io/crates/asciicast-rs)
+//! crate; this module converts its versioned event model into the shared
+//! [`replay`] representation behind an opaque [`Recording`]. A recording is
+//! treated as *replay data only*: recorded output bytes are fed to the terminal
+//! emulator, while recorded commands, input, markers, and exit status are inert
+//! metadata that is never executed.
+//!
+//! asciicast v2 and v3 are supported (v1 is rejected). Events are pulled lazily
+//! from a streaming [`asciicast_rs::Reader`] one line at a time, so a long
+//! recording is never fully buffered as a parsed event vector before conversion.
+//! The reader's [`absolute_times`](asciicast_rs::Reader::absolute_times) adapter
+//! normalises the two versions' timing (v2's absolute timestamps and v3's
+//! per-event intervals) into the absolute timestamps the replay core expects.
+//! Resize events apply grow-only (a dimension may grow but never shrink), so a
+//! replay never loses content that was visible at a larger size.
+
+use std::{io::BufRead, time::Duration};
+
+use acdc_parser::InlineNode;
+use asciicast_rs::{Reader, V2, V3, common, v2, v3};
+
+use crate::{
+    cell_grid::{Rgb, TerminalSize},
+    replay::{self, Event},
+};
+
+/// The default foreground/background colours recorded in an asciicast header.
+///
+/// A premium replay paints its chrome with the terminal's own colours instead
+/// of a generic light/dark theme; this is the subset of the recorded theme the
+/// renderer needs (the indexed palette resolves per cell during capture).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReplayTheme {
+    /// Default foreground (text) colour.
+    pub fg: Rgb,
+    /// Default background colour.
+    pub bg: Rgb,
+    /// The 16-colour palette (slots 0–15), each present when the recording
+    /// declared it. A renderer can publish these as themeable palette colours.
+    pub palette: [Option<Rgb>; 16],
+}
+
+impl From<&common::Theme> for ReplayTheme {
+    fn from(theme: &common::Theme) -> Self {
+        let mut palette = [None; 16];
+        for (slot, colour) in palette.iter_mut().zip(theme.palette.iter()) {
+            *slot = Some(rgb_from(*colour));
+        }
+        Self {
+            fg: rgb_from(theme.fg),
+            bg: rgb_from(theme.bg),
+            palette,
+        }
+    }
+}
+
+/// Convert an `asciicast-rs` colour into acdc's [`Rgb`].
+fn rgb_from(colour: common::Rgb) -> Rgb {
+    Rgb {
+        r: colour.r(),
+        g: colour.g(),
+        b: colour.b(),
+    }
+}
+
+/// A parsed asciicast recording, converted into replay events.
+///
+/// This is the only handle callers hold. Its internals (the initial size and
+/// the converted replay events) are private on purpose: a consumer works through
+/// [`size`](Self::size), [`duration`](Self::duration), and
+/// [`capture`](Self::capture) and never sees the asciicast event model or the
+/// `replay` representation it was converted into. That keeps recording sampling
+/// and frame capture owned here rather than leaking into call sites.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Recording {
+    size: TerminalSize,
+    events: Vec<Event<'static>>,
+    theme: Option<ReplayTheme>,
+    title: Option<String>,
+}
+
+impl Recording {
+    /// Initial terminal size declared by the recording header.
+    #[must_use]
+    pub const fn size(&self) -> TerminalSize {
+        self.size
+    }
+
+    /// Total recorded duration: the absolute timestamp of the last event, if any.
+    #[must_use]
+    pub fn duration(&self) -> Option<Duration> {
+        self.events.last().and_then(Event::timestamp)
+    }
+
+    /// The default colours recorded in the header, if the recording carried a
+    /// theme. Used to paint a replay's chrome in the terminal's own colours.
+    #[must_use]
+    pub const fn theme(&self) -> Option<ReplayTheme> {
+        self.theme
+    }
+
+    /// A human label for the recording: its `title`, falling back to the
+    /// recorded `command`. Shown in a replay's title bar.
+    #[must_use]
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Capture replay frames from the recording.
+    ///
+    /// Events are first down-sampled to at most `max_frames` terminal writes
+    /// (dropped output is folded into the next kept write so nothing is lost),
+    /// then fed to the shared replay capture pipeline at `size`.
+    /// `default_frame_duration` only spaces untimed events; asciicast events are
+    /// always timed, so it has no effect in practice.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when terminal dimensions are invalid, render-state
+    /// capture fails, or event timestamps move backwards.
+    pub fn capture(
+        self,
+        size: TerminalSize,
+        max_frames: usize,
+        default_frame_duration: Duration,
+    ) -> Result<replay::Timeline, replay::Error> {
+        let events = sample_events(self.events, max_frames);
+        let options =
+            replay::Options::new(size).with_default_frame_duration(default_frame_duration);
+        replay::capture(events, options)
+    }
+}
+
+/// Error returned when an asciicast recording cannot be parsed.
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// The recording could not be parsed by `asciicast-rs`.
+    #[error(transparent)]
+    Parse(#[from] asciicast_rs::Error),
+    /// The recording used a version the converter does not replay.
+    #[error("unsupported asciicast version {version}; only versions 2 and 3 are supported")]
+    UnsupportedVersion {
+        /// The version found in the recording.
+        version: u8,
+    },
+}
+
+/// Parse asciicast text into a [`Recording`].
+///
+/// The header's `version` field is peeked first, then the matching streaming
+/// reader converts the events lazily. v1 and any other unsupported version are
+/// rejected with [`Error::UnsupportedVersion`].
+fn parse(input: &str) -> Result<Recording, Error> {
+    parse_with(input, None)
+}
+
+/// Parse like [`parse`], but override the idle-gap cap (seconds) used to compress
+/// dead air. `None` falls back to the header's `idle_time_limit`, then to
+/// [`DEFAULT_IDLE_LIMIT_SECS`].
+fn parse_with(input: &str, idle_override: Option<f64>) -> Result<Recording, Error> {
+    match detect_version(input)? {
+        2 => recording_from_v2(v2::stream(input.as_bytes())?, idle_override),
+        3 => recording_from_v3(v3::stream(input.as_bytes())?, idle_override),
+        version => Err(Error::UnsupportedVersion { version }),
+    }
+}
+
+/// The one header field [`detect_version`] needs; other fields are ignored, so
+/// only the `version` integer is materialised rather than the whole header.
+#[derive(serde::Deserialize)]
+struct VersionProbe {
+    version: u8,
+}
+
+/// Peek the `version` field from the recording's header line without parsing the
+/// whole document, so [`parse`] can pick the right typed streaming reader.
+fn detect_version(input: &str) -> Result<u8, Error> {
+    let header = input
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .ok_or(asciicast_rs::Error::MissingHeader)?;
+    let probe: VersionProbe = serde_json::from_str(header).map_err(asciicast_rs::Error::from)?;
+    Ok(probe.version)
+}
+
+/// Parse an asciicast recording from a verbatim block's inline nodes.
+///
+/// The block content is reconstructed as plain text (joined on newlines) and
+/// parsed with [`parse`].
+///
+/// # Errors
+///
+/// Returns the same errors as [`parse`].
+pub fn parse_inlines(inlines: &[InlineNode<'_>]) -> Result<Recording, Error> {
+    parse(&crate::extract_inline_text(inlines, "\n"))
+}
+
+/// Parse an asciicast recording from inline nodes, overriding the idle-gap cap.
+///
+/// `idle_limit` caps the gap between consecutive events, compressing dead air
+/// (e.g. a build before a test run) so a replay dwells on real output. `None`
+/// falls back to the recording's `idle_time_limit` header, then to a default.
+///
+/// # Errors
+///
+/// Returns the same errors as [`parse_inlines`].
+pub fn parse_inlines_with(
+    inlines: &[InlineNode<'_>],
+    idle_limit: Option<Duration>,
+) -> Result<Recording, Error> {
+    parse_with(
+        &crate::extract_inline_text(inlines, "\n"),
+        idle_limit.map(|limit| limit.as_secs_f64()),
+    )
+}
+
+/// Build a [`Recording`] from a streaming v2 reader: terminal size, theme, and
+/// title come from the header, then each output event becomes a timed terminal
+/// write (idle gaps compressed), resizes become grow-only resizes, and input,
+/// markers, and exit are ignored. v2 stores absolute timestamps, which
+/// `absolute_times` yields directly.
+fn recording_from_v2<R: BufRead>(
+    reader: Reader<V2, R>,
+    idle_override: Option<f64>,
+) -> Result<Recording, Error> {
+    let header = reader.header();
+    let size = TerminalSize::new(header.width.into(), header.height.into());
+    let theme = header.theme.as_ref().map(ReplayTheme::from);
+    let title = header.title.clone().or_else(|| header.command.clone());
+    let mut clock = IdleClock::new(idle_override, header.idle_time_limit);
+    let mut current = size;
+    let mut events = Vec::new();
+    for item in reader.absolute_times() {
+        let (time, event) = item?;
+        let at = clock.tick(time);
+        match event.payload {
+            v2::EventPayload::Output(data) => events.push(Event::write_at(data.into_bytes(), at)),
+            v2::EventPayload::Resize(resize) => {
+                push_resize(&mut events, &mut current, at, resize.cols, resize.rows);
+            }
+            // Input, markers, and any future payloads are inert replay metadata.
+            v2::EventPayload::Input(_) | v2::EventPayload::Marker(_) | _ => {}
+        }
+    }
+    Ok(Recording {
+        size,
+        events,
+        theme,
+        title,
+    })
+}
+
+/// Build a [`Recording`] from a streaming v3 reader, like [`recording_from_v2`]
+/// but for v3, whose header nests the terminal info and adds exit events. v3
+/// stores per-event intervals, which `absolute_times` accumulates into the
+/// absolute timestamps used here.
+fn recording_from_v3<R: BufRead>(
+    reader: Reader<V3, R>,
+    idle_override: Option<f64>,
+) -> Result<Recording, Error> {
+    let header = reader.header();
+    let size = TerminalSize::new(header.term.cols.into(), header.term.rows.into());
+    let theme = header.term.theme.as_ref().map(ReplayTheme::from);
+    let title = header.title.clone().or_else(|| header.command.clone());
+    let mut clock = IdleClock::new(idle_override, header.idle_time_limit);
+    let mut current = size;
+    let mut events = Vec::new();
+    for item in reader.absolute_times() {
+        let (time, event) = item?;
+        let at = clock.tick(time);
+        match event.payload {
+            v3::EventPayload::Output(data) => events.push(Event::write_at(data.into_bytes(), at)),
+            v3::EventPayload::Resize(resize) => {
+                push_resize(&mut events, &mut current, at, resize.cols, resize.rows);
+            }
+            // Input, markers, exit status, and any future payloads are inert
+            // replay metadata.
+            v3::EventPayload::Input(_)
+            | v3::EventPayload::Marker(_)
+            | v3::EventPayload::Exit(_)
+            | _ => {}
+        }
+    }
+    Ok(Recording {
+        size,
+        events,
+        theme,
+        title,
+    })
+}
+
+/// Push a grow-only resize event: a dimension may grow but never shrink, so a
+/// replay never loses content that was visible at a larger size. A resize that
+/// would not grow the terminal is dropped.
+fn push_resize(
+    events: &mut Vec<Event<'static>>,
+    current: &mut TerminalSize,
+    at: Duration,
+    cols: u16,
+    rows: u16,
+) {
+    let grown = TerminalSize::new(current.cols.max(cols.into()), current.rows.max(rows.into()));
+    if grown != *current {
+        *current = grown;
+        events.push(Event::resize_at(grown, at));
+    }
+}
+
+/// Convert a recorded duration in seconds into a [`Duration`], treating
+/// non-finite or negative values (which a valid recording never has) as zero.
+fn seconds(value: f64) -> Duration {
+    Duration::try_from_secs_f64(value).unwrap_or(Duration::ZERO)
+}
+
+/// Default cap (seconds) on the idle gap between two events when the header does
+/// not set `idle_time_limit`. Recordings often front-load dead air (e.g. a
+/// `cargo build` before a test run), so without a cap a replay spends most of
+/// its time on a frozen screen. Compressing long gaps keeps playback on the
+/// parts that actually change. Gaps shorter than this are left untouched.
+const DEFAULT_IDLE_LIMIT_SECS: f64 = 2.0;
+
+/// Turns raw absolute event times into idle-compressed ones: any gap longer than
+/// `idle_limit` is shortened to it, so dead air never dominates a replay while
+/// the relative timing of active output is preserved.
+struct IdleClock {
+    idle_limit: f64,
+    previous_raw: f64,
+    elapsed: f64,
+}
+
+impl IdleClock {
+    /// Build a clock from the first positive limit among an explicit override
+    /// and the header's `idle_time_limit`, falling back to
+    /// [`DEFAULT_IDLE_LIMIT_SECS`] when neither is set.
+    fn new(idle_override: Option<f64>, header_limit: Option<f64>) -> Self {
+        let idle_limit = [idle_override, header_limit]
+            .into_iter()
+            .flatten()
+            .find(|limit| limit.is_finite() && *limit > 0.0)
+            .unwrap_or(DEFAULT_IDLE_LIMIT_SECS);
+        Self {
+            idle_limit,
+            previous_raw: 0.0,
+            elapsed: 0.0,
+        }
+    }
+
+    /// Advance to raw absolute time `raw`, returning the compressed timestamp.
+    fn tick(&mut self, raw: f64) -> Duration {
+        let gap = (raw - self.previous_raw).clamp(0.0, self.idle_limit);
+        self.elapsed += gap;
+        self.previous_raw = raw;
+        seconds(self.elapsed)
+    }
+}
+
+/// Down-sample timed replay events to at most `max_frames` writes. Output bytes
+/// between kept writes are concatenated into the next kept write (so no output is
+/// lost) at that write's real timestamp; resize events are always kept and flush
+/// any pending bytes before them, preserving ordering and monotonic timing.
+fn sample_events(events: Vec<Event<'static>>, max_frames: usize) -> Vec<Event<'static>> {
+    let write_count = events
+        .iter()
+        .filter(|event| matches!(event, Event::Write { .. }))
+        .count();
+    // Every write fits the budget, so nothing is merged or dropped: hand back the
+    // events as-is instead of copying their bytes through the merge buffer below.
+    if max_frames >= write_count {
+        return events;
+    }
+    // The kept indices are sorted and unique and write ordinals are visited in
+    // order, so a single forward cursor over them replaces a set membership test.
+    let mut keep = replay::sampled_indexes(write_count, max_frames)
+        .into_iter()
+        .peekable();
+
+    let mut result = Vec::new();
+    let mut pending: Vec<u8> = Vec::new();
+    let mut pending_at = Duration::ZERO;
+    let mut write_ordinal = 0;
+
+    for event in events {
+        match event {
+            Event::Write { bytes, at } => {
+                pending.extend_from_slice(&bytes);
+                pending_at = at.unwrap_or(pending_at);
+                let keep_this = keep.peek() == Some(&write_ordinal);
+                if keep_this {
+                    keep.next();
+                }
+                write_ordinal += 1;
+                if keep_this && !pending.is_empty() {
+                    result.push(Event::write_at(std::mem::take(&mut pending), pending_at));
+                }
+            }
+            Event::Resize { size, at } => {
+                if !pending.is_empty() {
+                    result.push(Event::write_at(std::mem::take(&mut pending), pending_at));
+                }
+                result.push(Event::Resize { size, at });
+            }
+            other @ Event::TimingBoundary { .. } => result.push(other),
+        }
+    }
+    if !pending.is_empty() {
+        result.push(Event::write_at(pending, pending_at));
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_v2_output_with_absolute_timestamps() -> Result<(), Error> {
+        let cast = concat!(
+            "{\"version\": 2, \"width\": 80, \"height\": 24}\n",
+            "[0.5, \"o\", \"hello\"]\n",
+            "[1.5, \"o\", \" world\\r\\n\"]\n",
+        );
+        let recording = parse(cast)?;
+
+        assert_eq!(recording.size(), TerminalSize::new(80, 24));
+        assert_eq!(
+            recording.events,
+            vec![
+                Event::write_at(b"hello".to_vec(), Duration::from_millis(500)),
+                Event::write_at(b" world\r\n".to_vec(), Duration::from_millis(1500)),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn long_idle_gaps_are_compressed_to_the_default_limit() -> Result<(), Error> {
+        // A 60s gap before the second event (dead air, e.g. compilation) is
+        // capped to the 2s default; the short 0.3s gap after it is untouched.
+        let cast = concat!(
+            "{\"version\": 2, \"width\": 80, \"height\": 24}\n",
+            "[0.0, \"o\", \"build\\r\\n\"]\n",
+            "[60.0, \"o\", \"first\\r\\n\"]\n",
+            "[60.3, \"o\", \"second\\r\\n\"]\n",
+        );
+        let recording = parse(cast)?;
+
+        assert_eq!(
+            recording.events,
+            vec![
+                Event::write_at(b"build\r\n".to_vec(), Duration::ZERO),
+                Event::write_at(b"first\r\n".to_vec(), Duration::from_secs(2)),
+                Event::write_at(b"second\r\n".to_vec(), Duration::from_millis(2300)),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn header_idle_time_limit_overrides_the_default() -> Result<(), Error> {
+        // The header sets a 0.5s idle limit, so the 60s gap collapses to 0.5s.
+        let cast = concat!(
+            "{\"version\": 2, \"width\": 80, \"height\": 24, \"idle_time_limit\": 0.5}\n",
+            "[0.0, \"o\", \"a\"]\n",
+            "[60.0, \"o\", \"b\"]\n",
+        );
+        let recording = parse(cast)?;
+
+        assert_eq!(
+            recording.events,
+            vec![
+                Event::write_at(b"a".to_vec(), Duration::ZERO),
+                Event::write_at(b"b".to_vec(), Duration::from_millis(500)),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn header_theme_and_command_are_captured() -> Result<(), Error> {
+        let cast = concat!(
+            "{\"version\": 2, \"width\": 80, \"height\": 24, \"command\": \"cargo test\", ",
+            "\"theme\": {\"fg\": \"#c0caf5\", \"bg\": \"#1a1b26\", ",
+            "\"palette\": \"#000000:#ff0000:#00ff00:#ffff00:#0000ff:#ff00ff:#00ffff:#ffffff\"}}\n",
+            "[0.0, \"o\", \"hi\"]\n",
+        );
+        let recording = parse(cast)?;
+
+        assert_eq!(recording.title(), Some("cargo test"));
+        assert_eq!(
+            recording.theme().map(|t| t.fg),
+            Some(Rgb {
+                r: 0xc0,
+                g: 0xca,
+                b: 0xf5
+            })
+        );
+        assert_eq!(
+            recording.theme().map(|t| t.bg),
+            Some(Rgb {
+                r: 0x1a,
+                g: 0x1b,
+                b: 0x26
+            })
+        );
+        // The eight declared palette colours fill slots 0–7; the rest stay unset.
+        assert_eq!(
+            recording.theme().and_then(|t| t.palette[0]),
+            Some(Rgb { r: 0, g: 0, b: 0 })
+        );
+        assert_eq!(
+            recording.theme().and_then(|t| t.palette[7]),
+            Some(Rgb {
+                r: 0xff,
+                g: 0xff,
+                b: 0xff
+            })
+        );
+        assert_eq!(recording.theme().and_then(|t| t.palette[8]), None);
+        Ok(())
+    }
+
+    #[test]
+    fn parses_v3_term_object_and_accumulates_relative_intervals() -> Result<(), Error> {
+        // v3 times are intervals since the previous event, so absolute
+        // timestamps are the running sum: 0.5, then 0.5 + 0.25 = 0.75.
+        let cast = concat!(
+            "{\"version\": 3, \"term\": {\"cols\": 100, \"rows\": 30}}\n",
+            "[0.5, \"o\", \"a\"]\n",
+            "[0.25, \"o\", \"b\"]\n",
+        );
+        let recording = parse(cast)?;
+
+        assert_eq!(recording.size(), TerminalSize::new(100, 30));
+        assert_eq!(
+            recording.events,
+            vec![
+                Event::write_at(b"a".to_vec(), Duration::from_millis(500)),
+                Event::write_at(b"b".to_vec(), Duration::from_millis(750)),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resize_grows_but_never_shrinks() -> Result<(), Error> {
+        let cast = concat!(
+            "{\"version\": 2, \"width\": 80, \"height\": 24}\n",
+            "[0.1, \"r\", \"100x30\"]\n",
+            "[0.2, \"r\", \"40x10\"]\n",
+            "[0.3, \"r\", \"100x40\"]\n",
+        );
+        let recording = parse(cast)?;
+
+        // First resize grows to 100x30; the shrink to 40x10 is dropped; the
+        // final resize grows rows to 40 while keeping the wider 100 columns.
+        assert_eq!(
+            recording.events,
+            vec![
+                Event::resize_at(TerminalSize::new(100, 30), Duration::from_millis(100)),
+                Event::resize_at(TerminalSize::new(100, 40), Duration::from_millis(300)),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_input_marker_and_exit_events() -> Result<(), Error> {
+        let cast = concat!(
+            "{\"version\": 3, \"term\": {\"cols\": 80, \"rows\": 24}}\n",
+            "[0.1, \"i\", \"ls\"]\n",
+            "[0.2, \"m\", \"chapter 1\"]\n",
+            "[0.3, \"o\", \"out\"]\n",
+            "[0.4, \"x\", \"0\"]\n",
+        );
+        let recording = parse(cast)?;
+
+        // Only the output event survives; input, marker, and exit are inert.
+        // Intervals still accumulate across the ignored events: 0.1+0.2+0.3.
+        assert_eq!(
+            recording.events,
+            vec![Event::write_at(b"out".to_vec(), Duration::from_millis(600))]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unsupported_v1_is_an_error() {
+        let cast =
+            "{\"version\": 1, \"width\": 80, \"height\": 24, \"duration\": 1.0, \"stdout\": []}";
+        assert!(matches!(
+            parse(cast),
+            Err(Error::UnsupportedVersion { version: 1 })
+        ));
+    }
+
+    #[test]
+    fn malformed_input_is_a_parse_error() {
+        assert!(matches!(parse("not a cast"), Err(Error::Parse(_))));
+    }
+}

--- a/converters/terminal/src/asciicast.rs
+++ b/converters/terminal/src/asciicast.rs
@@ -108,28 +108,19 @@ impl Recording {
         self.title.as_deref()
     }
 
-    /// Capture replay frames from the recording.
+    /// Capture replay frames from the recording at `size`.
     ///
-    /// Events are first down-sampled to at most `max_frames` terminal writes
-    /// (dropped output is folded into the next kept write so nothing is lost),
-    /// then fed to the shared replay capture pipeline at `size`.
-    /// `default_frame_duration` only spaces untimed events; asciicast events are
-    /// always timed, so it has no effect in practice.
+    /// Every distinct visible screen the session produced is captured (with
+    /// consecutive duplicates deduplicated by the shared replay pipeline).
+    /// asciicast events are always timed, so no synthetic frame spacing is
+    /// applied.
     ///
     /// # Errors
     ///
     /// Returns an error when terminal dimensions are invalid, render-state
     /// capture fails, or event timestamps move backwards.
-    pub fn capture(
-        self,
-        size: TerminalSize,
-        max_frames: usize,
-        default_frame_duration: Duration,
-    ) -> Result<replay::Timeline, replay::Error> {
-        let events = sample_events(self.events, max_frames);
-        let options =
-            replay::Options::new(size).with_default_frame_duration(default_frame_duration);
-        replay::capture(events, options)
+    pub fn capture(self, size: TerminalSize) -> Result<replay::Timeline, replay::Error> {
+        replay::capture(self.events, replay::Options::new(size))
     }
 }
 
@@ -356,60 +347,6 @@ impl IdleClock {
         self.previous_raw = raw;
         seconds(self.elapsed)
     }
-}
-
-/// Down-sample timed replay events to at most `max_frames` writes. Output bytes
-/// between kept writes are concatenated into the next kept write (so no output is
-/// lost) at that write's real timestamp; resize events are always kept and flush
-/// any pending bytes before them, preserving ordering and monotonic timing.
-fn sample_events(events: Vec<Event<'static>>, max_frames: usize) -> Vec<Event<'static>> {
-    let write_count = events
-        .iter()
-        .filter(|event| matches!(event, Event::Write { .. }))
-        .count();
-    // Every write fits the budget, so nothing is merged or dropped: hand back the
-    // events as-is instead of copying their bytes through the merge buffer below.
-    if max_frames >= write_count {
-        return events;
-    }
-    // The kept indices are sorted and unique and write ordinals are visited in
-    // order, so a single forward cursor over them replaces a set membership test.
-    let mut keep = replay::sampled_indexes(write_count, max_frames)
-        .into_iter()
-        .peekable();
-
-    let mut result = Vec::new();
-    let mut pending: Vec<u8> = Vec::new();
-    let mut pending_at = Duration::ZERO;
-    let mut write_ordinal = 0;
-
-    for event in events {
-        match event {
-            Event::Write { bytes, at } => {
-                pending.extend_from_slice(&bytes);
-                pending_at = at.unwrap_or(pending_at);
-                let keep_this = keep.peek() == Some(&write_ordinal);
-                if keep_this {
-                    keep.next();
-                }
-                write_ordinal += 1;
-                if keep_this && !pending.is_empty() {
-                    result.push(Event::write_at(std::mem::take(&mut pending), pending_at));
-                }
-            }
-            Event::Resize { size, at } => {
-                if !pending.is_empty() {
-                    result.push(Event::write_at(std::mem::take(&mut pending), pending_at));
-                }
-                result.push(Event::Resize { size, at });
-            }
-            other @ Event::TimingBoundary { .. } => result.push(other),
-        }
-    }
-    if !pending.is_empty() {
-        result.push(Event::write_at(pending, pending_at));
-    }
-    result
 }
 
 #[cfg(test)]

--- a/converters/terminal/src/cell_grid.rs
+++ b/converters/terminal/src/cell_grid.rs
@@ -3,7 +3,7 @@
 use libghostty_vt::{
     RenderState, Terminal, TerminalOptions,
     render::{CellIterator, RowIterator},
-    style::{RgbColor, Underline},
+    style::{RgbColor, StyleColor, Underline},
 };
 
 /// Error type returned while capturing ANSI bytes into a [`CellGrid`].
@@ -131,10 +131,17 @@ impl CellDecorations {
 pub struct Cell {
     /// Grapheme cluster rendered in this cell.
     pub text: String,
-    /// Explicit foreground color, if any.
+    /// Explicit foreground color (resolved to RGB), if any.
     pub fg: Option<Rgb>,
-    /// Explicit background color, if any.
+    /// Explicit background color (resolved to RGB), if any.
     pub bg: Option<Rgb>,
+    /// Foreground palette index (0–15), when the colour came from the terminal
+    /// palette rather than a direct RGB value. Lets a renderer emit a themeable
+    /// palette class instead of a fixed colour; `fg` holds the resolved RGB
+    /// regardless.
+    pub fg_index: Option<u8>,
+    /// Background palette index (0–15); see [`Cell::fg_index`].
+    pub bg_index: Option<u8>,
     /// Text decorations for this cell.
     pub decorations: CellDecorations,
 }
@@ -221,6 +228,17 @@ impl CellGrid {
     }
 }
 
+/// The 0-15 palette index of a cell colour, when it is one of the 16 base
+/// palette colours. Direct RGB, the 256-colour cube (16-255), and the default
+/// colour all return `None`; those are not themeable through the 16-colour
+/// palette, so a renderer falls back to the resolved RGB for them.
+fn palette_index(color: StyleColor) -> Option<u8> {
+    match color {
+        StyleColor::Palette(index) if index.0 < 16 => Some(index.0),
+        StyleColor::Palette(_) | StyleColor::Rgb(_) | StyleColor::None => None,
+    }
+}
+
 pub(crate) fn new_terminal(size: TerminalSize) -> Result<Terminal<'static, 'static>, Error> {
     let (cols, rows) = size.as_u16()?;
     Ok(Terminal::new(TerminalOptions {
@@ -265,6 +283,8 @@ impl<'alloc> GridCapture<'alloc> {
                     text: cell.graphemes()?.iter().collect(),
                     fg: cell.fg_color()?.map(Rgb::from),
                     bg: cell.bg_color()?.map(Rgb::from),
+                    fg_index: palette_index(style.fg_color),
+                    bg_index: palette_index(style.bg_color),
                     decorations: CellDecorations {
                         bold: style.bold,
                         italic: style.italic,

--- a/converters/terminal/src/lib.rs
+++ b/converters/terminal/src/lib.rs
@@ -15,7 +15,7 @@ use acdc_converters_core::{
     },
     visitor::Visitor,
 };
-#[cfg(feature = "render-state")]
+#[cfg(feature = "emulator")]
 use acdc_parser::BlockMetadata;
 use acdc_parser::{Document, DocumentAttributes, IndexTermKind, InlineMacro, InlineNode, TocEntry};
 
@@ -270,7 +270,7 @@ pub fn render_document_to_ansi(
 /// # Errors
 ///
 /// Returns an error if syntax highlighting or writing fails.
-#[cfg(feature = "render-state")]
+#[cfg(feature = "emulator")]
 pub fn render_listing_to_ansi(
     options: Options,
     document_attributes: DocumentAttributes<'_>,
@@ -300,7 +300,7 @@ pub fn render_listing_to_ansi(
     Ok(output)
 }
 
-#[cfg(feature = "render-state")]
+#[cfg(feature = "emulator")]
 fn preview_highlight_language(language: &str) -> &str {
     match language {
         "console" | "terminal" | "shell" => "bash",
@@ -417,10 +417,10 @@ pub(crate) fn extract_macro_text(m: &InlineMacro, line_break: &str) -> String {
 
 mod admonition;
 mod appearance;
-#[cfg(feature = "render-state")]
+#[cfg(feature = "emulator")]
 pub mod asciicast;
 mod audio;
-#[cfg(feature = "render-state")]
+#[cfg(feature = "emulator")]
 pub mod cell_grid;
 mod delimited;
 mod document;
@@ -430,7 +430,7 @@ mod index;
 mod inlines;
 mod list;
 mod paragraph;
-#[cfg(feature = "render-state")]
+#[cfg(feature = "emulator")]
 pub mod replay;
 mod section;
 mod syntax;

--- a/converters/terminal/src/lib.rs
+++ b/converters/terminal/src/lib.rs
@@ -417,6 +417,8 @@ pub(crate) fn extract_macro_text(m: &InlineMacro, line_break: &str) -> String {
 
 mod admonition;
 mod appearance;
+#[cfg(feature = "render-state")]
+pub mod asciicast;
 mod audio;
 #[cfg(feature = "render-state")]
 pub mod cell_grid;

--- a/converters/terminal/src/replay.rs
+++ b/converters/terminal/src/replay.rs
@@ -177,7 +177,7 @@ impl<'a> Event<'a> {
         Self::TimingBoundary { at: Some(at) }
     }
 
-    const fn timestamp(&self) -> Option<Duration> {
+    pub(crate) const fn timestamp(&self) -> Option<Duration> {
         match self {
             Self::Write { at, .. } | Self::Resize { at, .. } | Self::TimingBoundary { at } => *at,
         }
@@ -514,11 +514,63 @@ fn record_frame<'alloc>(
     Ok(())
 }
 
+/// Pick at most `budget` evenly spaced indices from `0..item_count`, always
+/// including the last index so a sampled sequence still ends on its final state.
+///
+/// Replay samplers use this to bound how many frames a long recording produces:
+/// they keep the items at these indices and fold the dropped items into them.
+/// The returned indices are sorted ascending with no duplicates.
+#[must_use]
+pub fn sampled_indexes(item_count: usize, budget: usize) -> Vec<usize> {
+    if item_count == 0 {
+        return Vec::new();
+    }
+    let budget = budget.min(item_count);
+    if item_count <= budget {
+        return (0..item_count).collect();
+    }
+    if budget <= 1 {
+        return vec![item_count - 1];
+    }
+
+    let last_index = item_count - 1;
+    let last_slot = budget - 1;
+    let mut indexes = Vec::with_capacity(budget);
+    let mut previous_index = None;
+
+    for slot in 0..budget {
+        let index = if slot == last_slot {
+            last_index
+        } else {
+            slot.saturating_mul(last_index) / last_slot
+        };
+        if previous_index != Some(index) {
+            indexes.push(index);
+            previous_index = Some(index);
+        }
+    }
+
+    indexes
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn sampled_indexes_bounds_count_and_keeps_endpoints() {
+        assert!(sampled_indexes(0, 5).is_empty());
+        assert_eq!(sampled_indexes(3, 5), vec![0, 1, 2]);
+        assert_eq!(sampled_indexes(10, 1), vec![9]);
+
+        let indexes = sampled_indexes(10, 4);
+        assert_eq!(indexes.first(), Some(&0));
+        assert_eq!(indexes.last(), Some(&9));
+        assert!(indexes.len() <= 4);
+        assert!(indexes.is_sorted_by(|a, b| a < b), "strictly increasing");
+    }
 
     fn options() -> Options {
         Options::new(TerminalSize::new(8, 3)).with_default_frame_duration(Duration::from_millis(50))


### PR DESCRIPTION
This PR tried very hard to do one thing: add support for asciicast recordings, but it ended up doing a couple more. The couple more are listed below.

Adding support for asciicast required some CSP changes, which made me realise it was a bit of a mess so I tidied things up a bit:
- moved all things CSP related to its own file
- moved all the javascript into files and generate the csp hash as needed during build time