### PR TITLE
feat(html): opt-in index generation (:acdc-index:) with section-title back-links

### DIFF
--- a/converters/html/CHANGELOG.md
+++ b/converters/html/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Set the `:acdc-index:` attribute to generate an index in the document's
+  `[index]` section: an alphabetical listing where each term links to the
+  sections it appears in. Without it, `[index]` sections stay empty, matching
+  `asciidoctor`.
 - A section renders its roles as part of its wrapper class (e.g. `[.role]` on a
   section gives `<div class="sect2 role">`, and a level-0 part gives
   `<h1 class="sect0 role">`), matching `asciidoctor`.

--- a/converters/html/src/delimited.rs
+++ b/converters/html/src/delimited.rs
@@ -1077,7 +1077,7 @@ mod tests {
             listing_counter: Rc::new(Cell::new(0)),
             index_term_counter: Rc::new(Cell::new(0)),
             index_entries: Rc::new(std::cell::RefCell::new(Vec::new())),
-            has_valid_index_section: false,
+            generate_index: false,
             section_number_tracker,
             part_number_tracker,
             appendix_tracker,

--- a/converters/html/src/html_visitor.rs
+++ b/converters/html/src/html_visitor.rs
@@ -156,6 +156,9 @@ pub struct HtmlVisitor<'a, 'd, W: Write> {
     /// Current section style (e.g., "bibliography", "glossary").
     /// Set when entering a section, used by child blocks for style inheritance.
     pub(crate) section_style: Option<String>,
+    /// Plain-text title of the section currently being rendered, used as the
+    /// label for index back-links. `None` outside any section (e.g. preamble).
+    pub(crate) current_section_title: Option<String>,
     /// Resolved docinfo content for injection at head, header, and footer positions.
     docinfo: DocInfo,
 }
@@ -185,6 +188,7 @@ impl<'a, 'd, W: Write> HtmlVisitor<'a, 'd, W> {
             diagnostics,
             current_subs: NORMAL.to_vec(),
             section_style: None,
+            current_section_title: None,
             docinfo,
         }
     }
@@ -763,7 +767,13 @@ impl<W: Write> Visitor for HtmlVisitor<'_, '_, W> {
             .style
             .as_ref()
             .map(std::string::ToString::to_string);
+        // Set before rendering the header so index terms in the section's own
+        // title attribute to this section; restore the parent (or None) on exit
+        // so nested sections pop back correctly.
+        let previous_section_title = self.current_section_title.take();
+        self.current_section_title = Some(acdc_parser::inlines_to_string(&section.title));
         let result = self.render_section(section);
+        self.current_section_title = previous_section_title;
         self.section_style = previous_style;
         result
     }

--- a/converters/html/src/index.rs
+++ b/converters/html/src/index.rs
@@ -2,7 +2,20 @@
 //!
 //! Renders a populated index catalog from collected index term entries.
 //! Terms are organized alphabetically by first letter, with hierarchical
-//! nesting for secondary and tertiary terms.
+//! nesting for secondary and tertiary terms. Each occurrence is a back-link
+//! whose label is the section it appears in (the HTML analog of a page number);
+//! repeats within one section are disambiguated as `Section (2)`, `Section (3)`.
+//!
+//! NOTE: this is an acdc extension, opt-in via the `:acdc-index:` document
+//! attribute. asciidoctor's html5 backend does **not** generate an index — it
+//! renders an `[index]` section with an empty body and emits no
+//! `<a id="_indexterm_N">` anchors (index generation only happens in `DocBook`
+//! output or via extensions such as asciidoctor-pdf). When `:acdc-index:` is
+//! unset, acdc matches asciidoctor exactly; when set, acdc emits a back-linked
+//! anchor per index-term occurrence (see `inlines::render_indexterm`) and builds
+//! the listing below. The `index_catalog*` test fixtures (attribute set)
+//! therefore intentionally diverge from asciidoctor; fixtures without the
+//! attribute stay byte-identical.
 
 use std::{collections::BTreeMap, io::Write};
 
@@ -11,11 +24,28 @@ use acdc_parser::{IndexTermKind, Section};
 
 use crate::{Error, HtmlVisitor, IndexTermEntry};
 
+/// A single occurrence of a term: the anchor to jump to, and the title of the
+/// section it occurs in (`None` outside any section — falls back to the doc title).
+#[derive(Clone, Debug)]
+struct Occurrence {
+    anchor_id: String,
+    section_title: Option<String>,
+}
+
+impl Occurrence {
+    fn from_entry(entry: &IndexTermEntry) -> Self {
+        Self {
+            anchor_id: entry.anchor_id.clone(),
+            section_title: entry.section_title.clone(),
+        }
+    }
+}
+
 /// Represents a single index entry with all its occurrences.
 #[derive(Debug, Default)]
 struct IndexEntry {
-    /// Anchor IDs where this term appears (for linking)
-    anchors: Vec<String>,
+    /// Occurrences of this term (for linking)
+    occurrences: Vec<Occurrence>,
     /// Nested secondary terms (if any)
     secondary: BTreeMap<String, SecondaryEntry>,
 }
