### PR TITLE
fix(parser): handle multi-attribute conditionals

### DIFF
--- a/acdc-parser/CHANGELOG.md
+++ b/acdc-parser/CHANGELOG.md
@@ -115,6 +115,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ifdef` and `ifndef` conditions now accept any number of attribute names joined
+  by `,` or `+`. A named `endif` can repeat the complete condition
+  case-insensitively, matching `asciidoctor`. Conditional blocks also remain in
+  effect across blank lines and nest correctly, so skipped content and closing
+  directives no longer leak into the parsed document.
 - Warnings now report the correct original file and line for content that follows a
   preprocessor edit. A dropped adjacent line comment, a stripped
   `ifdef`/`ifndef`/`ifeval` block, or a collapsed multi-line attribute continuation

--- a/acdc-parser/src/preprocessor/conditional.rs
+++ b/acdc-parser/src/preprocessor/conditional.rs
@@ -7,34 +7,32 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub(crate) enum Conditional {
-    Ifdef(Ifdef),
-    Ifndef(Ifndef),
-    Ifeval(Ifeval),
+pub(crate) struct Conditional<'input> {
+    condition: Condition<'input>,
+    content: Option<&'input str>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
+enum Condition<'input> {
+    Ifdef(AttributeCondition<'input>),
+    Ifndef(AttributeCondition<'input>),
+    Ifeval(EvalCondition),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum Operation {
     Or,
     And,
 }
 
-#[derive(Debug)]
-pub(crate) struct Ifdef {
-    attributes: Vec<String>,
-    content: Option<String>,
+#[derive(Debug, PartialEq)]
+struct AttributeCondition<'input> {
+    attributes: Vec<&'input str>,
     operation: Option<Operation>,
 }
 
 #[derive(Debug)]
-pub(crate) struct Ifndef {
-    attributes: Vec<String>,
-    content: Option<String>,
-    operation: Option<Operation>,
-}
-
-#[derive(Debug)]
-pub(crate) struct Ifeval {
+struct EvalCondition {
     left: EvalValue,
     operator: Operator,
     right: EvalValue,
@@ -58,63 +56,67 @@ pub(crate) enum Operator {
 }
 
 #[derive(Debug)]
-pub(crate) struct Endif {
-    pub(crate) attribute: Option<String>,
+pub(crate) struct Endif<'input> {
+    condition: Option<AttributeCondition<'input>>,
 }
 
 peg::parser! {
     grammar conditional_parser() for str {
-        pub(crate) rule conditional() -> Conditional
+        pub(crate) rule conditional() -> Conditional<'input>
             = ifdef() / ifndef() / ifeval()
 
-        pub(crate) rule endif() -> Endif
-            = "endif::" attribute:name()? "[]" {
+        pub(crate) rule endif() -> Endif<'input>
+            = "endif::" condition:attribute_condition()? "[]" {
                 Endif {
-                    attribute
+                    condition
                 }
             }
 
-        rule ifdef() -> Conditional
-            = "ifdef::" a:attributes() "[" content:content()? "]" {
-                Conditional::Ifdef(Ifdef {
-                    attributes: a.0,
-                    operation: a.1,
+        rule ifdef() -> Conditional<'input>
+            = "ifdef::" condition:attribute_condition() "[" content:content()? "]" {
+                Conditional {
+                    condition: Condition::Ifdef(condition),
                     content,
-                })
+                }
             }
 
-        rule ifndef() -> Conditional
-            = "ifndef::" a:attributes() "[" content:content()? "]" {
-                Conditional::Ifndef(Ifndef {
-                    attributes: a.0,
-                    operation: a.1,
+        rule ifndef() -> Conditional<'input>
+            = "ifndef::" condition:attribute_condition() "[" content:content()? "]" {
+                Conditional {
+                    condition: Condition::Ifndef(condition),
                     content,
-                })
+                }
             }
 
-        rule ifeval() -> Conditional
+        rule ifeval() -> Conditional<'input>
             = "ifeval::[" left:eval_value() operator:operator() right:eval_value() "]" {
 
                 // We parse everything we get here as a string, then whoever gets this,
                 // should convert into the proper EvalValue
-                Conditional::Ifeval(Ifeval {
-                    left: EvalValue::String(left),
-                    operator,
-                    right: EvalValue::String(right)
-                })
+                Conditional {
+                    condition: Condition::Ifeval(EvalCondition {
+                        left: EvalValue::String(left),
+                        operator,
+                        right: EvalValue::String(right)
+                    }),
+                    content: None,
+                }
             }
 
-        rule attributes() -> (Vec<String>, Option<Operation>)
-            = n1:name() op:operation() rest:(n:name() { n })* {
-                let mut names = vec![n1];
-                names.extend(rest);
-                (names, Some(op))
+        rule attribute_condition() -> AttributeCondition<'input>
+            = first:name() rest:("," name:name() { name })+ {
+                let mut attributes = Vec::with_capacity(rest.len() + 1);
+                attributes.push(first);
+                attributes.extend(rest);
+                AttributeCondition::new(attributes, Some(Operation::Or))
             }
-        / n1:name() { (vec![n1], None) }
-
-        rule operation() -> Operation
-            = "+" { Operation::And }
-        / "," { Operation::Or }
+        / first:name() rest:("+" name:name() { name })+ {
+                let mut attributes = Vec::with_capacity(rest.len() + 1);
+                attributes.push(first);
+                attributes.extend(rest);
+                AttributeCondition::new(attributes, Some(Operation::And))
+            }
+        / name:name() { AttributeCondition::new(vec![name], None) }
 
         rule eval_value() -> String
             = n:$((!operator() ![']'] [_])+)  {
@@ -131,21 +133,40 @@ peg::parser! {
 
         rule name_match() = (!['[' | ',' | '+'] [_])+
 
-        rule name() -> String
+        rule name() -> &'input str
             = n:$(name_match())  {
-                n.to_string()
+                n
             }
 
-        rule content() -> String
+        rule content() -> &'input str
             = c:$((!"]" [_])+) {
-                c.to_string()
+                c
             }
     }
 }
 
-impl Conditional {
+impl<'input> AttributeCondition<'input> {
+    fn new(attributes: Vec<&'input str>, operation: Option<Operation>) -> Self {
+        Self {
+            attributes,
+            operation,
+        }
+    }
+
+    fn matches(&self, other: &Self) -> bool {
+        self.operation == other.operation
+            && self.attributes.len() == other.attributes.len()
+            && self
+                .attributes
+                .iter()
+                .zip(&other.attributes)
+                .all(|(left, right)| left.eq_ignore_ascii_case(right))
+    }
+}
+
+impl Conditional<'_> {
     fn evaluate_attributes(
-        attrs: &[String],
+        attrs: &[&str],
         operation: Option<&Operation>,
         doc_attrs: &DocumentAttributes,
         negate: bool,
@@ -171,54 +192,53 @@ impl Conditional {
         current_offset: usize,
         file_parent: Option<&Path>,
     ) -> Result<bool, Error> {
-        Ok(match self {
-            Conditional::Ifdef(ifdef) => {
-                let is_true = Self::evaluate_attributes(
-                    &ifdef.attributes,
-                    ifdef.operation.as_ref(),
-                    attributes,
-                    false,
-                );
-                if is_true && let Some(if_content) = &ifdef.content {
-                    content.clone_from(if_content);
-                }
-                is_true
-            }
-            Conditional::Ifndef(ifndef) => {
-                let is_true = Self::evaluate_attributes(
-                    &ifndef.attributes,
-                    ifndef.operation.as_ref(),
-                    attributes,
-                    true,
-                );
-                if is_true && let Some(if_content) = &ifndef.content {
-                    content.clone_from(if_content);
-                }
-                is_true
-            }
-            Conditional::Ifeval(ifeval) => {
+        let is_true = match &self.condition {
+            Condition::Ifdef(condition) => Self::evaluate_attributes(
+                &condition.attributes,
+                condition.operation.as_ref(),
+                attributes,
+                false,
+            ),
+            Condition::Ifndef(condition) => Self::evaluate_attributes(
+                &condition.attributes,
+                condition.operation.as_ref(),
+                attributes,
+                true,
+            ),
+            Condition::Ifeval(ifeval) => {
                 ifeval.evaluate(attributes, line_number, current_offset, file_parent)?
             }
-        })
+        };
+        if is_true && let Some(if_content) = &self.content {
+            content.push_str(if_content);
+        }
+        Ok(is_true)
     }
-}
 
-impl Endif {
-    #[tracing::instrument(level = "trace")]
-    pub(crate) fn closes(&self, conditional: &Conditional) -> bool {
-        if let Some(attribute) = &self.attribute {
-            match conditional {
-                Conditional::Ifdef(ifdef) => ifdef.attributes.contains(attribute),
-                Conditional::Ifndef(ifndef) => ifndef.attributes.contains(attribute),
-                Conditional::Ifeval(_ifeval) => false,
-            }
-        } else {
-            true
+    pub(crate) fn has_inline_content(&self) -> bool {
+        self.content.is_some()
+    }
+
+    fn attribute_condition(&self) -> Option<&AttributeCondition<'_>> {
+        match &self.condition {
+            Condition::Ifdef(condition) | Condition::Ifndef(condition) => Some(condition),
+            Condition::Ifeval(_) => None,
         }
     }
 }
 
-impl Ifeval {
+impl Endif<'_> {
+    #[tracing::instrument(level = "trace")]
+    pub(crate) fn closes(&self, conditional: &Conditional<'_>) -> bool {
+        match (&self.condition, conditional.attribute_condition()) {
+            (None, _) => true,
+            (Some(endif), Some(opening)) => endif.matches(opening),
+            (Some(_), None) => false,
+        }
+    }
+}
+
+impl EvalCondition {
     #[tracing::instrument(level = "trace", skip(file_parent))]
     fn evaluate(
         &self,
@@ -294,12 +314,12 @@ impl EvalValue {
 }
 
 #[tracing::instrument(level = "trace", skip(file_parent))]
-pub(crate) fn parse_line(
-    line: &str,
+pub(crate) fn parse_line<'input>(
+    line: &'input str,
     line_number: usize,
     current_offset: usize,
     file_parent: Option<&Path>,
-) -> Result<Conditional, Error> {
+) -> Result<Conditional<'input>, Error> {
     conditional_parser::conditional(line).map_err(|error| {
         tracing::error!(?error, "failed to parse conditional directive");
         Error::InvalidConditionalDirective(Box::new(SourceLocation {
@@ -310,12 +330,12 @@ pub(crate) fn parse_line(
 }
 
 #[tracing::instrument(level = "trace", skip(file_parent))]
-pub(crate) fn parse_endif(
-    line: &str,
+pub(crate) fn parse_endif<'input>(
+    line: &'input str,
     line_number: usize,
     current_offset: usize,
     file_parent: Option<&Path>,
-) -> Result<Endif, Error> {
+) -> Result<Endif<'input>, Error> {
     conditional_parser::endif(line).map_err(|error| {
         tracing::error!(?error, "failed to parse endif directive");
         Error::InvalidConditionalDirective(Box::new(SourceLocation {
@@ -334,7 +354,7 @@ mod tests {
         let line = "ifdef::attribute[]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(conditional, Conditional::Ifdef(ifdef) if ifdef.attributes == vec!["attribute"] && ifdef.operation.is_none() && ifdef.content.is_none())
+            matches!(conditional, Conditional { condition: Condition::Ifdef(condition), content: None } if condition.attributes == vec!["attribute"] && condition.operation.is_none())
         );
         Ok(())
     }
@@ -344,7 +364,7 @@ mod tests {
         let line = "ifdef::attr1,attr2[]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(conditional, Conditional::Ifdef(ifdef) if ifdef.attributes == vec!["attr1", "attr2"] && ifdef.operation == Some(Operation::Or) && ifdef.content.is_none())
+            matches!(conditional, Conditional { condition: Condition::Ifdef(condition), content: None } if condition.attributes == vec!["attr1", "attr2"] && condition.operation == Some(Operation::Or))
         );
         Ok(())
     }
@@ -354,9 +374,35 @@ mod tests {
         let line = "ifdef::attr1+attr2[]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(conditional, Conditional::Ifdef(ifdef) if ifdef.attributes == vec!["attr1", "attr2"] && ifdef.operation == Some(Operation::And) && ifdef.content.is_none())
+            matches!(conditional, Conditional { condition: Condition::Ifdef(condition), content: None } if condition.attributes == vec!["attr1", "attr2"] && condition.operation == Some(Operation::And))
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_ifdef_three_or_attributes() -> Result<(), Error> {
+        let conditional = parse_line("ifdef::attr1,attr2,attr3[]", 1, 0, None)?;
+        assert!(
+            matches!(conditional, Conditional { condition: Condition::Ifdef(condition), .. } if condition.attributes == vec!["attr1", "attr2", "attr3"] && condition.operation == Some(Operation::Or))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_ifdef_three_and_attributes() -> Result<(), Error> {
+        let conditional = parse_line("ifdef::attr1+attr2+attr3[]", 1, 0, None)?;
+        assert!(
+            matches!(conditional, Conditional { condition: Condition::Ifdef(condition), .. } if condition.attributes == vec!["attr1", "attr2", "attr3"] && condition.operation == Some(Operation::And))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_ifdef_rejects_mixed_attribute_operators() {
+        assert!(matches!(
+            parse_line("ifdef::attr1,attr2+attr3[]", 1, 0, None),
+            Err(Error::InvalidConditionalDirective(..))
+        ));
     }
 
     #[test]
@@ -364,7 +410,7 @@ mod tests {
         let line = "ifndef::attribute[]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(conditional, Conditional::Ifndef(ifndef) if ifndef.attributes == vec!["attribute"] && ifndef.operation.is_none() && ifndef.content.is_none())
+            matches!(conditional, Conditional { condition: Condition::Ifndef(condition), content: None } if condition.attributes == vec!["attribute"] && condition.operation.is_none())
         );
         Ok(())
     }
@@ -374,7 +420,7 @@ mod tests {
         let line = "ifeval::[1 + 1 == 2]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(&conditional, Conditional::Ifeval(ifeval) if ifeval.left == EvalValue::String("1 + 1".to_string()) && ifeval.operator == Operator::Equal && ifeval.right == EvalValue::String("2".to_string()))
+            matches!(&conditional, Conditional { condition: Condition::Ifeval(ifeval), content: None } if ifeval.left == EvalValue::String("1 + 1".to_string()) && ifeval.operator == Operator::Equal && ifeval.right == EvalValue::String("2".to_string()))
         );
         assert!(conditional.is_true(
             &DocumentAttributes::default(),
@@ -391,7 +437,7 @@ mod tests {
         let line = "ifeval::['ASDF' == ASDF]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(&conditional, Conditional::Ifeval(ifeval) if ifeval.left == EvalValue::String("'ASDF'".to_string()) && ifeval.operator == Operator::Equal && ifeval.right == EvalValue::String("ASDF".to_string()))
+            matches!(&conditional, Conditional { condition: Condition::Ifeval(ifeval), content: None } if ifeval.left == EvalValue::String("'ASDF'".to_string()) && ifeval.operator == Operator::Equal && ifeval.right == EvalValue::String("ASDF".to_string()))
         );
         assert!(conditional.is_true(
             &DocumentAttributes::default(),
@@ -408,7 +454,7 @@ mod tests {
         let line = "ifeval::['1+1' >= 2]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(&conditional, Conditional::Ifeval(ifeval) if ifeval.left == EvalValue::String("'1+1'".to_string()) && ifeval.operator == Operator::GreaterThanOrEqual && ifeval.right == EvalValue::String("2".to_string()))
+            matches!(&conditional, Conditional { condition: Condition::Ifeval(ifeval), content: None } if ifeval.left == EvalValue::String("'1+1'".to_string()) && ifeval.operator == Operator::GreaterThanOrEqual && ifeval.right == EvalValue::String("2".to_string()))
         );
 
         assert!(matches!(
@@ -429,7 +475,7 @@ mod tests {
         let line = "ifdef::attribute[Some content here]";
         let conditional = parse_line(line, 1, 0, None)?;
         assert!(
-            matches!(conditional, Conditional::Ifdef(ifdef) if ifdef.attributes == vec!["attribute"] && ifdef.operation.is_none() && ifdef.content == Some("Some content here".to_string()))
+            matches!(conditional, Conditional { condition: Condition::Ifdef(condition), content: Some(content) } if condition.attributes == vec!["attribute"] && condition.operation.is_none() && content == "Some content here")
         );
         Ok(())
     }
@@ -438,7 +484,13 @@ mod tests {
     fn test_endif() -> Result<(), Error> {
         let line = "endif::attribute[]";
         let endif = parse_endif(line, 1, 0, None)?;
-        assert_eq!(endif.attribute, Some("attribute".to_string()));
+        assert!(matches!(
+            endif.condition,
+            Some(AttributeCondition {
+                attributes,
+                operation: None,
+            }) if attributes == ["attribute"]
+        ));
         Ok(())
     }
 
@@ -446,7 +498,27 @@ mod tests {
     fn test_endif_no_attribute() -> Result<(), Error> {
         let line = "endif::[]";
         let endif = parse_endif(line, 1, 0, None)?;
-        assert_eq!(endif.attribute, None);
+        assert_eq!(endif.condition, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_endif_matches_complete_condition_case_insensitively() -> Result<(), Error> {
+        let conditional = parse_line("ifdef::Backend-PDF,Backend-DocBook5[]", 1, 0, None)?;
+        let endif = parse_endif("endif::backend-pdf,backend-docbook5[]", 2, 0, None)?;
+        assert!(endif.closes(&conditional));
+        Ok(())
+    }
+
+    #[test]
+    fn test_endif_rejects_partial_or_reordered_condition() -> Result<(), Error> {
+        let conditional = parse_line("ifdef::backend-pdf,backend-docbook5[]", 1, 0, None)?;
+        let partial = parse_endif("endif::backend-pdf[]", 2, 0, None)?;
+        let reordered = parse_endif("endif::backend-docbook5,backend-pdf[]", 2, 0, None)?;
+        let different_operation = parse_endif("endif::backend-pdf+backend-docbook5[]", 2, 0, None)?;
+        assert!(!partial.closes(&conditional));
+        assert!(!reordered.closes(&conditional));
+        assert!(!different_operation.closes(&conditional));
         Ok(())
     }
 }

--- a/acdc-parser/src/preprocessor/mod.rs
+++ b/acdc-parser/src/preprocessor/mod.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::Cow,
     cell::RefCell,
-    fmt::Write as _,
+    ops::Range,
     path::{Path, PathBuf},
     rc::Rc,
 };
@@ -66,9 +66,22 @@ struct DirectiveContext<'a> {
     file_parent: Option<&'a Path>,
 }
 
+/// An open block-form conditional and whether its content is active after
+/// accounting for every enclosing conditional.
+#[derive(Debug)]
+struct ConditionalFrame<'input> {
+    conditional: conditional::Conditional<'input>,
+    active: bool,
+}
+
 /// Mutable state accumulated during preprocessing.
-struct PreprocessorState {
-    lines: Vec<String>,
+struct PreprocessorState<'input> {
+    input: &'input str,
+    output: Vec<Cow<'input, str>>,
+    /// A maximal run of unchanged output lines borrowed directly from `input`.
+    /// Interior newlines are part of the range; the newline after the final line
+    /// is supplied when output chunks are joined.
+    borrowed_run: Option<Range<usize>>,
     byte_offset: usize,
     leveloffset_ranges: Vec<LeveloffsetRange>,
     source_ranges: Vec<SourceRange>,
@@ -120,10 +133,63 @@ impl OriginMapping {
     }
 }
 
-impl PreprocessorState {
-    fn push_line(&mut self, line: String) {
+impl<'input> PreprocessorState<'input> {
+    fn new(input: &'input str, source_file: Option<&Path>) -> Self {
+        let mut src_line_starts = vec![0];
+        src_line_starts.extend(
+            input
+                .bytes()
+                .enumerate()
+                .filter_map(|(idx, byte)| (byte == b'\n').then_some(idx + 1)),
+        );
+        Self {
+            input,
+            output: Vec::new(),
+            borrowed_run: None,
+            byte_offset: 0,
+            leveloffset_ranges: Vec::new(),
+            source_ranges: Vec::new(),
+            source_file: source_file.map(Path::to_path_buf),
+            src_line_starts,
+            run: None,
+            run_expected_src_line: 1,
+        }
+    }
+
+    /// Flush the pending unchanged source run into a single borrowed output
+    /// chunk. This is the key slow-path allocation invariant: retained source
+    /// lines are grouped by contiguous input range instead of owned one-by-one.
+    fn flush_borrowed_run(&mut self) {
+        if let Some(range) = self.borrowed_run.take() {
+            self.output.push(Cow::Borrowed(&self.input[range]));
+        }
+    }
+
+    /// Emit a line that cannot be coalesced with unchanged source text.
+    fn push_line(&mut self, line: Cow<'input, str>) {
+        self.flush_borrowed_run();
         self.byte_offset += line.len() + 1;
-        self.lines.push(line);
+        self.output.push(line);
+    }
+
+    /// Emit an unchanged line from the primary input. Consecutive source lines
+    /// extend a single borrowed range, including their interior newlines.
+    fn push_source_line(&mut self, line: &'input str, src_line: usize) {
+        self.note_source_line(src_line);
+
+        let start = self.src_offset_of_line(src_line);
+        let end = start + line.len();
+        debug_assert_eq!(self.input.get(start..end), Some(line));
+
+        if let Some(range) = &mut self.borrowed_run
+            && range.end.checked_add(1) == Some(start)
+        {
+            range.end = end;
+        } else {
+            self.flush_borrowed_run();
+            self.borrowed_run = Some(start..end);
+        }
+        self.byte_offset += line.len() + 1;
     }
 
     /// Byte offset of 1-indexed source `line` in the primary input.
@@ -192,16 +258,16 @@ impl PreprocessorState {
         }
     }
 
-    /// Emit a multi-source-line chunk (a collapsed attribute continuation or a
-    /// retained conditional body) as its own standalone [`SourceRange`] anchored
-    /// at `src_start_line`, so it never shares a run with surrounding lines whose
+    /// Emit synthesized content (a collapsed attribute continuation or active
+    /// single-line conditional) as its own standalone [`SourceRange`] anchored at
+    /// `src_start_line`, so it never shares a run with surrounding lines whose
     /// output-newline count would otherwise be miscounted.
     fn push_chunk(&mut self, content: String, src_start_line: usize) {
         self.flush_run();
         let start = self.byte_offset;
         let source_start_offset = self.src_offset_of_line(src_start_line);
-        self.push_line(content);
-        // A collapsed continuation / retained conditional body is not re-indented.
+        self.push_line(Cow::Owned(content));
+        // Synthesized content is not re-indented.
         self.push_source_range(
             start,
             self.byte_offset,
@@ -295,7 +361,7 @@ pub(crate) fn read_and_decode_file(
 ///
 /// All public entry points take the handle explicitly; the struct is
 /// purely a carrier so nested `&self` helpers (`process_include`,
-/// `process_conditional`, `process_directive_line`) can reach the sink
+/// `process_conditional_line`, `process_directive_line`) can reach the sink
 /// without threading it through every parameter list.
 #[derive(Debug)]
 pub(crate) struct Preprocessor {
@@ -522,85 +588,6 @@ impl Preprocessor {
         Ok(None)
     }
 
-    /// Process a conditional directive (ifdef/ifndef/ifeval)
-    #[tracing::instrument(skip(self, lines, attributes))]
-    fn process_conditional<'a, I: Iterator<Item = &'a str>>(
-        &self,
-        line: &str,
-        lines: &mut std::iter::Peekable<I>,
-        ctx: &mut DirectiveContext<'_>,
-        attributes: &crate::DocumentAttributes,
-    ) -> Result<Option<(String, usize)>, Error> {
-        let mut content = String::new();
-        let condition_line_number = *ctx.line_number;
-        // Tracks whether any body line was consumed, so the returned content maps
-        // to the first body line (multi-line form) rather than the directive line
-        // (single-line form).
-        let mut body_consumed = false;
-        let condition = conditional::parse_line(
-            line,
-            condition_line_number,
-            ctx.current_offset,
-            ctx.file_parent,
-        )?;
-
-        while let Some(next_line) = lines.peek() {
-            if next_line.is_empty() {
-                tracing::trace!(?line, "single line if directive");
-                break;
-            } else if next_line.starts_with("endif") {
-                // Calculate the line number and offset for the endif line
-                let endif_line_number = *ctx.line_number + 1;
-                let endif_offset =
-                    ctx.current_offset + line.len() + content.len() + content.lines().count();
-                let endif = conditional::parse_endif(
-                    next_line,
-                    endif_line_number,
-                    endif_offset,
-                    ctx.file_parent,
-                )?;
-
-                if !endif.closes(&condition) {
-                    // Record as a warning in addition to raising the hard
-                    // error: the warning lands on `ParseResult::warnings`
-                    // even if the caller recovers from the error.
-                    self.add_warning_at(
-                        "attribute mismatch between if and endif directives",
-                        Self::create_source_location(endif_line_number, ctx.file_parent),
-                    );
-                    return Err(Error::InvalidConditionalDirective(Box::new(
-                        Self::create_source_location(endif_line_number, ctx.file_parent),
-                    )));
-                }
-                tracing::trace!(?content, "multiline if directive");
-                lines.next();
-                *ctx.line_number += 1;
-                break;
-            }
-            let _ = writeln!(content, "{next_line}");
-            lines.next();
-            *ctx.line_number += 1;
-            body_consumed = true;
-        }
-
-        if condition.is_true(
-            attributes,
-            &mut content,
-            condition_line_number,
-            ctx.current_offset,
-            ctx.file_parent,
-        )? {
-            let content_start_line = if body_consumed {
-                condition_line_number + 1
-            } else {
-                condition_line_number
-            };
-            Ok(Some((content, content_start_line)))
-        } else {
-            Ok(None)
-        }
-    }
-
     #[tracing::instrument(skip(lines, attribute_content))]
     fn process_continuation<'a, I: Iterator<Item = &'a str>>(
         attribute_content: &mut String,
@@ -682,7 +669,8 @@ impl Preprocessor {
     /// This also merges nested ranges from included files, adjusting their byte offsets
     /// to be relative to the current output position. This enables proper accumulation
     /// through arbitrarily deep include nesting.
-    fn handle_include_result(include_result: IncludeResult, state: &mut PreprocessorState) {
+    fn handle_include_result(include_result: IncludeResult, state: &mut PreprocessorState<'_>) {
+        state.flush_borrowed_run();
         let start_offset = state.byte_offset;
 
         // Calculate the byte length of the included content
@@ -809,16 +797,90 @@ impl Preprocessor {
         }
 
         state.byte_offset += content_len;
-        state.lines.extend(include_result.lines);
+        state
+            .output
+            .extend(include_result.lines.into_iter().map(Cow::Owned));
     }
 
-    fn process_directive_line<'a>(
+    /// Process a block or single-line conditional directive.
+    ///
+    /// Returns `true` when `line` was a conditional directive and therefore
+    /// must not be emitted as ordinary document content.
+    fn process_conditional_line<'input>(
         &self,
-        line: &'a str,
-        lines: &mut std::iter::Peekable<std::str::Lines<'a>>,
+        line: &'input str,
+        ctx: &DirectiveContext<'_>,
+        attributes: &crate::DocumentAttributes,
+        stack: &mut Vec<ConditionalFrame<'input>>,
+        out: &mut PreprocessorState<'_>,
+    ) -> Result<bool, Error> {
+        if !line.ends_with(']') || line.starts_with('[') || !line.contains("::") {
+            return Ok(false);
+        }
+
+        if line.starts_with("ifdef") || line.starts_with("ifndef") || line.starts_with("ifeval") {
+            let mut content = String::new();
+            let conditional = conditional::parse_line(
+                line,
+                *ctx.line_number,
+                ctx.current_offset,
+                ctx.file_parent,
+            )?;
+            let parent_active = stack.last().is_none_or(|frame| frame.active);
+            let is_inline = conditional.has_inline_content();
+            let active = parent_active
+                && conditional.is_true(
+                    attributes,
+                    &mut content,
+                    *ctx.line_number,
+                    ctx.current_offset,
+                    ctx.file_parent,
+                )?;
+
+            if is_inline {
+                if active {
+                    out.push_chunk(content, *ctx.line_number);
+                }
+            } else {
+                stack.push(ConditionalFrame {
+                    conditional,
+                    active,
+                });
+            }
+            return Ok(true);
+        }
+
+        if line.starts_with("endif")
+            && let Some(frame) = stack.last()
+        {
+            let endif = conditional::parse_endif(
+                line,
+                *ctx.line_number,
+                ctx.current_offset,
+                ctx.file_parent,
+            )?;
+            if !endif.closes(&frame.conditional) {
+                self.add_warning_at(
+                    "attribute mismatch between if and endif directives",
+                    Self::create_source_location(*ctx.line_number, ctx.file_parent),
+                );
+                return Err(Error::InvalidConditionalDirective(Box::new(
+                    Self::create_source_location(*ctx.line_number, ctx.file_parent),
+                )));
+            }
+            stack.pop();
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn process_directive_line<'input>(
+        &self,
+        line: &'input str,
         ctx: &mut DirectiveContext<'_>,
         options: &Options,
-        out: &mut PreprocessorState,
+        out: &mut PreprocessorState<'input>,
     ) -> Result<(), Error> {
         if line.starts_with("\\include")
             || line.starts_with("\\ifdef")
@@ -826,16 +888,7 @@ impl Preprocessor {
             || line.starts_with("\\ifeval")
         {
             out.note_source_line(*ctx.line_number);
-            out.push_line(line[1..].to_string());
-        } else if line.starts_with("ifdef")
-            || line.starts_with("ifndef")
-            || line.starts_with("ifeval")
-        {
-            if let Some((content, content_start_line)) =
-                self.process_conditional(line, lines, ctx, &options.document_attributes)?
-            {
-                out.push_chunk(content, content_start_line);
-            }
+            out.push_line(Cow::Borrowed(&line[1..]));
         } else if line.starts_with("include") {
             // Included content carries its own source ranges; close the main-file
             // run first so it does not overlap them.
@@ -850,8 +903,7 @@ impl Preprocessor {
                 Self::handle_include_result(include_result, out);
             }
         } else {
-            out.note_source_line(*ctx.line_number);
-            out.push_line(line.to_string());
+            out.push_source_line(line, *ctx.line_number);
         }
         Ok(())
     }
@@ -877,49 +929,66 @@ impl Preprocessor {
             });
         }
 
+        self.process_slow_path(&normalized, file_parent, options, setext)
+    }
+
+    /// Rebuild a document that contains at least one preprocessor trigger.
+    ///
+    /// Keep this out of line so the much larger include/conditional machinery
+    /// cannot perturb instruction layout for the common pass-through path.
+    #[cold]
+    #[inline(never)]
+    fn process_slow_path<'a>(
+        &self,
+        normalized: &Cow<'a, str>,
+        file_parent: Option<&Path>,
+        options: &Options,
+        setext: bool,
+    ) -> Result<PreprocessorResult<'a>, Error> {
         // Slow path: at least one trigger fires (include, conditional,
         // multi-line attribute continuation, or escaped directive). Rebuild
-        // line-by-line as before. Hold the normalized text as a local so the
-        // peekable iterator can borrow from it for the duration of this call.
-        let normalized_owned;
-        let normalized_ref: &str = match &normalized {
-            Cow::Borrowed(s) => s,
-            Cow::Owned(s) => {
-                normalized_owned = s;
-                normalized_owned.as_str()
-            }
-        };
+        // line-by-line. The output is materialized before `normalized` drops,
+        // whether normalization borrowed the caller's input or created a buffer.
+        let normalized_ref = normalized.as_ref();
 
         let mut options = options.clone();
-        let output = Vec::with_capacity(normalized_ref.lines().count());
-        // Byte offset of each source line in the normalized primary input, so a
-        // run/chunk anchored at a source line can record its origin-file byte offset.
-        let mut src_line_starts = vec![0usize];
-        src_line_starts.extend(
-            normalized_ref
-                .bytes()
-                .enumerate()
-                .filter_map(|(idx, b)| (b == b'\n').then_some(idx + 1)),
-        );
         let mut lines = normalized_ref.lines().peekable();
         let mut line_number = 1;
         let mut current_offset = 0;
-        let mut out = PreprocessorState {
-            lines: output,
-            byte_offset: 0,
-            leveloffset_ranges: Vec::new(),
-            source_ranges: Vec::new(),
-            source_file: file_parent.map(Path::to_path_buf),
-            src_line_starts,
-            run: None,
-            run_expected_src_line: 1,
-        };
+        let mut out = PreprocessorState::new(normalized_ref, file_parent);
         // Tracks verbatim-block and previous-line context so adjacent line
         // comments can be dropped (matching asciidoctor's reader). See
         // `comment::CommentScanner`.
         let mut scanner = CommentScanner::new(setext);
+        let mut conditional_stack = Vec::new();
 
         while let Some(line) = lines.next() {
+            let conditional_consumed = {
+                let ctx = DirectiveContext {
+                    line_number: &mut line_number,
+                    current_offset,
+                    file_parent,
+                };
+                self.process_conditional_line(
+                    line,
+                    &ctx,
+                    &options.document_attributes,
+                    &mut conditional_stack,
+                    &mut out,
+                )?
+            };
+            if conditional_consumed {
+                current_offset += line.len() + 1;
+                line_number += 1;
+                continue;
+            }
+
+            if conditional_stack.last().is_some_and(|frame| !frame.active) {
+                current_offset += line.len() + 1;
+                line_number += 1;
+                continue;
+            }
+
             if line.starts_with(':') && (line.ends_with(" + \\") || line.ends_with(" \\")) {
                 let mut attribute_content = String::with_capacity(line.len() * 2);
                 if line.ends_with(" + \\") {
@@ -946,8 +1015,7 @@ impl Preprocessor {
                 attribute::parse_line(&mut options.document_attributes, line.trim());
             }
             if scanner.at_verbatim_delimiter(line) {
-                out.note_source_line(line_number);
-                out.push_line(line.to_string());
+                out.push_source_line(line, line_number);
             } else if line.starts_with("//") {
                 if scanner.drops(line) {
                     // Drop the adjacent comment; don't `record` it, so a run of
@@ -958,18 +1026,16 @@ impl Preprocessor {
                     line_number += 1;
                     continue;
                 }
-                out.note_source_line(line_number);
-                out.push_line(line.to_string());
+                out.push_source_line(line, line_number);
             } else if line.ends_with(']') && !line.starts_with('[') && line.contains("::") {
                 let mut ctx = DirectiveContext {
                     line_number: &mut line_number,
                     current_offset,
                     file_parent,
                 };
-                self.process_directive_line(line, &mut lines, &mut ctx, &options, &mut out)?;
+                self.process_directive_line(line, &mut ctx, &options, &mut out)?;
             } else {
-                out.note_source_line(line_number);
-                out.push_line(line.to_string());
+                out.push_source_line(line, line_number);
             }
             scanner.record(line);
             current_offset += line.len() + 1;
@@ -977,9 +1043,10 @@ impl Preprocessor {
         }
 
         out.flush_run();
+        out.flush_borrowed_run();
 
         Ok(PreprocessorResult {
-            text: Cow::Owned(out.lines.join("\n")),
+            text: Cow::Owned(out.output.join("\n")),
             leveloffset_ranges: out.leveloffset_ranges,
             source_ranges: out.source_ranges,
         })
@@ -992,6 +1059,23 @@ mod tests {
     use crate::grammar::LineMap;
 
     #[test]
+    fn unchanged_source_lines_share_one_borrowed_output_chunk() {
+        let input = "first\n\nsecond\nthird";
+        let mut state = PreprocessorState::new(input, None);
+
+        for (index, line) in input.lines().enumerate() {
+            state.push_source_line(line, index + 1);
+        }
+        state.flush_borrowed_run();
+
+        assert_eq!(state.output.len(), 1);
+        assert!(matches!(
+            state.output.as_slice(),
+            [Cow::Borrowed(output)] if *output == input
+        ));
+    }
+
+    #[test]
     fn test_process() -> Result<(), Error> {
         let options = Options::default();
         let input = ":attribute: value
@@ -1001,7 +1085,140 @@ content
 endif::[]
 ";
         let result = Preprocessor::process(input, &options, Rc::default())?;
-        assert_eq!(result.text, ":attribute: value\n\ncontent\n");
+        assert_eq!(result.text, ":attribute: value\n\ncontent");
+        Ok(())
+    }
+
+    #[test]
+    fn multi_attribute_conditional_in_header() -> Result<(), Error> {
+        let input = "= Title
+ifdef::backend-pdf,backend-docbook5[]
+:title-page:
+endif::backend-pdf,backend-docbook5[]
+
+== Visible
+Body";
+        let result = Preprocessor::process(input, &Options::default(), Rc::default())?;
+        assert_eq!(result.text, "= Title\n\n== Visible\nBody");
+        Ok(())
+    }
+
+    #[test]
+    fn active_multi_attribute_conditional_in_header() -> Result<(), Error> {
+        let options = Options::builder()
+            .with_attribute("backend-pdf", true)
+            .build();
+        let input = "= Title
+ifdef::backend-pdf,backend-docbook5[]
+:title-page:
+endif::backend-pdf,backend-docbook5[]
+
+== Visible
+Body";
+        let result = Preprocessor::process(input, &options, Rc::default())?;
+        assert_eq!(result.text, "= Title\n:title-page:\n\n== Visible\nBody");
+        Ok(())
+    }
+
+    #[test]
+    fn parser_accepts_multi_attribute_conditional_in_header() -> Result<(), Error> {
+        let input = "= Title
+ifdef::backend-pdf,backend-docbook5[]
+:title-page:
+endif::backend-pdf,backend-docbook5[]
+
+== Visible
+Body";
+        let parsed = crate::parse(input, &Options::default())?;
+        assert!(parsed.document().header.is_some());
+        assert!(matches!(
+            parsed.document().blocks.as_slice(),
+            [crate::Block::Section(_)]
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn inactive_conditional_body_can_contain_blank_lines() -> Result<(), Error> {
+        let input = "= Title
+
+ifdef::backend-pdf,backend-docbook5[]
+
+== Hidden
+
+Hidden body
+
+endif::backend-pdf,backend-docbook5[]
+
+== Visible
+Visible body";
+        let result = Preprocessor::process(input, &Options::default(), Rc::default())?;
+        assert_eq!(result.text, "= Title\n\n\n== Visible\nVisible body");
+        assert!(!result.text.contains("Hidden"));
+        assert!(!result.text.contains("endif::"));
+        Ok(())
+    }
+
+    #[test]
+    fn nested_conditionals_follow_enclosing_activity() -> Result<(), Error> {
+        let options = Options::builder().with_attribute("outer", true).build();
+        let input = "ifdef::outer[]
+outer content
+ifdef::inner[]
+hidden inner content
+endif::inner[]
+after inner
+endif::outer[]
+tail";
+        let result = Preprocessor::process(input, &options, Rc::default())?;
+        assert_eq!(result.text, "outer content\nafter inner\ntail");
+        Ok(())
+    }
+
+    #[test]
+    fn inactive_enclosing_conditional_hides_active_nested_condition() -> Result<(), Error> {
+        let options = Options::builder().with_attribute("inner", true).build();
+        let input = "ifdef::outer[]
+hidden outer content
+ifdef::inner[]
+hidden inner content
+endif::inner[]
+endif::outer[]
+tail";
+        let result = Preprocessor::process(input, &options, Rc::default())?;
+        assert_eq!(result.text, "tail");
+        Ok(())
+    }
+
+    #[test]
+    fn multi_attribute_conditions_evaluate_every_attribute() -> Result<(), Error> {
+        let options = Options::builder()
+            .with_attribute("third", true)
+            .with_attribute("first", true)
+            .with_attribute("second", true)
+            .build();
+        let input = "ifdef::missing-one,missing-two,third[]
+or content
+endif::missing-one,missing-two,third[]
+ifdef::first+second+third[]
+and content
+endif::first+second+third[]";
+        let result = Preprocessor::process(input, &options, Rc::default())?;
+        assert_eq!(result.text, "or content\nand content");
+        Ok(())
+    }
+
+    #[test]
+    fn attribute_defined_in_active_conditional_affects_later_condition() -> Result<(), Error> {
+        let options = Options::builder().with_attribute("outer", true).build();
+        let input = "ifdef::outer[]
+:inner:
+endif::outer[]
+ifdef::inner[]
+visible
+endif::inner[]";
+        let result = Preprocessor::process(input, &options, Rc::default())?;
+        assert_eq!(result.text, ":inner:\nvisible");
         Ok(())
     }
 
@@ -1097,6 +1314,13 @@ more";
         let input = "one\nifdef::cond[]\nhidden\nendif::[]\ntwo\n";
         assert_eq!(reported_source_line(input, "doc.adoc", "one"), Some(1));
         assert_eq!(reported_source_line(input, "doc.adoc", "two"), Some(5));
+    }
+
+    #[test]
+    fn active_conditional_remaps_body_and_following_lines_to_source() {
+        let input = ":cond:\nifdef::cond[]\ninside\nendif::[]\nafter\n";
+        assert_eq!(reported_source_line(input, "doc.adoc", "inside"), Some(3));
+        assert_eq!(reported_source_line(input, "doc.adoc", "after"), Some(5));
     }
 
     #[test]
@@ -1318,7 +1542,7 @@ ifdef::asdf[]
 content
 endif::asdf[]";
         let result = Preprocessor::process(input, &options, Rc::default())?;
-        assert_eq!(result.text, ":asdf:\n\ncontent\n");
+        assert_eq!(result.text, ":asdf:\n\ncontent");
         Ok(())
     }
 
@@ -1329,6 +1553,18 @@ endif::asdf[]";
 content
 endif::another[]";
         let output = Preprocessor::process(input, &options, Rc::default());
+        assert!(matches!(
+            output,
+            Err(Error::InvalidConditionalDirective(..))
+        ));
+    }
+
+    #[test]
+    fn multi_attribute_endif_must_match_complete_condition() {
+        let input = "ifdef::backend-pdf,backend-docbook5[]
+content
+endif::backend-pdf[]";
+        let output = Preprocessor::process(input, &Options::default(), Rc::default());
         assert!(matches!(
             output,
             Err(Error::InvalidConditionalDirective(..))

--- a/acdc-parser/tests/conditional_allocations.rs
+++ b/acdc-parser/tests/conditional_allocations.rs
@@ -1,0 +1,204 @@
+//! Deterministic allocation budgets for conditional preprocessing.
+//!
+//! BEWARE: this was pretty much all written by Claude not me (@nlopes)!
+//!
+//! Timing benchmarks remain machine-sensitive, so this test protects the
+//! underlying work directly: allocation and reallocation counts plus requested
+//! bytes. Keep this file to one test because allocator regions are process-wide.
+
+use std::{alloc::System, fmt::Write as _, hint::black_box};
+
+use acdc_parser::{Options, parse};
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, Stats, StatsAlloc};
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+#[derive(Clone, Copy)]
+struct Budget {
+    allocations: usize,
+    reallocations: usize,
+    bytes_allocated: usize,
+    bytes_reallocated: isize,
+}
+
+#[derive(Clone, Copy)]
+struct ScenarioBudget {
+    line_count: usize,
+    active: Budget,
+    inactive: Budget,
+    plain_control: Budget,
+    slow_control: Budget,
+}
+
+const BUDGETS: [ScenarioBudget; 2] = [
+    ScenarioBudget {
+        line_count: 1_000,
+        active: Budget {
+            allocations: 371,
+            reallocations: 25,
+            bytes_allocated: 261_651,
+            bytes_reallocated: 17_384,
+        },
+        inactive: Budget {
+            allocations: 349,
+            reallocations: 9,
+            bytes_allocated: 34_090,
+            bytes_reallocated: 8_184,
+        },
+        plain_control: Budget {
+            allocations: 350,
+            reallocations: 16,
+            bytes_allocated: 232_707,
+            bytes_reallocated: 9_200,
+        },
+        slow_control: Budget {
+            allocations: 371,
+            reallocations: 25,
+            bytes_allocated: 261_062,
+            bytes_reallocated: 17_384,
+        },
+    },
+    ScenarioBudget {
+        line_count: 10_000,
+        active: Budget {
+            allocations: 371,
+            reallocations: 37,
+            bytes_allocated: 2_290_875,
+            bytes_reallocated: 278_504,
+        },
+        inactive: Budget {
+            allocations: 349,
+            reallocations: 13,
+            bytes_allocated: 156_970,
+            bytes_reallocated: 131_064,
+        },
+        plain_control: Budget {
+            allocations: 350,
+            reallocations: 24,
+            bytes_allocated: 2_139_051,
+            bytes_reallocated: 147_440,
+        },
+        slow_control: Budget {
+            allocations: 371,
+            reallocations: 37,
+            bytes_allocated: 2_290_286,
+            bytes_reallocated: 278_504,
+        },
+    },
+];
+
+fn push_listing(document: &mut String, line_count: usize) {
+    document.push_str("....\n");
+    for line in 0..line_count {
+        let _ = writeln!(
+            document,
+            "line {line:05}: fixed conditional allocation payload"
+        );
+    }
+    document.push_str("....\n");
+}
+
+fn conditional_document(line_count: usize) -> String {
+    let mut document = String::with_capacity(line_count * 52);
+    document.push_str("ifdef::bench-active[]\n");
+    push_listing(&mut document, line_count);
+    document.push_str("endif::bench-active[]\n");
+    document
+}
+
+fn plain_control_document(line_count: usize) -> String {
+    let mut document = String::with_capacity(line_count * 52);
+    push_listing(&mut document, line_count);
+    document
+}
+
+fn slow_path_control_document(line_count: usize) -> String {
+    let mut document = String::with_capacity(line_count * 52);
+    document.push_str(":bench-note: fixed \\\ncontinuation\n\n");
+    push_listing(&mut document, line_count);
+    document
+}
+
+fn measure(input: &str, options: &Options) -> Result<Stats, acdc_parser::Error> {
+    let region = Region::new(GLOBAL);
+    let parsed = parse(black_box(input), black_box(options))?;
+    black_box(&parsed);
+    let stats = region.change();
+    drop(parsed);
+    Ok(stats)
+}
+
+fn assert_within_budget(case: &str, line_count: usize, stats: Stats, budget: Budget) {
+    assert!(
+        stats.allocations <= budget.allocations,
+        "{case}/{line_count} allocation count regressed: {} > {} ({stats:?})",
+        stats.allocations,
+        budget.allocations
+    );
+    assert!(
+        stats.reallocations <= budget.reallocations,
+        "{case}/{line_count} reallocation count regressed: {} > {} ({stats:?})",
+        stats.reallocations,
+        budget.reallocations
+    );
+    assert!(
+        stats.bytes_allocated <= budget.bytes_allocated,
+        "{case}/{line_count} allocated-byte count regressed: {} > {} ({stats:?})",
+        stats.bytes_allocated,
+        budget.bytes_allocated
+    );
+    assert!(
+        stats.bytes_reallocated <= budget.bytes_reallocated,
+        "{case}/{line_count} reallocated-byte count regressed: {} > {} ({stats:?})",
+        stats.bytes_reallocated,
+        budget.bytes_reallocated
+    );
+}
+
+#[test]
+fn conditional_allocation_work_stays_within_budget() -> Result<(), acdc_parser::Error> {
+    let active_options = Options::builder()
+        .with_attribute("bench-active", true)
+        .build();
+    let inactive_options = Options::default();
+
+    for budget in BUDGETS {
+        let line_count = budget.line_count;
+        let conditional = conditional_document(line_count);
+        let plain_control = plain_control_document(line_count);
+        let slow_control = slow_path_control_document(line_count);
+
+        // Warm caches and one-time parser state before opening allocator regions.
+        let _ = parse(&conditional, &active_options)?;
+        let _ = parse(&conditional, &inactive_options)?;
+        let _ = parse(&plain_control, &inactive_options)?;
+        let _ = parse(&slow_control, &inactive_options)?;
+
+        let active = measure(&conditional, &active_options)?;
+        let inactive = measure(&conditional, &inactive_options)?;
+        let plain_control = measure(&plain_control, &inactive_options)?;
+        let slow_control = measure(&slow_control, &inactive_options)?;
+
+        eprintln!(
+            "conditional allocations/{line_count}: active={active:?} inactive={inactive:?} \
+             plain_control={plain_control:?} slow_control={slow_control:?}"
+        );
+
+        assert_within_budget("active", line_count, active, budget.active);
+        assert_within_budget("inactive", line_count, inactive, budget.inactive);
+        assert_within_budget(
+            "plain_control",
+            line_count,
+            plain_control,
+            budget.plain_control,
+        );
+        assert_within_budget(
+            "slow_control",
+            line_count,
+            slow_control,
+            budget.slow_control,
+        );
+    }
+    Ok(())
+}

--- a/acdc-parser/tests/conditional_allocations.rs
+++ b/acdc-parser/tests/conditional_allocations.rs
@@ -14,6 +14,11 @@ use stats_alloc::{INSTRUMENTED_SYSTEM, Region, Stats, StatsAlloc};
 #[global_allocator]
 static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
+// Requested allocation sizes can differ slightly across compiler targets due
+// to standard-library type layout. Keep this fixed tolerance small enough that
+// per-line or capacity-growth regressions still fail the budget.
+const ALLOCATED_BYTE_LAYOUT_TOLERANCE: usize = 128;
+
 #[derive(Clone, Copy)]
 struct Budget {
     allocations: usize,
@@ -130,6 +135,10 @@ fn measure(input: &str, options: &Options) -> Result<Stats, acdc_parser::Error> 
 }
 
 fn assert_within_budget(case: &str, line_count: usize, stats: Stats, budget: Budget) {
+    let allocated_byte_limit = budget
+        .bytes_allocated
+        .saturating_add(ALLOCATED_BYTE_LAYOUT_TOLERANCE);
+
     assert!(
         stats.allocations <= budget.allocations,
         "{case}/{line_count} allocation count regressed: {} > {} ({stats:?})",
@@ -143,10 +152,10 @@ fn assert_within_budget(case: &str, line_count: usize, stats: Stats, budget: Bud
         budget.reallocations
     );
     assert!(
-        stats.bytes_allocated <= budget.bytes_allocated,
+        stats.bytes_allocated <= allocated_byte_limit,
         "{case}/{line_count} allocated-byte count regressed: {} > {} ({stats:?})",
         stats.bytes_allocated,
-        budget.bytes_allocated
+        allocated_byte_limit
     );
     assert!(
         stats.bytes_reallocated <= budget.bytes_reallocated,


### PR DESCRIPTION
Ended up doing a bunch of benchmarks and realised we could gain 10-15% by borrowing parsed directive data and isolating the slow preprocessing path to reduce allocs.

Fixes #423.