@@ -23,10 +53,10 @@ struct IndexEntry {
 /// Represents a secondary-level index entry.
 #[derive(Debug, Default)]
 struct SecondaryEntry {
-    /// Anchor IDs where this secondary term appears
-    anchors: Vec<String>,
+    /// Occurrences of this secondary term
+    occurrences: Vec<Occurrence>,
     /// Nested tertiary terms (if any)
-    tertiary: BTreeMap<String, Vec<String>>,
+    tertiary: BTreeMap<String, Vec<Occurrence>>,
 }
 
 /// Build a hierarchical index structure from collected entries.
@@ -34,11 +64,12 @@ fn build_index_structure(entries: &[IndexTermEntry]) -> BTreeMap<String, IndexEn
     let mut index: BTreeMap<String, IndexEntry> = BTreeMap::new();
 
     for entry in entries {
+        let occurrence = Occurrence::from_entry(entry);
         match &entry.kind {
             IndexTermKind::Flow(term) => {
                 // Flow terms: primary only
                 let primary_entry = index.entry(term.to_string()).or_default();
-                primary_entry.anchors.push(entry.anchor_id.clone());
+                primary_entry.occurrences.push(occurrence);
             }
             IndexTermKind::Concealed {
                 term,
@@ -50,13 +81,13 @@ fn build_index_structure(entries: &[IndexTermEntry]) -> BTreeMap<String, IndexEn
                 match (secondary, tertiary) {
                     (None, None) => {
                         // Primary term only
-                        primary_entry.anchors.push(entry.anchor_id.clone());
+                        primary_entry.occurrences.push(occurrence);
                     }
                     (Some(sec), None) => {
                         // Primary + secondary
                         let secondary_entry =
                             primary_entry.secondary.entry(sec.to_string()).or_default();
-                        secondary_entry.anchors.push(entry.anchor_id.clone());
+                        secondary_entry.occurrences.push(occurrence);
                     }
                     (Some(sec), Some(tert)) => {
                         // Primary + secondary + tertiary
@@ -66,11 +97,11 @@ fn build_index_structure(entries: &[IndexTermEntry]) -> BTreeMap<String, IndexEn
                             .tertiary
                             .entry(tert.to_string())
                             .or_default()
-                            .push(entry.anchor_id.clone());
+                            .push(occurrence);
                     }
                     (None, Some(_)) => {
                         // Invalid: tertiary without secondary - treat as primary only
-                        primary_entry.anchors.push(entry.anchor_id.clone());
+                        primary_entry.occurrences.push(occurrence);
                     }
                 }
             }
@@ -104,12 +135,31 @@ fn group_by_letter(
     grouped
 }
 
-/// Render links for a set of anchor IDs.
-fn render_links(anchors: &[String]) -> String {
-    anchors
+/// Escape text destined for HTML element content / link text.
+fn escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Render back-links for a term's occurrences, in document order. The link text
+/// is the section each occurrence is in (`fallback` when it has none); repeated
+/// occurrences within the same section get a `(n)` suffix.
+fn render_links(occurrences: &[Occurrence], fallback: &str) -> String {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    occurrences
         .iter()
-        .enumerate()
-        .map(|(i, anchor)| format!("<a href=\"#{anchor}\">[{}]</a>", i + 1))
+        .map(|occ| {
+            let label = occ.section_title.as_deref().unwrap_or(fallback);
+            let n = counts.entry(label).or_insert(0);
+            *n += 1;
+            let text = if *n == 1 {
+                escape(label)
+            } else {
+                format!("{} ({n})", escape(label))
+            };
+            format!("<a href=\"#{}\">{text}</a>", occ.anchor_id)
+        })
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -129,6 +179,12 @@ pub(crate) fn render<W: Write>(
         return Ok(());
     }
 
+    // Label for occurrences outside any section (e.g. the preamble).
+    let fallback = processor
+        .document_attributes()
+        .get_string("doctitle")
+        .map_or_else(|| "top".to_string(), std::borrow::Cow::into_owned);
+
     let index = build_index_structure(&entries);
     let grouped = group_by_letter(index);
 
@@ -140,9 +196,9 @@ pub(crate) fn render<W: Write>(
         writeln!(w, "<dl class=\"indexterms\">")?;
 
         for (term, entry) in terms {
-            writeln!(w, "<dt>{term}")?;
-            if !entry.anchors.is_empty() {
-                write!(w, " {}", render_links(&entry.anchors))?;
+            writeln!(w, "<dt>{}", escape(term))?;
+            if !entry.occurrences.is_empty() {
+                write!(w, " {}", render_links(&entry.occurrences, &fallback))?;
             }
             writeln!(w, "</dt>")?;
 
@@ -151,9 +207,9 @@ pub(crate) fn render<W: Write>(
                 writeln!(w, "<dl class=\"indexterms-secondary\">")?;
 
                 for (secondary, sec_entry) in &entry.secondary {
-                    writeln!(w, "<dt>{secondary}")?;
-                    if !sec_entry.anchors.is_empty() {
-                        write!(w, " {}", render_links(&sec_entry.anchors))?;
+                    writeln!(w, "<dt>{}", escape(secondary))?;
+                    if !sec_entry.occurrences.is_empty() {
+                        write!(w, " {}", render_links(&sec_entry.occurrences, &fallback))?;
                     }
                     writeln!(w, "</dt>")?;
 
@@ -161,10 +217,10 @@ pub(crate) fn render<W: Write>(
                         writeln!(w, "<dd>")?;
                         writeln!(w, "<dl class=\"indexterms-tertiary\">")?;
 
-                        for (tertiary, anchors) in &sec_entry.tertiary {
-                            writeln!(w, "<dt>{tertiary}")?;
-                            if !anchors.is_empty() {
-                                write!(w, " {}", render_links(anchors))?;
+                        for (tertiary, occurrences) in &sec_entry.tertiary {
+                            writeln!(w, "<dt>{}", escape(tertiary))?;
+                            if !occurrences.is_empty() {
+                                write!(w, " {}", render_links(occurrences, &fallback))?;
                             }
                             writeln!(w, "</dt>")?;
                         }

--- a/converters/html/src/inlines.rs
+++ b/converters/html/src/inlines.rs
@@ -1156,23 +1156,22 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
         options: &RenderOptions,
         subs: &[Substitution],
     ) -> Result<(), Error> {
-        if options.toc_mode {
-            // In TOC mode, skip anchor but still output visible term text
-            if it.is_visible() {
-                let text = substitution_text(it.term(), subs, options);
-                write!(self.writer_mut(), "{text}")?;
-            }
-            return Ok(());
+        // An index term's anchor only exists to be the link target of acdc's
+        // generated `[index]` section (an extension; asciidoctor's html5 backend
+        // emits no anchor and leaves `[index]` empty). So emit one — and feed
+        // the index catalog, recording the enclosing section for the back-link
+        // label — only when index generation is enabled (`:acdc-index:` + a
+        // last `[index]` section).
+        if !options.toc_mode && self.processor.generate_index() {
+            let anchor_id = self.processor.clone().add_index_entry(
+                index_term_kind_to_static(&it.kind),
+                self.current_section_title.clone(),
+            );
+            write!(self.writer_mut(), "<a id=\"{anchor_id}\"></a>")?;
         }
 
-        let anchor_id = self
-            .processor
-            .clone()
-            .add_index_entry(index_term_kind_to_static(&it.kind));
-        write!(self.writer_mut(), "<a id=\"{anchor_id}\"></a>")?;
-
         // Flow terms (visible): also output the term text.
-        // Concealed terms: anchor only, no visible text.
+        // Concealed terms: no visible text.
         if it.is_visible() {
             let text = substitution_text(it.term(), subs, options);
             write!(self.writer_mut(), "{text}")?;

--- a/converters/html/src/lib.rs
+++ b/converters/html/src/lib.rs
@@ -96,6 +96,10 @@ pub struct IndexTermEntry {
     pub kind: IndexTermKind<'static>,
     /// Anchor ID for linking back to the term's location
     pub anchor_id: String,
+    /// Plain-text title of the section the term occurs in, used as the
+    /// back-link label. `None` for terms outside any section (e.g. the
+    /// preamble), which fall back to the document title.
+    pub section_title: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -125,9 +129,12 @@ pub struct Processor<'a> {
     /// Collected index term entries for rendering in the index catalog.
     /// Uses `Rc<RefCell<>>` so all clones can add entries during traversal.
     index_entries: Rc<RefCell<Vec<IndexTermEntry>>>,
-    /// Whether the document's last section has the `[index]` style.
-    /// Index sections are only rendered if they are the last section.
-    has_valid_index_section: bool,
+    /// Whether to generate acdc's index catalog: true only when the
+    /// `:acdc-index:` document attribute is set AND the document's last section
+    /// has the `[index]` style. When false the feature is fully off — no
+    /// `_indexterm_` anchors and `[index]` sections render empty, matching
+    /// asciidoctor (index generation is an acdc extension; see `crate::index`).
+    generate_index: bool,
     /// Section number tracker for `:sectnums:` support.
     section_number_tracker: SectionNumberTracker,
     /// Part number tracker for `:partnums:` support in book doctype.
@@ -187,10 +194,11 @@ impl<'a> Processor<'a> {
         &self.index_entries
     }
 
-    /// Check if the document has a valid index section (last section with `[index]` style).
+    /// Whether acdc's index catalog should be generated (the `:acdc-index:`
+    /// attribute is set and the last section has the `[index]` style).
     #[must_use]
-    pub fn has_valid_index_section(&self) -> bool {
-        self.has_valid_index_section
+    pub fn generate_index(&self) -> bool {
+        self.generate_index
     }
 
     /// Get the HTML output variant.
@@ -267,9 +275,14 @@ impl<'a> Processor<'a> {
         }
     }
 
-    /// Generate a unique anchor ID for an index term and collect the entry.
+    /// Generate a unique anchor ID for an index term and collect the entry,
+    /// recording the section it occurs in for the back-link label.
     #[must_use]
-    pub fn add_index_entry(&self, kind: IndexTermKind<'static>) -> String {
+    pub fn add_index_entry(
+        &self,
+        kind: IndexTermKind<'static>,
+        section_title: Option<String>,
+    ) -> String {
         let count = self.index_term_counter.get();
         self.index_term_counter.set(count + 1);
         let anchor_id = format!("_indexterm_{count}");
@@ -277,6 +290,7 @@ impl<'a> Processor<'a> {
         self.index_entries.borrow_mut().push(IndexTermEntry {
             kind,
             anchor_id: anchor_id.clone(),
+            section_title,
         });
 
         anchor_id
@@ -305,7 +319,8 @@ impl<'a> Processor<'a> {
             toc_entries: doc.toc_entries.clone(),
             references: doc.references.clone(),
             document_attributes: doc.attributes.clone(),
-            has_valid_index_section: last_section_has_style(&doc.blocks, "index"),
+            generate_index: index_generation_enabled(&doc.attributes)
+                && last_section_has_style(&doc.blocks, "index"),
             section_number_tracker,
             part_number_tracker,
             appendix_tracker,
@@ -399,6 +414,17 @@ pub(crate) const WEBFONTS_DEFAULT: &str = "";
 /// Stylesheet I/O failures all advise the same fix; centralize the wording.
 pub(crate) const STYLESHEET_ADVICE: &str =
     "Check stylesheet paths and filesystem permissions, then rerun the conversion.";
+
+/// Whether acdc's index generation is opted into via the `:acdc-index:`
+/// document attribute. Index generation is an acdc extension over asciidoctor's
+/// html5 backend (see `crate::index`), so it is off unless the author asks for
+/// it. Treated as a boolean attribute: present and not soft-unset (`:!acdc-index:`)
+/// turns it on.
+pub(crate) fn index_generation_enabled(attributes: &DocumentAttributes<'_>) -> bool {
+    attributes
+        .get("acdc-index")
+        .is_some_and(|v| !matches!(v, AttributeValue::Bool(false) | AttributeValue::None))
+}
 
 pub(crate) fn load_css(dark_mode: bool, variant: HtmlVariant) -> &'static str {
     match (variant, dark_mode) {
@@ -580,7 +606,7 @@ impl<'a> Processor<'a> {
             listing_counter: Rc::new(Cell::new(0)),
             index_term_counter: Rc::new(Cell::new(0)),
             index_entries: Rc::new(RefCell::new(Vec::new())),
-            has_valid_index_section: false,
+            generate_index: false,
             section_number_tracker,
             part_number_tracker,
             appendix_tracker,

--- a/converters/html/src/section.rs
+++ b/converters/html/src/section.rs
@@ -9,31 +9,28 @@ impl<W: Write> HtmlVisitor<'_, '_, W> {
     /// Visit a section using the visitor pattern
     ///
     /// Renders the section header, walks nested blocks, then renders footer.
-    /// For sections with `[index]` style, renders a populated index catalog
-    /// only if it's the last section in the document.
+    /// A section with the `[index]` style gets acdc's generated index catalog
+    /// (an extension over asciidoctor's html5 backend, which leaves `[index]`
+    /// empty — see `crate::index`) only when it's the document's last section;
+    /// any other `[index]` section renders like a normal section, so its
+    /// heading is still emitted (matching asciidoctor) rather than dropped.
     pub(crate) fn render_section(&mut self, section: &Section) -> Result<(), Error> {
         let processor = self.processor.clone();
 
-        // Check if this is an index section
         let is_index_section = section
             .metadata
             .style
             .as_ref()
             .is_some_and(|s| *s == "index");
-
-        // Index sections are only rendered if they're the last section
-        if is_index_section && !processor.has_valid_index_section() {
-            // Skip rendering entirely - not even the title
-            return Ok(());
-        }
+        let render_catalog = is_index_section && processor.generate_index();
 
         self.render_section_header(section)?;
 
-        if is_index_section {
+        if render_catalog {
             // Render the collected index catalog
             crate::index::render(section, self)?;
         } else {
-            // Normal section: render nested blocks
+            // Normal section (and non-last index sections): render nested blocks
             for nested_block in &section.content {
                 self.visit_block(nested_block)?;
             }

--- a/converters/html/tests/fixtures/expected/html/embedded/index_catalog.html
+++ b/converters/html/tests/fixtures/expected/html/embedded/index_catalog.html
@@ -14,7 +14,21 @@
 <p>Concealed terms: <a id="_indexterm_2"></a>visible text.</p>
 </div>
 <div class="paragraph">
-<p>Another reference to <a id="_indexterm_3"></a>cat for multiple occurrences.</p>
+<p>A primary-only concealed term: <a id="_indexterm_3"></a> here.</p>
+</div>
+<div class="paragraph">
+<p>A primary plus secondary concealed term: <a id="_indexterm_4"></a> here.</p>
+</div>
+<div class="paragraph">
+<p>Another reference to <a id="_indexterm_5"></a>cat for multiple occurrences.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_feline_behaviour">Feline Behaviour</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The <a id="_indexterm_6"></a>cat appears again in another section.</p>
 </div>
 </div>
 </div>
@@ -32,21 +46,37 @@
 <dd>
 <dl class="indexterms-tertiary">
 <dt>Cats
- <a href="#_indexterm_2">[1]</a></dt>
+ <a href="#_indexterm_2">Introduction</a></dt>
 </dl>
 </dd>
+</dl>
+</dd>
+</dl>
+<h3 class="indexletter">B</h3>
+<dl class="indexterms">
+<dt>Birds
+</dt>
+<dd>
+<dl class="indexterms-secondary">
+<dt>Parrots
+ <a href="#_indexterm_4">Introduction</a></dt>
 </dl>
 </dd>
 </dl>
 <h3 class="indexletter">C</h3>
 <dl class="indexterms">
 <dt>cat
- <a href="#_indexterm_0">[1]</a>, <a href="#_indexterm_3">[2]</a></dt>
+ <a href="#_indexterm_0">Introduction</a>, <a href="#_indexterm_5">Introduction (2)</a>, <a href="#_indexterm_6">Feline Behaviour</a></dt>
 </dl>
 <h3 class="indexletter">D</h3>
 <dl class="indexterms">
 <dt>dog
- <a href="#_indexterm_1">[1]</a></dt>
+ <a href="#_indexterm_1">Introduction</a></dt>
+</dl>
+<h3 class="indexletter">Z</h3>
+<dl class="indexterms">
+<dt>Zoology
+ <a href="#_indexterm_3">Introduction</a></dt>
 </dl>
 </div>
 </div>

--- a/converters/html/tests/fixtures/expected/html/embedded/index_catalog_not_last.html
+++ b/converters/html/tests/fixtures/expected/html/embedded/index_catalog_not_last.html
@@ -5,8 +5,13 @@
 <p>This tests when the index section is not the last section.</p>
 </div>
 <div class="paragraph">
-<p>A <a id="_indexterm_0"></a>cat is mentioned here.</p>
+<p>A cat is mentioned here.</p>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_index">Index</h2>
+<div class="sectionbody">
 </div>
 </div>
 <div class="sect1">

--- a/converters/html/tests/fixtures/expected/html/embedded/index_catalog_title_toc.html
+++ b/converters/html/tests/fixtures/expected/html/embedded/index_catalog_title_toc.html
@@ -1,0 +1,29 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li>
+<a href="#_animals_like_the_cat">Animals like the cat</a>
+</li>
+<li>
+<a href="#_index">Index</a>
+</li>
+</ul>
+</div>
+<div class="sect1">
+<h2 id="_animals_like_the_cat">Animals like the <a id="_indexterm_0"></a>cat</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The <a id="_indexterm_1"></a>cat appears in the body too.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_index">Index</h2>
+<div class="sectionbody">
+<h3 class="indexletter">C</h3>
+<dl class="indexterms">
+<dt>cat
+ <a href="#_indexterm_0">Animals like the cat</a>, <a href="#_indexterm_1">Animals like the cat (2)</a></dt>
+</dl>
+</div>
+</div>

--- a/converters/html/tests/fixtures/expected/html/embedded/indexterm_conformance.html
+++ b/converters/html/tests/fixtures/expected/html/embedded/indexterm_conformance.html
@@ -1,0 +1,57 @@
+<div id="toc" class="toc">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li>
+<a href="#_forms">Forms</a>
+</li>
+<li>
+<a href="#_section_with_a_visible_title_term_and">Section with a visible title term and </a>
+</li>
+<li>
+<a href="#_index">Index</a>
+</li>
+</ul>
+</div>
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>Preamble has a visible preamble and  term.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_forms">Forms</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Concealed primary:  end.</p>
+</div>
+<div class="paragraph">
+<p>Concealed primary plus secondary:  end.</p>
+</div>
+<div class="paragraph">
+<p>Concealed primary plus secondary plus tertiary:  end.</p>
+</div>
+<div class="paragraph">
+<p>Concealed macro:  end.</p>
+</div>
+<div class="paragraph">
+<p>Visible flow: iota end.</p>
+</div>
+<div class="paragraph">
+<p>Visible macro: kappa end.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_section_with_a_visible_title_term_and">Section with a visible title term and </h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Body paragraph.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_index">Index</h2>
+<div class="sectionbody">
+</div>
+</div>

--- a/converters/html/tests/fixtures/expected/html/embedded/indexterm_no_index_section.html
+++ b/converters/html/tests/fixtures/expected/html/embedded/indexterm_no_index_section.html
@@ -1,0 +1,17 @@
+<div class="sect1">
+<h2 id="_terms">Terms</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Concealed three:  end.</p>
+</div>
+<div class="paragraph">
+<p>Concealed macro:  end.</p>
+</div>
+<div class="paragraph">
+<p>Visible flow: Viz Term end.</p>
+</div>
+<div class="paragraph">
+<p>Visible macro: Other Term end.</p>
+</div>
+</div>
+</div>

--- a/converters/html/tests/fixtures/expected/html5s/embedded/index_catalog.html
+++ b/converters/html/tests/fixtures/expected/html5s/embedded/index_catalog.html
@@ -4,7 +4,13 @@
 <p>A <a id="_indexterm_0"></a>cat is a domestic animal.</p>
 <p>We also mention a <a id="_indexterm_1"></a>dog in the text.</p>
 <p>Concealed terms: <a id="_indexterm_2"></a>visible text.</p>
-<p>Another reference to <a id="_indexterm_3"></a>cat for multiple occurrences.</p>
+<p>A primary-only concealed term: <a id="_indexterm_3"></a> here.</p>
+<p>A primary plus secondary concealed term: <a id="_indexterm_4"></a> here.</p>
+<p>Another reference to <a id="_indexterm_5"></a>cat for multiple occurrences.</p>
+</section>
+<section class="doc-section level-1">
+<h2 id="_feline_behaviour">Feline Behaviour</h2>
+<p>The <a id="_indexterm_6"></a>cat appears again in another section.</p>
 </section>
 <section class="doc-section level-1">
 <h2 id="_index">Index</h2>
@@ -19,20 +25,36 @@
 <dd>
 <dl class="indexterms-tertiary">
 <dt>Cats
- <a href="#_indexterm_2">[1]</a></dt>
+ <a href="#_indexterm_2">Introduction</a></dt>
 </dl>
 </dd>
+</dl>
+</dd>
+</dl>
+<h3 class="indexletter">B</h3>
+<dl class="indexterms">
+<dt>Birds
+</dt>
+<dd>
+<dl class="indexterms-secondary">
+<dt>Parrots
+ <a href="#_indexterm_4">Introduction</a></dt>
 </dl>
 </dd>
 </dl>
 <h3 class="indexletter">C</h3>
 <dl class="indexterms">
 <dt>cat
- <a href="#_indexterm_0">[1]</a>, <a href="#_indexterm_3">[2]</a></dt>
+ <a href="#_indexterm_0">Introduction</a>, <a href="#_indexterm_5">Introduction (2)</a>, <a href="#_indexterm_6">Feline Behaviour</a></dt>
 </dl>
 <h3 class="indexletter">D</h3>
 <dl class="indexterms">
 <dt>dog
- <a href="#_indexterm_1">[1]</a></dt>
+ <a href="#_indexterm_1">Introduction</a></dt>
+</dl>
+<h3 class="indexletter">Z</h3>
+<dl class="indexterms">
+<dt>Zoology
+ <a href="#_indexterm_3">Introduction</a></dt>
 </dl>
 </section>

--- a/converters/html/tests/fixtures/expected/html5s/embedded/index_catalog_not_last.html
+++ b/converters/html/tests/fixtures/expected/html5s/embedded/index_catalog_not_last.html
@@ -1,7 +1,10 @@
 <section class="doc-section level-1">
 <h2 id="_introduction">Introduction</h2>
 <p>This tests when the index section is not the last section.</p>
-<p>A <a id="_indexterm_0"></a>cat is mentioned here.</p>
+<p>A cat is mentioned here.</p>
+</section>
+<section class="doc-section level-1">
+<h2 id="_index">Index</h2>
 </section>
 <section class="doc-section level-1">
 <h2 id="_final_section">Final Section</h2>

--- a/converters/html/tests/fixtures/expected/html5s/embedded/index_catalog_title_toc.html
+++ b/converters/html/tests/fixtures/expected/html5s/embedded/index_catalog_title_toc.html
@@ -1,0 +1,23 @@
+<nav id="toc" class="toc" role="doc-toc">
+<h2 id="toc-title">Table of Contents</h2>
+<ol class="toc-list level-1">
+<li>
+<a href="#_animals_like_the_cat">Animals like the cat</a>
+</li>
+<li>
+<a href="#_index">Index</a>
+</li>
+</ol>
+</nav>
+<section class="doc-section level-1">
+<h2 id="_animals_like_the_cat">Animals like the <a id="_indexterm_0"></a>cat</h2>
+<p>The <a id="_indexterm_1"></a>cat appears in the body too.</p>
+</section>
+<section class="doc-section level-1">
+<h2 id="_index">Index</h2>
+<h3 class="indexletter">C</h3>
+<dl class="indexterms">
+<dt>cat
+ <a href="#_indexterm_0">Animals like the cat</a>, <a href="#_indexterm_1">Animals like the cat (2)</a></dt>
+</dl>
+</section>

--- a/converters/html/tests/fixtures/expected/html5s/embedded/indexterm_conformance.html
+++ b/converters/html/tests/fixtures/expected/html5s/embedded/indexterm_conformance.html
@@ -1,0 +1,33 @@
+<nav id="toc" class="toc" role="doc-toc">
+<h2 id="toc-title">Table of Contents</h2>
+<ol class="toc-list level-1">
+<li>
+<a href="#_forms">Forms</a>
+</li>
+<li>
+<a href="#_section_with_a_visible_title_term_and">Section with a visible title term and </a>
+</li>
+<li>
+<a href="#_index">Index</a>
+</li>
+</ol>
+</nav>
+<section id="preamble" aria-label="Preamble">
+<p>Preamble has a visible preamble and  term.</p>
+</section>
+<section class="doc-section level-1">
+<h2 id="_forms">Forms</h2>
+<p>Concealed primary:  end.</p>
+<p>Concealed primary plus secondary:  end.</p>
+<p>Concealed primary plus secondary plus tertiary:  end.</p>
+<p>Concealed macro:  end.</p>
+<p>Visible flow: iota end.</p>
+<p>Visible macro: kappa end.</p>
+</section>
+<section class="doc-section level-1">
+<h2 id="_section_with_a_visible_title_term_and">Section with a visible title term and </h2>
+<p>Body paragraph.</p>
+</section>
+<section class="doc-section level-1">
+<h2 id="_index">Index</h2>
+</section>

--- a/converters/html/tests/fixtures/expected/html5s/embedded/indexterm_no_index_section.html
+++ b/converters/html/tests/fixtures/expected/html5s/embedded/indexterm_no_index_section.html
@@ -1,0 +1,7 @@
+<section class="doc-section level-1">
+<h2 id="_terms">Terms</h2>
+<p>Concealed three:  end.</p>
+<p>Concealed macro:  end.</p>
+<p>Visible flow: Viz Term end.</p>
+<p>Visible macro: Other Term end.</p>
+</section>

--- a/converters/html/tests/fixtures/source/html/embedded/index_catalog.adoc
+++ b/converters/html/tests/fixtures/source/html/embedded/index_catalog.adoc
@@ -1,4 +1,5 @@
 = Index Catalog Test
+:acdc-index:
 
 == Introduction
 
@@ -10,7 +11,15 @@ We also mention a indexterm2:[dog] in the text.
 
 Concealed terms: (((Animals, Mammals, Cats)))visible text.
 
+A primary-only concealed term: (((Zoology))) here.
+
+A primary plus secondary concealed term: (((Birds, Parrots))) here.
+
 Another reference to ((cat)) for multiple occurrences.
+
+== Feline Behaviour
+
+The ((cat)) appears again in another section.
 
 [index]
 == Index

--- a/converters/html/tests/fixtures/source/html/embedded/index_catalog_title_toc.adoc
+++ b/converters/html/tests/fixtures/source/html/embedded/index_catalog_title_toc.adoc
@@ -1,0 +1,10 @@
+= Doc Title
+:toc:
+:acdc-index:
+
+== Animals like the ((cat))
+
+The ((cat)) appears in the body too.
+
+[index]
+== Index

--- a/converters/html/tests/fixtures/source/html/embedded/indexterm_conformance.adoc
+++ b/converters/html/tests/fixtures/source/html/embedded/indexterm_conformance.adoc
@@ -1,0 +1,25 @@
+= Index Terms Conformance
+:toc:
+
+Preamble has a ((visible preamble)) and (((concealed preamble))) term.
+
+== Forms
+
+Concealed primary: (((alpha))) end.
+
+Concealed primary plus secondary: (((beta, gamma))) end.
+
+Concealed primary plus secondary plus tertiary: (((delta, epsilon, zeta))) end.
+
+Concealed macro: indexterm:[eta, theta] end.
+
+Visible flow: ((iota)) end.
+
+Visible macro: indexterm2:[kappa] end.
+
+== Section with a ((visible title term)) and (((concealed, in title)))
+
+Body paragraph.
+
+[index]
+== Index

--- a/converters/html/tests/fixtures/source/html/embedded/indexterm_no_index_section.adoc
+++ b/converters/html/tests/fixtures/source/html/embedded/indexterm_no_index_section.adoc
@@ -1,0 +1,11 @@
+= Index Terms Without An Index Section
+
+== Terms
+
+Concealed three: (((foo,bar,baz))) end.
+
+Concealed macro: indexterm:[alpha,beta] end.
+
+Visible flow: ((Viz Term)) end.
+
+Visible macro: indexterm2:[Other Term] end.

--- a/converters/html/tests/fixtures/source/html5s/embedded/index_catalog_title_toc.adoc
+++ b/converters/html/tests/fixtures/source/html5s/embedded/index_catalog_title_toc.adoc
@@ -1,0 +1,1 @@
+../../html/embedded/index_catalog_title_toc.adoc

--- a/converters/html/tests/fixtures/source/html5s/embedded/indexterm_conformance.adoc
+++ b/converters/html/tests/fixtures/source/html5s/embedded/indexterm_conformance.adoc
@@ -1,0 +1,1 @@
+../../html/embedded/indexterm_conformance.adoc

--- a/converters/html/tests/fixtures/source/html5s/embedded/indexterm_no_index_section.adoc
+++ b/converters/html/tests/fixtures/source/html5s/embedded/indexterm_no_index_section.adoc
@@ -1,0 +1,1 @@
+../../html/embedded/indexterm_no_index_section.adoc


### PR DESCRIPTION
## Summary

acdc's HTML backend generated a full index (anchors + listing) for `[index]` sections — something **asciidoctor's html5 backend and `asciidoctor-html5s` do not do** (they leave `[index]` empty and emit no index-term anchors; index generation is DocBook/asciidoctor-pdf only).

This PR keeps acdc's index as a deliberate value-add but makes it **opt-in**, so the default output matches asciidoctor exactly, and improves the back-link presentation.

### Behavior

- **Default (no attribute):** no `_indexterm_` anchors; `[index]` sections render empty — byte-identical to asciidoctor in both backends. This resolves the stray-anchor divergence (TODO item **K**): concealed `(((…)))` and `indexterm:[…]` produce nothing, visible `((…))` and `indexterm2:[…]` produce only their text.
- **`:acdc-index:` set:** the document's last `[index]` section renders an alphabetical, back-linked listing; each index-term occurrence gets an anchor.
- **Back-links are section titles** (the HTML analog of page numbers), e.g. `cat → Introduction, Introduction (2), Feline Behaviour` — replacing the previous meaningless `[1] [2]` ordinals. Repeats within a section are disambiguated as `Section (2)`; terms outside any section fall back to the document title.
- A non-last `[index]` section renders its heading with an empty body instead of being dropped.

### Verification

A comprehensive matrix (all four term forms × all concealed arities × preamble / paragraph / section title / TOC / `[index]`) is **canon-identical** to both `asciidoctor -b html5` and `asciidoctor -r asciidoctor-html5s -b html5s`. With `:acdc-index:` set, the *only* difference from asciidoctor is the gated anchors + listing (proven: the same sources with the attribute off match asciidoctor in both backends).

Fixtures (html + html5s each):

| Conformance (no attribute, == asciidoctor) | Feature (`:acdc-index:`) |
|---|---|
| `indexterm_no_index_section` | `index_catalog` (multi-section, all arities, same-section repeat) |
| `index_catalog_not_last` | `index_catalog_title_toc` (term in a title + TOC) |
| `indexterm_conformance` (full matrix) | |

- 1580 / 1580 workspace tests pass; `clippy --deny clippy::pedantic` clean; `cargo fmt` applied.

### Also

- AGENTS.md: changelog entries must describe user-facing behavior, not internal mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)